### PR TITLE
Add flask-cors dependency to Docker image

### DIFF
--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -1,5 +1,5 @@
 FROM apache/superset:4.1.1
 
 USER root
-RUN pip install psycopg2-binary redis
+RUN pip install psycopg2-binary redis flask-cors
 USER superset


### PR DESCRIPTION
## Summary
Added `flask-cors` package to the Docker image dependencies to enable Cross-Origin Resource Sharing (CORS) support in the Superset application.

## Changes
- Added `flask-cors` to the pip install command in the Dockerfile alongside existing dependencies (`psycopg2-binary` and `redis`)

## Details
This change ensures that the CORS middleware is available in the containerized Superset environment, allowing the application to handle cross-origin requests appropriately. This is useful when Superset needs to serve requests from different origins or when it's deployed behind a proxy with different domain configurations.

https://claude.ai/code/session_01RnCtf2G5u2PaLPVGUtY7pp