### PR TITLE
Add OllamaTimestampListener to track LLM keyword execution times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 COMPOSE  := docker compose
 ROBOT    := uv run robot
-LISTENER := --listener rfc.db_listener.DbListener --listener rfc.ci_metadata_listener.CiMetadataListener
+LISTENER := --listener rfc.db_listener.DbListener --listener rfc.ci_metadata_listener.CiMetadataListener --listener rfc.ollama_timestamp_listener.OllamaTimestampListener
 
 # Load .env if present
 -include .env

--- a/ai/AGENTS.md
+++ b/ai/AGENTS.md
@@ -179,11 +179,13 @@ Robot Framework Test
 │   ├─ CI Metadata (ci_metadata.py) ── GitLab CI env collection
 │   ├─ CI Metadata Listener (ci_metadata_listener.py) ── attaches CI metadata to output
 │   ├─ DB Listener (db_listener.py) ── archives results to SQL database
+│   ├─ Ollama Timestamp Listener (ollama_timestamp_listener.py) ── timestamps Ollama chats
 │   └─ Test Database (test_database.py) ── SQLite + PostgreSQL backends
 │
 ├─> Listeners (auto-attached to every test run)
 │   ├─ DbListener ── archives runs/results to SQL (SQLite or PostgreSQL)
-│   └─ CiMetadataListener ── adds CI context to Robot Framework output
+│   ├─ CiMetadataListener ── adds CI context to Robot Framework output
+│   └─ OllamaTimestampListener ── timestamps every Ollama chat call
 │
 ├─> Docker Containers
 │   ├─ Code Execution (Python, Node, Shell)
@@ -223,6 +225,7 @@ robotframework-chat/
 │   ├── ci_metadata.py          # CI metadata collection
 │   ├── ci_metadata_listener.py # Listener: CI metadata → Robot output
 │   ├── db_listener.py          # Listener: test results → SQL database
+│   ├── ollama_timestamp_listener.py # Listener: timestamps Ollama chats
 │   ├── test_database.py        # SQLite + PostgreSQL database backends
 │   ├── keywords.py             # Core LLM keywords
 │   ├── grader.py               # LLM answer grading
@@ -259,19 +262,21 @@ logic outside of these directories.
 
 ## Listeners
 
-Two Robot Framework listeners handle test result collection:
+Three Robot Framework listeners handle test result collection:
 
 | Listener | Purpose |
 |----------|---------|
 | `rfc.db_listener.DbListener` | Archives test runs and individual results to the SQL database (SQLite or PostgreSQL) |
 | `rfc.ci_metadata_listener.CiMetadataListener` | Collects GitLab CI metadata (commit, branch, pipeline URL, runner info) and adds it to test output |
+| `rfc.ollama_timestamp_listener.OllamaTimestampListener` | Timestamps every Ollama keyword call (Ask LLM, Wait For LLM, etc.) and saves `ollama_timestamps.json` |
 
-Both listeners are always active in the Makefile targets and in CI. Use them together:
+All listeners are always active in the Makefile targets and in CI. Use them together:
 
 ```bash
 uv run robot -d results/math \
   --listener rfc.db_listener.DbListener \
   --listener rfc.ci_metadata_listener.CiMetadataListener \
+  --listener rfc.ollama_timestamp_listener.OllamaTimestampListener \
   robot/math/tests/
 ```
 

--- a/config/test_suites.yaml
+++ b/config/test_suites.yaml
@@ -92,6 +92,7 @@ ci:
   listeners:
     - "rfc.db_listener.DbListener"
     - "rfc.ci_metadata_listener.CiMetadataListener"
+    - "rfc.ollama_timestamp_listener.OllamaTimestampListener"
 
   # Job groups: combine multiple atomic suites into a single CI job.
   # Suites not listed here run as individual jobs.

