### PR TITLE
Ensure Node.js >= 18 is available for Playwright tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -118,6 +118,7 @@ dashboard-playwright:
   stage: test
   needs: []
   before_script:
+    - . ci/ensure_node.sh
     - uv sync --extra dev --extra dashboard
     - uv pip install robotframework-browser
     - uv run rfbrowser init chromium

--- a/ci/ensure_node.sh
+++ b/ci/ensure_node.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# ci/ensure_node.sh - Ensure Node.js >= 18 is available (required by Playwright)
+#
+# Source this script so PATH changes persist in the caller:
+#   . ci/ensure_node.sh
+#
+# Strategy:
+#   1. If current Node.js is already >= 18, do nothing.
+#   2. Try nvm (common on CI shell executors).
+#   3. Fallback: download a Node.js binary to /tmp.
+
+set -euo pipefail
+
+REQUIRED_MAJOR=18
+NODE_FALLBACK_VER="v20.18.1"
+
+_node_major() {
+    node --version 2>/dev/null | sed -n 's/^v\([0-9]*\).*/\1/p'
+}
+
+# Already sufficient?
+if [ "$(_node_major)" -ge "$REQUIRED_MAJOR" ] 2>/dev/null; then
+    echo "Node.js $(node --version) satisfies >= ${REQUIRED_MAJOR}"
+    return 0 2>/dev/null || exit 0
+fi
+
+echo "Node.js >= ${REQUIRED_MAJOR} required; current: $(node --version 2>/dev/null || echo 'not found')"
+
+# --- Try nvm ---------------------------------------------------------------
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+    echo "Loading nvm from $NVM_DIR ..."
+    # shellcheck disable=SC1091
+    . "$NVM_DIR/nvm.sh"
+    nvm install 20 2>/dev/null || nvm use 20 2>/dev/null || true
+    if [ "$(_node_major)" -ge "$REQUIRED_MAJOR" ] 2>/dev/null; then
+        echo "Using Node.js $(node --version) via nvm"
+        return 0 2>/dev/null || exit 0
+    fi
+fi
+
+# --- Fallback: download Node.js binary ------------------------------------
+NODE_DIR="/tmp/node-${NODE_FALLBACK_VER}-linux-x64"
+
+if [ ! -x "$NODE_DIR/bin/node" ]; then
+    echo "Downloading Node.js ${NODE_FALLBACK_VER} ..."
+    curl -fsSL "https://nodejs.org/dist/${NODE_FALLBACK_VER}/node-${NODE_FALLBACK_VER}-linux-x64.tar.xz" \
+        | tar -xJ -C /tmp
+fi
+
+export PATH="$NODE_DIR/bin:$PATH"
+echo "Using Node.js $(node --version) from $NODE_DIR"

--- a/ci/test_dashboard.sh
+++ b/ci/test_dashboard.sh
@@ -27,6 +27,11 @@ run_pytest() {
 # Playwright: Robot Framework Browser tests against a running dashboard
 # ---------------------------------------------------------------------------
 run_playwright() {
+    echo "--- Ensuring compatible Node.js ---"
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    # shellcheck disable=SC1091
+    . "$SCRIPT_DIR/ensure_node.sh"
+
     echo "--- Installing Playwright browsers ---"
     uv run rfbrowser init chromium
 


### PR DESCRIPTION
## Summary
Add a CI script to ensure Node.js >= 18 is available for Playwright/Robot Framework Browser tests, which require a compatible Node.js version.

## Key Changes
- **New script `ci/ensure_node.sh`**: Implements a three-tier strategy to ensure Node.js >= 18:
  1. Check if current Node.js already satisfies the requirement
  2. Attempt to use nvm (Node Version Manager) if available
  3. Fallback to downloading a prebuilt Node.js binary (v20.18.1) to `/tmp`
  
- **Updated `ci/test_dashboard.sh`**: Call `ensure_node.sh` before running Playwright tests to guarantee Node.js compatibility

- **Updated `.gitlab-ci.yml`**: Add `ensure_node.sh` to the `dashboard-playwright` job's `before_script` to ensure Node.js is available before installing dependencies

## Implementation Details
- The script uses `source` (`. script.sh`) to allow PATH modifications to persist in the caller's environment
- Handles both sourced and executed contexts with appropriate `return`/`exit` statements
- Downloads Node.js binary only if not already cached in `/tmp`
- Includes proper error handling with `set -euo pipefail` and shellcheck directives

https://claude.ai/code/session_01NkUJi3HE47SvDfnDctLVus