### PR TITLE
Add Ollama readiness polling and improve container lifecycle management

### DIFF
--- a/robot/docker/llm/tests/multi_model.robot
+++ b/robot/docker/llm/tests/multi_model.robot
@@ -45,7 +45,7 @@ Extract Code From Response
 
 Check Ollama Health On Endpoint
     [Arguments]    ${endpoint}
-    ${response}=    GET    ${endpoint}/api/tags    timeout=5
+    ${response}=    GET    ${endpoint}/api/tags    timeout=5    expected_status=any
     Should Be Equal As Integers    ${response.status_code}    200
 
 *** Test Cases ***

--- a/robot/resources/llm_containers.resource
+++ b/robot/resources/llm_containers.resource
@@ -60,6 +60,9 @@ Start LLM Container
     LLM.Set LLM Endpoint    ${OLLAMA_BASE_URL}
     LLM.Set LLM Model    ${first_model}
 
+    # Wait for Ollama to finish loading and be idle before returning
+    LLM.Wait For LLM    timeout=60
+
     Log    LLM container started: ${container_id} on port ${available_port} with models: ${pull_models}
     RETURN    ${container_id}
 
@@ -79,7 +82,7 @@ Wait For Ollama Ready
 
 Check Ollama Health
     [Documentation]    Check if Ollama API is responding
-    ${response}=    GET    ${OLLAMA_BASE_URL}/api/tags    timeout=5
+    ${response}=    GET    ${OLLAMA_BASE_URL}/api/tags    timeout=5    expected_status=any
     Should Be Equal As Integers    ${response.status_code}    200
 
 Pull LLM Model

--- a/src/rfc/keywords.py
+++ b/src/rfc/keywords.py
@@ -1,3 +1,5 @@
+from typing import List, Dict, Any
+
 from robot.api import logger
 from robot.api.deco import keyword
 from .ollama import OllamaClient
@@ -6,7 +8,7 @@ from .grader import Grader
 
 class LLMKeywords:
     """
-    Robot Framework kewords for testing LLMs.
+    Robot Framework keywords for testing LLMs.
     """
 
     def __init__(self):
@@ -39,3 +41,65 @@ class LLMKeywords:
     def grade_answer(self, question: str, expected: str, actual: str):
         result = self.grader.grade(question, expected, actual)
         return result.score, result.reason
+
+    @keyword("Wait For LLM")
+    def wait_for_llm(self, timeout: int = 120, poll_interval: int = 2) -> bool:
+        """Wait until the Ollama LLM is available and not busy.
+
+        Polls the /api/ps endpoint to detect when no models are actively
+        processing requests. Use this before Ask LLM when Ollama may be
+        busy serving another request to avoid timeout errors.
+
+        Args:
+            timeout: Maximum seconds to wait (default 120).
+            poll_interval: Seconds between polling attempts (default 2).
+
+        Returns:
+            True when the LLM is ready.
+
+        Raises:
+            TimeoutError: If Ollama is still busy after timeout.
+
+        Example:
+            | Wait For LLM | timeout=60 |
+            | ${answer}= | Ask LLM | What is 2 + 2? |
+        """
+        timeout = int(timeout)
+        poll_interval = int(poll_interval)
+        logger.info(
+            f"Waiting for Ollama to be ready (timeout={timeout}s, "
+            f"poll={poll_interval}s)"
+        )
+        return self.client.wait_until_ready(timeout, poll_interval)
+
+    @keyword("Get Running Models")
+    def get_running_models(self) -> List[Dict[str, Any]]:
+        """Get the list of models currently loaded/running in Ollama.
+
+        Queries the /api/ps endpoint to see which models are active.
+
+        Returns:
+            List of model info dicts from Ollama's /api/ps response.
+
+        Example:
+            | ${models}= | Get Running Models |
+            | Log | Currently running: ${models} |
+        """
+        models = self.client.running_models()
+        logger.info(f"Running models: {models}")
+        return models
+
+    @keyword("LLM Is Busy")
+    def llm_is_busy(self) -> bool:
+        """Check if Ollama currently has models loaded and running.
+
+        Returns:
+            True if Ollama has active models, False otherwise.
+
+        Example:
+            | ${busy}= | LLM Is Busy |
+            | Run Keyword If | ${busy} | Wait For LLM |
+        """
+        busy = self.client.is_busy()
+        logger.info(f"Ollama busy: {busy}")
+        return busy


### PR DESCRIPTION
## Summary
This PR adds functionality to detect when Ollama is idle and ready to process requests, along with improvements to container lifecycle management and Robot Framework keywords for LLM testing.

## Key Changes

### Ollama Client Enhancements (`src/rfc/ollama.py`)
- **New `running_models()` method**: Queries the `/api/ps` endpoint to get currently loaded/running models
- **New `is_busy()` method**: Checks if any models are currently loaded and processing
- **New `wait_until_ready()` method**: Polls Ollama until it's available and idle, with configurable timeout and poll interval. Gracefully handles older Ollama versions that don't support `/api/ps`

### Robot Framework Keywords (`src/rfc/keywords.py`)
- **New `Wait For LLM` keyword**: Exposes `wait_until_ready()` for Robot Framework tests to prevent timeout errors when Ollama is busy
- **New `Get Running Models` keyword**: Returns list of currently active models
- **New `LLM Is Busy` keyword**: Checks if Ollama has active models
- Fixed typo in class docstring ("kewords" → "keywords")
- Added type hints imports

### Container Lifecycle Improvements (`src/rfc/container_manager.py`)
- **Enhanced `stop_container()` method**: 
  - Now handles containers that have already been stopped or auto-removed by Docker without raising warnings
  - Added try-catch for `NotFound` exception when removing containers
  - Uses `finally` block to ensure internal tracking is always cleaned up
  - Changed warning log to info log for already-removed containers

### Robot Framework Test Resources
- **`llm_containers.resource`**: Added `Wait For LLM` call after starting LLM container to ensure Ollama is idle before tests begin
- **`multi_model.robot`**: Added `expected_status=any` to HTTP GET requests to handle non-200 responses gracefully

## Implementation Details
- The `wait_until_ready()` method includes detailed logging to track Ollama's state during polling
- Graceful degradation for older Ollama versions that don't have `/api/ps` endpoint
- Container cleanup is now more robust and won't fail if Docker has already auto-removed the container

https://claude.ai/code/session_011LyyCbjqHs9rmXRhL4fBkA