### PR TITLE
Allow CI lint jobs to fail without blocking pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,6 +45,7 @@ pre-commit:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: $CI_COMMIT_BRANCH
+  allow_failure: true
 
 ruff-check:
   stage: lint
@@ -56,6 +57,7 @@ ruff-check:
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+  allow_failure: true
 
 mypy-check:
   stage: lint


### PR DESCRIPTION
## Summary
This change makes the pre-commit and ruff-check linting jobs non-blocking by setting `allow_failure: true` on both jobs. This allows the CI pipeline to continue and report success even if these lint checks fail.

## Changes
- Added `allow_failure: true` to the `pre-commit` job
- Added `allow_failure: true` to the `ruff-check` job

## Details
These linting jobs will now be treated as warnings rather than hard failures. The pipeline will continue to completion and be marked as successful even if pre-commit or ruff checks fail, though the failures will still be visible in the job logs for developers to review and address.

https://claude.ai/code/session_019oJbyUNwXthwcmYAb4yfe4