### PR TITLE
Drop deprecated docker-compose v1 fallback and add make-targets CI job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,6 +51,21 @@ mirror-to-github:
 # LINT STAGE - Uses tools already installed on runner
 # =============================================================================
 
+make-targets:
+  stage: lint
+  before_script:
+    - uv sync --extra dev --extra superset
+  script:
+    - make help
+    - make version
+    - make lint
+    - make typecheck
+    - make check
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_BRANCH
+
 pre-commit:
   stage: lint
   before_script:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # robotframework-chat Makefile
 # Run `make help` for a list of targets.
 
-COMPOSE  := $(shell docker compose version >/dev/null 2>&1 && echo "docker compose" || echo "docker-compose")
+COMPOSE  := docker compose
 ROBOT    := uv run robot
 LISTENER := --listener rfc.db_listener.DbListener --listener rfc.ci_metadata_listener.CiMetadataListener --listener rfc.ollama_timestamp_listener.OllamaTimestampListener
 


### PR DESCRIPTION
The Makefile was falling back to docker-compose v1 (Python-based, 1.29.2) when docker compose v2 wasn't detected. This caused 'ContainerConfig' KeyError crashes with newer Docker images. Since docker-compose v1 is deprecated, remove the fallback entirely and require docker compose v2.

Add a make-targets job to the GitLab CI lint stage that exercises the key Makefile targets (help, version, lint, typecheck, check) on every branch push and merge request.

https://claude.ai/code/session_01JM2zk3zSbVsGRnWyUYLgJs