### PR TITLE
Replace required env vars with sensible defaults in docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,11 @@ install: ## Install Python dependencies
 
 # ── Docker / Superset ─────────────────────────────────────────────────
 
-up: ## Start PostgreSQL + Redis + Superset
+.env: ## Create .env from .env.example if missing
+	cp .env.example .env
+	@echo "Created .env from .env.example – edit it if needed."
+
+up: .env ## Start PostgreSQL + Redis + Superset
 	$(COMPOSE) up -d
 
 down: ## Stop all services

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-rfc}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
       POSTGRES_DB: ${POSTGRES_DB:-rfc}
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
@@ -50,9 +50,9 @@ services:
         condition: service_healthy
     environment:
       SUPERSET_CONFIG_PATH: /app/superset_config.py
-      SUPERSET_SECRET_KEY: ${SUPERSET_SECRET_KEY:?Set SUPERSET_SECRET_KEY in .env}
+      SUPERSET_SECRET_KEY: ${SUPERSET_SECRET_KEY:-generate-a-random-secret-here}
       POSTGRES_USER: ${POSTGRES_USER:-rfc}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
       POSTGRES_DB: ${POSTGRES_DB:-rfc}
       SUPERSET_ADMIN_USER: ${SUPERSET_ADMIN_USER:-admin}
       SUPERSET_ADMIN_PASSWORD: ${SUPERSET_ADMIN_PASSWORD:-admin}
@@ -89,9 +89,9 @@ services:
         condition: service_completed_successfully
     environment:
       SUPERSET_CONFIG_PATH: /app/superset_config.py
-      SUPERSET_SECRET_KEY: ${SUPERSET_SECRET_KEY:?Set SUPERSET_SECRET_KEY in .env}
+      SUPERSET_SECRET_KEY: ${SUPERSET_SECRET_KEY:-generate-a-random-secret-here}
       POSTGRES_USER: ${POSTGRES_USER:-rfc}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
       POSTGRES_DB: ${POSTGRES_DB:-rfc}
     ports:
       - "${SUPERSET_PORT:-8088}:8088"


### PR DESCRIPTION
## Summary
This change replaces strict environment variable requirements in `docker-compose.yml` with sensible defaults, making it easier to get started with the project without mandatory `.env` configuration. Additionally, a new Makefile target automatically creates a `.env` file from `.env.example` when needed.

## Key Changes
- **docker-compose.yml**: Replaced `${VAR:?error}` syntax (which fails if not set) with `${VAR:-default}` syntax for:
  - `POSTGRES_PASSWORD`: Now defaults to `changeme`
  - `SUPERSET_SECRET_KEY`: Now defaults to `generate-a-random-secret-here`
  - Applied across all service definitions (postgres, superset, superset-worker)

- **Makefile**: 
  - Added new `.env` target that automatically copies `.env.example` to `.env` if missing
  - Updated `up` target to depend on `.env`, ensuring the file exists before starting services
  - Added helpful message when `.env` is created

## Implementation Details
These changes lower the barrier to entry for local development by allowing the stack to start with default credentials, while still supporting custom values via environment variables or `.env` file overrides. Users can now run `make up` without pre-configuring a `.env` file, though they should customize credentials for production use.

https://claude.ai/code/session_016muijfQHyTPuA32YfU9pY4