### PR TITLE
fix: prevent Docker containers from exiting before exec commands comp…

### DIFF
--- a/robot/resources/container_profiles.resource
+++ b/robot/resources/container_profiles.resource
@@ -4,18 +4,18 @@ Library           rfc.docker_keywords.ConfigurableDockerKeywords    WITH NAME   
 
 *** Variables ***
 # Resource Profiles - Define resource constraints
-&{MINIMAL}          image=python:3.11-alpine    cpu_cores=0.25    memory_mb=128    scratch_mb=64     network_mode=none    read_only=True
-&{STANDARD}         image=python:3.11-slim      cpu_cores=0.5     memory_mb=512    scratch_mb=256    network_mode=none    read_only=True
-&{PERFORMANCE}      image=python:3.11-slim      cpu_cores=1.0     memory_mb=1024   scratch_mb=512    network_mode=none    read_only=True
-&{NETWORKED}        image=python:3.11-slim      cpu_cores=0.5     memory_mb=512    scratch_mb=256    network_mode=bridge  read_only=True
+&{MINIMAL}          image=python:3.11-alpine    command=sleep infinity    cpu_cores=0.25    memory_mb=128    scratch_mb=64     network_mode=none    read_only=True
+&{STANDARD}         image=python:3.11-slim      command=sleep infinity    cpu_cores=0.5     memory_mb=512    scratch_mb=256    network_mode=none    read_only=True
+&{PERFORMANCE}      image=python:3.11-slim      command=sleep infinity    cpu_cores=1.0     memory_mb=1024   scratch_mb=512    network_mode=none    read_only=True
+&{NETWORKED}        image=python:3.11-slim      command=sleep infinity    cpu_cores=0.5     memory_mb=512    scratch_mb=256    network_mode=bridge  read_only=True
 
 # Language-specific profiles
-&{PYTHON_MINIMAL}   image=python:3.11-alpine    cpu_cores=0.25    memory_mb=128    scratch_mb=64     network_mode=none    read_only=True    user=nobody
-&{PYTHON_STANDARD}  image=python:3.11-slim      cpu_cores=0.5     memory_mb=512    scratch_mb=256    network_mode=none    read_only=True    user=nobody
-&{PYTHON_PERF}      image=python:3.11-slim      cpu_cores=2.0     memory_mb=2048   scratch_mb=1024   network_mode=none    read_only=True    user=nobody
-&{NODE_STANDARD}    image=node:18-alpine        cpu_cores=0.5     memory_mb=512    scratch_mb=256    network_mode=none    read_only=True    user=node
-&{ALPINE_SHELL}     image=alpine:latest         cpu_cores=0.25    memory_mb=128    scratch_mb=64     network_mode=none    read_only=True    user=nobody
-&{UBUNTU_DEV}       image=ubuntu:22.04          cpu_cores=0.5     memory_mb=1024   scratch_mb=512    network_mode=none    read_only=False   user=root
+&{PYTHON_MINIMAL}   image=python:3.11-alpine    command=sleep infinity    cpu_cores=0.25    memory_mb=128    scratch_mb=64     network_mode=none    read_only=True    user=nobody
+&{PYTHON_STANDARD}  image=python:3.11-slim      command=sleep infinity    cpu_cores=0.5     memory_mb=512    scratch_mb=256    network_mode=none    read_only=True    user=nobody
+&{PYTHON_PERF}      image=python:3.11-slim      command=sleep infinity    cpu_cores=2.0     memory_mb=2048   scratch_mb=1024   network_mode=none    read_only=True    user=nobody
+&{NODE_STANDARD}    image=node:18-alpine        command=sleep infinity    cpu_cores=0.5     memory_mb=512    scratch_mb=256    network_mode=none    read_only=True    user=node
+&{ALPINE_SHELL}     image=alpine:latest         command=sleep infinity    cpu_cores=0.25    memory_mb=128    scratch_mb=64     network_mode=none    read_only=True    user=nobody
+&{UBUNTU_DEV}       image=ubuntu:22.04          command=sleep infinity    cpu_cores=0.5     memory_mb=1024   scratch_mb=512    network_mode=none    read_only=False   user=root
 
 # LLM Container Profiles (Ollama) - ports are assigned dynamically
 &{OLLAMA_CPU}       image=ollama/ollama:latest    cpu_cores=2.0     memory_mb=4096    scratch_mb=1024   network_mode=bridge    read_only=False    user=root

--- a/robot/resources/environments.resource
+++ b/robot/resources/environments.resource
@@ -51,7 +51,7 @@ Setup Shell Environment
     # Create container with a command that keeps it running
     # Use read_only=False and user=root since shell tests need to create files
     ${profile_dict}=    Get Variable Value    ${${profile}}
-    ${full_config}=    Create Dictionary    &{profile_dict}    command=sleep 3600    auto_remove=False    read_only=False    user=root
+    ${full_config}=    Create Dictionary    &{profile_dict}    command=sleep infinity    read_only=False    user=root
     ${container_id}=    Docker.Create Configurable Container    ${full_config}    rfc-${suite_name}
 
     # Install common tools

--- a/robot/resources/llm_containers.resource
+++ b/robot/resources/llm_containers.resource
@@ -39,7 +39,7 @@ Start LLM Container
 
     # Get base profile and add dynamic port configuration
     ${profile_dict}=    Get Variable Value    ${${profile}}
-    ${full_config}=    Create Dictionary    &{profile_dict}    ports=${port_mapping}    auto_remove=False
+    ${full_config}=    Create Dictionary    &{profile_dict}    ports=${port_mapping}
 
     # Create container with dynamic port
     ${container_id}=    Docker.Create Configurable Container    ${full_config}    ${container_name}

--- a/src/rfc/docker_config.py
+++ b/src/rfc/docker_config.py
@@ -80,7 +80,7 @@ class ContainerConfig:
     read_only: bool = True
     user: Optional[str] = "nobody"
     working_dir: Optional[str] = "/workspace"
-    auto_remove: bool = True
+    auto_remove: bool = False
     detach: bool = True
 
     @classmethod

--- a/src/rfc/docker_keywords.py
+++ b/src/rfc/docker_keywords.py
@@ -139,7 +139,7 @@ class ConfigurableDockerKeywords:
             read_only=to_bool(config.get("read_only"), True),
             user=config.get("user", "nobody"),
             working_dir=config.get("working_dir", "/workspace"),
-            auto_remove=to_bool(config.get("auto_remove"), True),
+            auto_remove=to_bool(config.get("auto_remove"), False),
             detach=to_bool(config.get("detach"), True),
         )
 
@@ -323,6 +323,7 @@ class ConfigurableDockerKeywords:
         """
         config = {
             "image": image,
+            "command": "sleep infinity",
             "cpu_cores": cpu_cores,
             "memory_mb": memory_mb,
             "network_mode": network_mode,
@@ -363,6 +364,7 @@ class ConfigurableDockerKeywords:
             # Create temporary container
             config = {
                 "image": image,
+                "command": "sleep infinity",
                 "cpu_cores": 0.5,
                 "memory_mb": 512,
                 "network_mode": "none",


### PR DESCRIPTION
…lete

Containers were being auto-removed by Docker before exec_run calls could happen. Two issues fixed:
- Changed auto_remove default from True to False so containers persist until explicitly stopped via stop_container/cleanup_all
- Added `sleep infinity` keep-alive command to all exec-oriented container profiles and code execution helpers, preventing the main process from exiting in detached mode

https://claude.ai/code/session_01W7YouYys15LonbFKPtbCYV