### PR TITLE
Remove timeout from run-dynamic-tests CI job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,7 +158,6 @@ run-regular-tests:
 
 run-dynamic-tests:
   stage: test
-  timeout: 60 minutes
   needs:
     - job: generate-dynamic-pipeline
       artifacts: true


### PR DESCRIPTION
## Summary
Removed the explicit 60-minute timeout constraint from the `run-dynamic-tests` CI job in the GitLab CI configuration.

## Changes
- Removed `timeout: 60 minutes` from the `run-dynamic-tests` job definition

## Details
This change allows the dynamic tests job to run without a hard timeout limit, letting it use the default timeout configuration instead. This may be necessary if dynamic tests occasionally require more than 60 minutes to complete, or to allow for more flexible execution time based on system load or test complexity.

https://claude.ai/code/session_01WUkXGLjVGZW8TTePd3fAwz