### PR TITLE
Remove readme field from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "hatchling.build"
 name = "robotframework-chat"
 version = "0.2.0"
 description = "Robot Framework-based test harness for systematically testing LLMs"
-readme = "readme.md"
 requires-python = ">=3.11"
 dependencies = [
     "certifi==2025.11.12",


### PR DESCRIPTION
## Summary
Removed the `readme` field from the project configuration in `pyproject.toml`.

## Changes
- Removed `readme = "readme.md"` from `pyproject.toml`

## Details
The `readme` field has been removed from the project metadata. This field was previously pointing to `readme.md` as the project's readme file. Depending on the build backend configuration, this may rely on default readme discovery or the field was redundant with other configuration.

https://claude.ai/code/session_01PMQPBAsBeVCdejWG4WmWPu