### PR TITLE
Improve GitLab sync workflow with automatic trigger and safer remote setup

### DIFF
--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -1,6 +1,9 @@
 name: Sync to GitLab
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       branch:
@@ -46,7 +49,11 @@ jobs:
 
           AUTH_URL="https://oauth2:${GITLAB_TOKEN}@gitlab.com/space-nomads/robotframework-chat.git"
 
-          git remote add gitlab "${AUTH_URL}"
+          if git remote get-url gitlab >/dev/null 2>&1; then
+            git remote set-url gitlab "${AUTH_URL}"
+          else
+            git remote add gitlab "${AUTH_URL}"
+          fi
 
           BRANCH="${{ github.event.inputs.branch }}"
 


### PR DESCRIPTION
## Summary
Enhanced the GitLab sync workflow to automatically trigger on pushes to main and improved the git remote configuration to handle existing remotes safely.

## Key Changes
- **Automatic triggering**: Added `push` event trigger for the `main` branch, so the sync workflow runs automatically on every push instead of requiring manual dispatch
- **Safer remote setup**: Modified the git remote configuration to check if the `gitlab` remote already exists before attempting to add it. If it exists, the URL is updated instead of failing with a duplicate remote error

## Implementation Details
The git remote handling now uses a conditional check:
- If the `gitlab` remote already exists, `git remote set-url` updates its URL
- If it doesn't exist, `git remote add` creates it with the provided authentication URL

This prevents errors when the workflow runs multiple times and makes the workflow more robust and idempotent.

https://claude.ai/code/session_01XjKbFFdw8M9XCSYnJMNyz5