### PR TITLE
Reformat logger.info call in stop_container method

### DIFF
--- a/src/rfc/container_manager.py
+++ b/src/rfc/container_manager.py
@@ -77,9 +77,7 @@ class ContainerManager:
 
         except NotFound:
             # Container already gone (auto-removed or manually stopped)
-            logger.info(
-                f"Container {container_id[:12]} already removed"
-            )
+            logger.info(f"Container {container_id[:12]} already removed")
         except DockerException as e:
             logger.error(f"Error stopping container {container_id[:12]}: {e}")
         finally:


### PR DESCRIPTION
## Summary
This PR contains a minor code formatting improvement to the `stop_container` method in the container manager module.

## Key Changes
- Reformatted the `logger.info()` call to fit on a single line, improving code readability and reducing unnecessary line breaks

## Implementation Details
The multi-line logger statement was condensed into a single line while maintaining the same functionality. This change follows Python style conventions for concise, readable code without sacrificing clarity.

https://claude.ai/code/session_013kSS8xdSLjL9cwWK4urW3X