--- a/src/rfc/ollama_timestamp_listener.py
+++ b/src/rfc/ollama_timestamp_listener.py
@@ -1,0 +1,123 @@
+"""Robot Framework listener that timestamps all Ollama chat interactions.
+
+Records start/end times and duration for every Ollama-related keyword
+call (Ask LLM, Set LLM Model, Wait For LLM, etc.) and saves a JSON
+log at the end of the top-level suite.
+
+Usage:
+    robot --listener rfc.ollama_timestamp_listener.OllamaTimestampListener tests/
+"""
+
+import json
+import os
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from robot.api import logger  # type: ignore
+
+# Keywords that represent Ollama interactions worth timestamping.
+_TRACKED_KEYWORDS = frozenset(
+    {
+        "Ask LLM",
+        "Set LLM Endpoint",
+        "Set LLM Model",
+        "Set LLM Parameters",
+        "Wait For LLM",
+        "Get Running Models",
+        "LLM Is Busy",
+    }
+)
+
+
+class OllamaTimestampListener:
+    """Listener that timestamps all Ollama chat keyword calls.
+
+    Hooks into ``start_keyword`` / ``end_keyword`` to record when each
+    Ollama-related keyword begins and finishes.  At the end of the
+    top-level suite the collected timestamps are saved to
+    ``ollama_timestamps.json`` in the output directory.
+
+    Usage:
+        robot --listener rfc.ollama_timestamp_listener.OllamaTimestampListener tests/
+    """
+
+    ROBOT_LISTENER_API_VERSION = 2
+
+    def __init__(self) -> None:
+        self._chats: List[Dict[str, Any]] = []
+        self._current_keyword: Optional[Dict[str, Any]] = None
+        self._suite_depth: int = 0
+
+    def start_suite(self, name: str, attributes: Dict[str, Any]) -> None:
+        """Track suite nesting depth."""
+        self._suite_depth += 1
+
+    def start_keyword(self, name: str, attributes: Dict[str, Any]) -> None:
+        """Record the start time when an Ollama keyword begins."""
+        if name not in _TRACKED_KEYWORDS:
+            return
+
+        args = attributes.get("args", [])
+        prompt = args[0] if args else ""
+
+        self._current_keyword = {
+            "keyword": name,
+            "prompt": prompt,
+            "start_time": datetime.utcnow().isoformat() + "Z",
+        }
+
+    def end_keyword(self, name: str, attributes: Dict[str, Any]) -> None:
+        """Record the end time and compute duration for Ollama keywords."""
+        if self._current_keyword is None:
+            return
+
+        end_time = datetime.utcnow()
+        end_iso = end_time.isoformat() + "Z"
+
+        start_dt = datetime.fromisoformat(
+            self._current_keyword["start_time"].rstrip("Z")
+        )
+        duration = (end_time - start_dt).total_seconds()
+
+        self._current_keyword["end_time"] = end_iso
+        self._current_keyword["duration_seconds"] = round(duration, 3)
+
+        self._chats.append(self._current_keyword)
+        self._current_keyword = None
+
+        logger.info(f"Ollama call '{name}' completed in {duration:.3f}s")
+
+    def end_suite(self, name: str, attributes: Dict[str, Any]) -> None:
+        """Save the timestamp log when the top-level suite ends."""
+        self._suite_depth -= 1
+        if self._suite_depth > 0:
+            return
+
+        if not self._chats:
+            return
+
+        self._save_timestamps_json(name)
+
+    def _save_timestamps_json(self, suite_name: str) -> None:
+        """Write collected timestamps to a JSON file.
+
+        Args:
+            suite_name: Name of the suite that just finished.
+        """
+        output_dir = os.getenv("ROBOT_OUTPUT_DIR", ".")
+        output_file = os.path.join(output_dir, "ollama_timestamps.json")
+
+        data = {
+            "suite": suite_name,
+            "total_chats": len(self._chats),
+            "chats": self._chats,
+        }
+
+        try:
+            with open(output_file, "w") as f:
+                json.dump(data, f, indent=2)
+            logger.info(
+                f"Ollama timestamps saved to: {output_file} ({len(self._chats)} calls)"
+            )
+        except Exception as e:
+            logger.warn(f"Could not save Ollama timestamps: {e}")

