### PR TITLE
Add robot directory to dashboard Docker image and compose

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -10,6 +10,7 @@ COPY pyproject.toml ./
 COPY src/ src/
 COPY dashboard/ dashboard/
 COPY config/ config/
+COPY robot/ robot/
 
 # Install the project with dashboard and superset extras
 RUN uv pip install --system --no-cache ".[dashboard,superset]"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,6 +131,7 @@ services:
       - "${DASHBOARD_PORT:-8050}:8050"
     volumes:
       - dashboard-results:/app/results/dashboard
+      - ./robot:/app/robot:ro
     healthcheck:
       test: ["CMD-SHELL", "python -c 'import urllib.request; urllib.request.urlopen(\"http://localhost:8050/\")' || exit 1"]
       interval: 15s


### PR DESCRIPTION
## Summary
This change adds the `robot/` directory to the dashboard Docker setup, making robot test files or resources available within the containerized dashboard service.

## Key Changes
- **Dockerfile**: Added `COPY robot/ robot/` to include the robot directory in the dashboard image build
- **docker-compose.yml**: Mounted the `./robot` directory as a read-only volume at `/app/robot` in the dashboard service

## Implementation Details
- The robot directory is copied during the Docker image build phase, ensuring it's available in the final image
- The docker-compose volume mount is read-only (`:ro` flag), preventing accidental modifications to the source robot files from within the container
- This setup allows the dashboard service to access robot test files or resources at runtime

https://claude.ai/code/session_01AipBeiRcekkSWgzQC9d6kh