### PR TITLE
Add CI job monitoring and artifact upload tracking

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -24,6 +24,7 @@ from dashboard.layout import (
 from dashboard.monitoring import (
     OllamaMonitor,
     PipelineMonitor,
+    build_job_table,
     build_ollama_cards,
     build_pipeline_table,
 )
@@ -403,16 +404,18 @@ def switch_top_tab(active_tab):
 
 @app.callback(
     Output("pipelines-table", "children"),
+    Output("jobs-table", "children"),
     Output("pipelines-last-updated", "children"),
     Input("monitoring-interval", "n_intervals"),
 )
 def update_pipelines(n_intervals):
-    """Fetch and render the GitLab pipelines table."""
+    """Fetch and render the GitLab pipelines and jobs tables."""
     monitor = PipelineMonitor.get()
     monitor.poll_if_due()
-    table = build_pipeline_table(monitor.pipelines, monitor=monitor)
+    pipeline_table = build_pipeline_table(monitor.pipelines, monitor=monitor)
+    job_table = build_job_table(monitor.jobs, monitor=monitor)
     ts = datetime.now().strftime("Updated %H:%M")
-    return table, ts
+    return pipeline_table, job_table, ts
 
 
 # -- Callback 9: update Ollama host cards -------------------------------------

--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -388,7 +388,7 @@ def create_app_layout() -> html.Div:
                         children=[
                             dbc.Tab(label="Sessions", tab_id="top-sessions"),
                             dbc.Tab(label="Ollama Hosts", tab_id="top-ollama"),
-                            dbc.Tab(label="GitLab Pipelines", tab_id="top-pipelines"),
+                            dbc.Tab(label="GitLab CI", tab_id="top-pipelines"),
                         ],
                         className="mb-3",
                     ),


### PR DESCRIPTION
## Summary
This PR extends the GitLab monitoring dashboard to display recent CI jobs alongside pipelines, and adds artifact upload detection by querying the test database.

## Key Changes

- **New `JobInfo` dataclass**: Represents a single GitLab CI job with fields for id, name, status, duration, pipeline details, and artifact upload status
- **Job fetching in `PipelineMonitor`**: 
  - Added `_fetch_jobs()` method to retrieve recent jobs from GitLab API
  - Added `_refresh_uploaded_pipelines()` to query test database for known pipeline URLs
  - Added `_is_uploaded()` helper to check if a pipeline has uploaded artifacts
  - New `jobs` property to expose the job list
- **Duration formatting**: New `_format_duration()` helper function that converts seconds to human-readable format (e.g., "1h 1m 35s")
- **Job table UI**: New `build_job_table()` function that renders jobs in a styled table with columns for ID, name, status, duration, pipeline info, branch, SHA, artifact status, and finish time
- **Dashboard integration**: 
  - Updated pipelines layout to include a separate "CI Jobs" section
  - Modified callback to update both pipeline and job tables
  - Added job count configuration (default 50)
- **Comprehensive test coverage**: Added 40+ tests covering JobInfo, duration formatting, job fetching, artifact detection, and table rendering

## Implementation Details

- Job fetching respects the configured `job_count` setting and includes proper error handling
- Artifact upload detection uses pipeline URL suffix matching to avoid false positives
- Duration formatting handles edge cases (None, zero, exact minutes/hours)
- Job table includes clickable job IDs linking to GitLab, status badges with color coding, and artifact upload indicators
- All new functionality is backward compatible with existing pipeline monitoring

https://claude.ai/code/session_01LgbUUNpFGPQoPX62ozERwp