--- a/tests/test_ollama_timestamp_listener.py
+++ b/tests/test_ollama_timestamp_listener.py
@@ -1,0 +1,121 @@
+"""Tests for OllamaTimestampListener."""
+
+import json
+import os
+import tempfile
+from unittest.mock import patch
+
+from rfc.ollama_timestamp_listener import OllamaTimestampListener
+
+
+class TestOllamaTimestampListener:
+    """Unit tests for the Ollama timestamp listener."""
+
+    def test_robot_listener_api_version(self):
+        listener = OllamaTimestampListener()
+        assert listener.ROBOT_LISTENER_API_VERSION == 2
+
+    def test_initial_state(self):
+        listener = OllamaTimestampListener()
+        assert listener._chats == []
+        assert listener._current_keyword is None
+
+    def test_start_keyword_tracks_ask_llm(self):
+        listener = OllamaTimestampListener()
+        listener.start_keyword("Ask LLM", {"args": ["What is 2+2?"]})
+        assert listener._current_keyword is not None
+        assert listener._current_keyword["keyword"] == "Ask LLM"
+        assert listener._current_keyword["prompt"] == "What is 2+2?"
+        assert "start_time" in listener._current_keyword
+
+    def test_start_keyword_ignores_non_ollama(self):
+        listener = OllamaTimestampListener()
+        listener.start_keyword("Should Be Equal", {"args": ["a", "b"]})
+        assert listener._current_keyword is None
+
+    def test_end_keyword_records_chat(self):
+        listener = OllamaTimestampListener()
+        listener.start_keyword("Ask LLM", {"args": ["What is 2+2?"]})
+        listener.end_keyword("Ask LLM", {"args": ["What is 2+2?"]})
+        assert len(listener._chats) == 1
+        chat = listener._chats[0]
+        assert chat["keyword"] == "Ask LLM"
+        assert chat["prompt"] == "What is 2+2?"
+        assert "start_time" in chat
+        assert "end_time" in chat
+        assert "duration_seconds" in chat
+        assert chat["duration_seconds"] >= 0
+
+    def test_end_keyword_ignores_untracked(self):
+        listener = OllamaTimestampListener()
+        listener.end_keyword("Should Be Equal", {"args": ["a", "b"]})
+        assert len(listener._chats) == 0
+
+    def test_multiple_chats_recorded(self):
+        listener = OllamaTimestampListener()
+        for i in range(3):
+            listener.start_keyword("Ask LLM", {"args": [f"Question {i}"]})
+            listener.end_keyword("Ask LLM", {"args": [f"Question {i}"]})
+        assert len(listener._chats) == 3
+        assert listener._chats[0]["prompt"] == "Question 0"
+        assert listener._chats[2]["prompt"] == "Question 2"
+
+    def test_end_suite_saves_json(self):
+        listener = OllamaTimestampListener()
+        listener.start_keyword("Ask LLM", {"args": ["Hello"]})
+        listener.end_keyword("Ask LLM", {"args": ["Hello"]})
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, {"ROBOT_OUTPUT_DIR": tmpdir}):
+                listener.end_suite("My Suite", {"totaltests": 1})
+
+            output_file = os.path.join(tmpdir, "ollama_timestamps.json")
+            assert os.path.exists(output_file)
+
+            with open(output_file) as f:
+                data = json.load(f)
+
+            assert data["suite"] == "My Suite"
+            assert data["total_chats"] == 1
+            assert len(data["chats"]) == 1
+            assert data["chats"][0]["prompt"] == "Hello"
+
+    def test_end_suite_no_chats_no_file(self):
+        listener = OllamaTimestampListener()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, {"ROBOT_OUTPUT_DIR": tmpdir}):
+                listener.end_suite("My Suite", {"totaltests": 0})
+
+            output_file = os.path.join(tmpdir, "ollama_timestamps.json")
+            assert not os.path.exists(output_file)
+
+    def test_tracks_set_llm_model(self):
+        listener = OllamaTimestampListener()
+        listener.start_keyword("Set LLM Model", {"args": ["mistral"]})
+        assert listener._current_keyword is not None
+        assert listener._current_keyword["keyword"] == "Set LLM Model"
+
+    def test_tracks_wait_for_llm(self):
+        listener = OllamaTimestampListener()
+        listener.start_keyword("Wait For LLM", {"args": []})
+        assert listener._current_keyword is not None
+        assert listener._current_keyword["keyword"] == "Wait For LLM"
+
+    def test_suite_depth_only_saves_at_top_level(self):
+        listener = OllamaTimestampListener()
+        listener.start_suite("Top", {})
+        listener.start_suite("Nested", {})
+        listener.start_keyword("Ask LLM", {"args": ["test"]})
+        listener.end_keyword("Ask LLM", {"args": ["test"]})
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, {"ROBOT_OUTPUT_DIR": tmpdir}):
+                # End nested suite — should not save
+                listener.end_suite("Nested", {"totaltests": 1})
+                output_file = os.path.join(tmpdir, "ollama_timestamps.json")
+                assert not os.path.exists(output_file)
+
+                # End top-level suite — should save
+                listener.end_suite("Top", {"totaltests": 1})
+                assert os.path.exists(output_file)


### PR DESCRIPTION
## Summary
Adds a new Robot Framework listener that automatically timestamps all Ollama-related keyword calls and saves the collected metrics to a JSON file for performance analysis.

## Key Changes
- **New listener**: `OllamaTimestampListener` in `src/rfc/ollama_timestamp_listener.py`
  - Hooks into Robot Framework's `start_keyword` and `end_keyword` events
  - Tracks 7 Ollama-related keywords: Ask LLM, Set LLM Endpoint, Set LLM Model, Set LLM Parameters, Wait For LLM, Get Running Models, LLM Is Busy
  - Records start time, end time, duration (in seconds), keyword name, and prompt for each call
  - Saves results to `ollama_timestamps.json` in the Robot Framework output directory at the end of the top-level test suite
  - Properly handles nested suites by only saving when the top-level suite completes

- **Comprehensive test coverage**: `tests/test_ollama_timestamp_listener.py`
  - 11 unit tests covering initialization, keyword tracking, chat recording, JSON output, and suite nesting behavior
  - Tests verify correct handling of tracked vs. non-tracked keywords and edge cases

- **Integration**: Updated Makefile and test configuration
  - Added listener to Makefile's `LISTENER` variable for all test runs
  - Added listener to `config/test_suites.yaml` CI configuration
  - Updated `ai/AGENTS.md` documentation to reflect the new listener

## Implementation Details
- Uses ISO 8601 timestamps with UTC timezone (appends "Z" suffix)
- Calculates duration as the difference between end and start times, rounded to 3 decimal places
- Gracefully handles missing arguments and file write errors with logging
- Respects `ROBOT_OUTPUT_DIR` environment variable for output file location
- Only generates JSON file if at least one Ollama keyword was tracked

https://claude.ai/code/session_01CeUzeoiLrzJwuGknmBLPgj