### PR TITLE
Add GitLab commit links to test metadata

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ stages:
 variables:
   OLLAMA_ENDPOINT: "http://localhost:11434"
   DEFAULT_MODEL: "llama3"
-  ROBOT_OPTIONS: "--metadata CI:true --metadata GitLab_URL:$CI_PROJECT_URL --metadata Commit_SHA:$CI_COMMIT_SHA"
+  ROBOT_OPTIONS: "--metadata CI:true"
 
 # ── Sync ─────────────────────────────────────────────────────────────
 

--- a/src/rfc/ci_metadata_listener.py
+++ b/src/rfc/ci_metadata_listener.py
@@ -49,6 +49,30 @@ class CiMetadataListener:
         if "metadata" in attributes:
             attributes["metadata"].update(self.ci_info)
 
+            project_url = self.ci_info.get("GitLab_URL", "")
+            commit_sha = self.ci_info.get("Commit_SHA", "")
+            commit_short = self.ci_info.get(
+                "Commit_Short_SHA", commit_sha[:8] if commit_sha else ""
+            )
+
+            # Format Commit_SHA as a clickable link to the GitLab commit
+            if project_url and commit_sha:
+                attributes["metadata"]["Commit_SHA"] = (
+                    f"[{commit_short}|{project_url}/-/commit/{commit_sha}]"
+                )
+
+            # Format Source as a clickable link to the file at the commit
+            source = attributes.get("source", "")
+            if source and project_url and commit_sha:
+                project_dir = os.getenv("CI_PROJECT_DIR", "")
+                if project_dir and source.startswith(project_dir):
+                    rel_path = source[len(project_dir) :].lstrip(os.sep)
+                else:
+                    rel_path = source
+                attributes["metadata"]["Source"] = (
+                    f"[{rel_path}|{project_url}/-/blob/{commit_sha}/{rel_path}]"
+                )
+
     def end_suite(self, name: str, attributes: Dict[str, Any]):
         """Called when a test suite ends.
 


### PR DESCRIPTION
## Summary
Enhanced the CI metadata listener to automatically generate clickable links to GitLab commits and source files, improving traceability in test reports.

## Key Changes
- Modified `ci_metadata_listener.py` to format `Commit_SHA` metadata as a clickable link to the GitLab commit page
- Added automatic formatting of `Source` metadata as a clickable link to the file at the specific commit in GitLab
- Moved GitLab URL and commit SHA extraction from Robot Framework command-line options to programmatic handling in the listener
- Updated `.gitlab-ci.yml` to remove redundant metadata parameters from `ROBOT_OPTIONS`, allowing the listener to handle them internally

## Implementation Details
- The listener now retrieves `GitLab_URL` and `Commit_SHA` from the `ci_info` dictionary
- Commit links use the format `[short_sha|project_url/-/commit/full_sha]` for easy identification
- Source file links are generated by computing the relative path from `CI_PROJECT_DIR` and formatting as `[rel_path|project_url/-/blob/commit_sha/rel_path]`
- Gracefully handles missing environment variables and edge cases (empty URLs, missing commit info)

https://claude.ai/code/session_01CymcrAyh7p2wdf5etxebrd