### PR TITLE
Fix Makefile help target and compose detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # robotframework-chat Makefile
 # Run `make help` for a list of targets.
 
-COMPOSE  := $(shell docker compose version >/dev/null 2>&1 && echo "docker compose" || echo "docker-compose")
+COMPOSE  := $(shell docker compose version >/dev/null 2>&1 && echo "docker compose" || { echo "Error: Docker Compose V2 is required. Install it with: https://docs.docker.com/compose/install/" >&2; echo "false"; })
 ROBOT    := uv run robot
 LISTENER := --listener rfc.db_listener.DbListener --listener rfc.ci_metadata_listener.CiMetadataListener --listener rfc.ollama_timestamp_listener.OllamaTimestampListener
 
@@ -14,8 +14,8 @@ export
         import lint format typecheck check version
 
 help: ## Show this help
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
-		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+	@grep -hE '^[a-zA-Z_-]+:.*## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
 # ── Setup ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
- Add -h flag to grep in help target to suppress filename prefixes caused by $(MAKEFILE_LIST) expanding to multiple files when .env is included
- Remove ? (non-greedy quantifier) from grep/awk patterns since awk ERE doesn't support it
- Replace silent docker-compose V1 fallback with explicit error message and fail-fast behavior (COMPOSE=false) since V1 is EOL and fails with KeyError on newer Docker engines

https://claude.ai/code/session_01D86gNdXeF4Q674hujRayth