### PR TITLE
Add helper scripts for Docker Compose stack management

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Start the Docker Compose stack safely.
+# Tears down any existing containers first to avoid stale state,
+# then starts everything in detached mode.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+echo "Stopping existing containers..."
+docker compose down
+
+echo "Starting containers..."
+docker compose up -d
+
+echo "Stack is up. Use 'docker compose ps' to check status."

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Stop the Docker Compose stack.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+echo "Stopping containers..."
+docker compose down
+
+echo "Stack stopped."


### PR DESCRIPTION
## Summary
Add convenient shell scripts to simplify starting and stopping the Docker Compose stack, improving the developer experience by providing standardized commands for common operations.

## Key Changes
- **scripts/start.sh**: New script that safely starts the Docker Compose stack by first tearing down any existing containers to avoid stale state, then bringing up all services in detached mode
- **scripts/stop.sh**: New script that cleanly stops and removes all Docker Compose containers

## Implementation Details
- Both scripts use `set -euo pipefail` for safe bash execution (exit on error, undefined variables, and pipe failures)
- Scripts automatically navigate to the project root directory using `cd "$(dirname "$0")/.."` for portability
- User-friendly echo messages provide feedback on each operation
- The start script includes a helpful tip to use `docker compose ps` for status checking

https://claude.ai/code/session_011RYYUWFpFt3hyKcyDhNCFX