### PR TITLE
Add runner tags to robot-docker-tests CI job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,6 +104,9 @@ robot-math-tests:
 robot-docker-tests:
   stage: test
   <<: *robot_template
+  tags:
+    - ollama
+    - docker
   script:
     - uv run robot -d results/docker -v OLLAMA_ENDPOINT:$OLLAMA_ENDPOINT -v DEFAULT_MODEL:$DEFAULT_MODEL robot/docker/
   artifacts:


### PR DESCRIPTION
## Summary
Added GitLab CI runner tags to the `robot-docker-tests` job to ensure it runs on appropriate infrastructure.

## Changes
- Added `tags` configuration to the `robot-docker-tests` job with two tags:
  - `ollama`: Ensures the runner has Ollama available
  - `docker`: Ensures the runner has Docker available

## Details
This change ensures that the robot Docker tests are executed on GitLab runners that have both Ollama and Docker installed and configured, preventing job failures due to missing dependencies or services.

https://claude.ai/code/session_01DrZSUcQpayRBTvKuCavPXm