### PR TITLE
Add manual GitHub-to-GitLab sync workflow

### DIFF
--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -1,0 +1,66 @@
+name: Sync to GitLab
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to sync (leave empty for all branches)"
+        required: false
+        default: ""
+      sync_tags:
+        description: "Also sync tags"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+jobs:
+  sync:
+    runs-on: self-hosted
+    environment: robotframework
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Push to GitLab
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          GITLAB_URL="https://gitlab.com/space-nomads/robotframework-chat.git"
+
+          echo "::add-mask::${GITLAB_TOKEN}"
+          echo "::add-mask::${GITLAB_URL}"
+
+          if [ -z "${GITLAB_TOKEN:-}" ]; then
+            echo "::error::GITLAB_TOKEN secret must be configured."
+            echo "Create a GitLab personal access token with write_repository scope"
+            echo "and add it as a repository secret named GITLAB_TOKEN."
+            exit 1
+          fi
+
+          AUTH_URL="https://oauth2:${GITLAB_TOKEN}@gitlab.com/space-nomads/robotframework-chat.git"
+
+          git remote add gitlab "${AUTH_URL}"
+
+          BRANCH="${{ github.event.inputs.branch }}"
+
+          if [ -n "${BRANCH}" ]; then
+            echo "Syncing branch: ${BRANCH}"
+            git push gitlab "refs/heads/${BRANCH}:refs/heads/${BRANCH}" --force
+          else
+            echo "Syncing all branches"
+            git push gitlab --all --force
+          fi
+
+          if [ "${{ github.event.inputs.sync_tags }}" = "true" ]; then
+            echo "Syncing tags"
+            git push gitlab --tags --force
+          fi
+
+          echo "Sync complete."


### PR DESCRIPTION
Adds a workflow_dispatch-only pipeline that mirrors branches and tags from GitHub to GitLab (space-nomads/robotframework-chat). Uses a self-hosted runner and the 'robotframework' environment for secrets.

Requires one environment secret:
- GITLAB_TOKEN: personal access token with write_repository scope

https://claude.ai/code/session_01XrPYVUpCUDZXzYGdRaofhD