### PR TITLE
Build Superset from custom Dockerfile with additional dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
 
   # ── Superset init (one-shot: migrate, create admin, bootstrap) ──────
   superset-init:
-    image: apache/superset:4.1.1
+    build: ./superset
     depends_on:
       postgres:
         condition: service_healthy
@@ -72,13 +72,14 @@ services:
           --email "$SUPERSET_ADMIN_EMAIL" \
           --password "$SUPERSET_ADMIN_PASSWORD" || true &&
         superset init &&
-        python /app/bootstrap_dashboards.py &&
+        (python /app/bootstrap_dashboards.py ||
+          echo "WARNING: dashboard bootstrap failed (non-fatal)") &&
         echo "=== Superset init complete ==="
     restart: "no"
 
   # ── Superset web server ─────────────────────────────────────────────
   superset:
-    image: apache/superset:4.1.1
+    build: ./superset
     restart: unless-stopped
     depends_on:
       postgres:

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -1,0 +1,5 @@
+FROM apache/superset:4.1.1
+
+USER root
+RUN pip install psycopg2-binary redis
+USER superset


### PR DESCRIPTION
## Summary
This PR transitions the Superset service from using the pre-built Apache image to building from a custom Dockerfile, enabling installation of additional Python dependencies required for the application.

## Key Changes
- Created a custom `superset/Dockerfile` that extends `apache/superset:4.1.1` and installs `psycopg2-binary` and `redis` packages
- Updated both `superset-init` and `superset` services in `docker-compose.yml` to build from the custom Dockerfile instead of pulling the pre-built image
- Made dashboard bootstrap failure non-fatal by wrapping the bootstrap command with error handling that logs a warning instead of failing the entire init process

## Implementation Details
- The custom Dockerfile uses the official Apache Superset image as a base, installs the additional dependencies as root, then switches back to the `superset` user for security
- The `psycopg2-binary` package is needed for PostgreSQL database connectivity
- The `redis` package is required for caching/session management
- Dashboard bootstrap errors are now caught and logged as warnings, allowing the init process to complete successfully even if dashboard setup encounters issues

https://claude.ai/code/session_01KfMqKqUz4YHqiM6scJTCEU