### PR TITLE
Support both docker compose and docker-compose commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # robotframework-chat Makefile
 # Run `make help` for a list of targets.
 
-COMPOSE  := docker compose
+COMPOSE  := $(shell docker compose version >/dev/null 2>&1 && echo "docker compose" || echo "docker-compose")
 ROBOT    := uv run robot
 LISTENER := --listener rfc.db_listener.DbListener --listener rfc.ci_metadata_listener.CiMetadataListener
 


### PR DESCRIPTION
## Summary
Updated the Makefile to automatically detect and use the appropriate Docker Compose command, supporting both the newer `docker compose` (v2) and legacy `docker-compose` (v1) installations.

## Changes
- Modified the `COMPOSE` variable to use shell command substitution that checks for `docker compose` availability first
- Falls back to `docker-compose` if the newer command is not available
- This ensures compatibility across different Docker installations and versions

## Implementation Details
The change uses a shell conditional that:
1. Attempts to run `docker compose version` and suppresses output
2. Uses `docker compose` if the command succeeds (exit code 0)
3. Falls back to `docker-compose` if the command fails

https://claude.ai/code/session_016GpKiVyeyDbzEfDYKXgDoe