### PR TITLE
Add ollama_timestamps.json as GitLab CI artifact

### DIFF
--- a/ci/common.yml
+++ b/ci/common.yml
@@ -18,6 +18,7 @@
     paths:
       - results/
       - data/
+      - ollama_timestamps.json
   allow_failure: true
 
 .dashboard-setup:

--- a/scripts/generate_pipeline.py
+++ b/scripts/generate_pipeline.py
@@ -115,7 +115,7 @@ def generate_regular(config: dict[str, Any]) -> dict[str, Any]:
             "script": [robot_cmd],
             "artifacts": {
                 "when": "always",
-                "paths": [f"{output_dir}/", "data/"],
+                "paths": [f"{output_dir}/", "data/", "ollama_timestamps.json"],
             },
             "allow_failure": True,
         }
@@ -212,7 +212,7 @@ def generate_dynamic(config: dict[str, Any]) -> dict[str, Any]:
                     "script": [robot_cmd],
                     "artifacts": {
                         "when": "always",
-                        "paths": [f"{output_dir}/", "data/"],
+                        "paths": [f"{output_dir}/", "data/", "ollama_timestamps.json"],
                     },
                     "allow_failure": True,
                 }


### PR DESCRIPTION
Include ollama_timestamps.json in artifact paths for all Robot Framework test jobs so Ollama call timing data is preserved after pipeline runs.

https://claude.ai/code/session_0123Lqp9ukvVaHq6nttQuBYS