### PR TITLE
Add bidirectional repo sync between GitHub and GitLab

### DIFF
--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types: [closed]
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       branch:
@@ -21,6 +25,9 @@ on:
 
 jobs:
   sync:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.merged == true
     runs-on: self-hosted
     environment: robotframework
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,9 +30,9 @@ variables:
 
 # ── Sync ─────────────────────────────────────────────────────────────
 
-mirror-to-github:
+sync-push:
   stage: sync
-  script: [bash ci/sync.sh]
+  script: [make sync-push]
   rules:
     - if: $CI_PIPELINE_SOURCE == "push"
     - if: $CI_PIPELINE_SOURCE == "schedule"

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ export
 .PHONY: help install up down restart logs bootstrap \
         test test-math test-docker test-safety test-dashboard test-dashboard-playwright \
         import lint format typecheck check version \
-        ci-lint ci-test ci-generate ci-report ci-sync ci-sync-db ci-deploy ci-review ci-test-dashboard \
-        ci-status ci-list-pipelines ci-list-jobs ci-fetch-artifact ci-verify-db
+        ci-lint ci-test ci-generate ci-report ci-sync-db ci-deploy ci-review ci-test-dashboard \
+        ci-status ci-list-pipelines ci-list-jobs ci-fetch-artifact ci-verify-db \
+        sync-push sync-pull
 
 help: ## Show this help
 	@grep -hE '^[a-zA-Z_-]+:.*## .*$$' $(MAKEFILE_LIST) | \
@@ -95,8 +96,11 @@ ci-generate: ## Generate child pipeline YAML (regular|dynamic|discover)
 ci-report: ## Generate repo metrics (add POST_MR=1 to post to MR)
 	bash ci/report.sh $(if $(POST_MR),--post-mr,)
 
-ci-sync: ## Mirror repo to GitHub
+sync-push: ## Mirror repo from GitLab to GitHub
 	bash ci/sync.sh
+
+sync-pull: ## Pull repo from GitHub to GitLab
+	bash ci/sync_pull.sh
 
 ci-status: ## Check GitLab API connectivity
 	uv run python scripts/sync_ci_results.py status

--- a/ci/sync_pull.sh
+++ b/ci/sync_pull.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# ci/sync_pull.sh - Pull GitHub repo and push to GitLab
+#
+# Required env vars:
+#   GITHUB_USER   - GitHub username
+#   GITHUB_TOKEN  - GitHub personal access token
+#   GITLAB_TOKEN  - GitLab personal access token (write_repository scope)
+#
+# Optional env vars:
+#   GITHUB_REPO   - GitHub repo name (default: robotframework-chat)
+#   GITLAB_URL    - GitLab repo URL (default: gitlab.com/space-nomads/robotframework-chat.git)
+#
+# Usage: bash ci/sync_pull.sh
+
+set -euo pipefail
+
+echo "=== Sync: GitHub → GitLab ==="
+
+# Validate required variables
+for var in GITHUB_USER GITHUB_TOKEN GITLAB_TOKEN; do
+    if [ -z "${!var:-}" ]; then
+        echo "ERROR: $var is not set"
+        exit 1
+    fi
+done
+
+GITHUB_REPO="${GITHUB_REPO:-robotframework-chat}"
+GITLAB_URL="${GITLAB_URL:-gitlab.com/space-nomads/robotframework-chat.git}"
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+echo "Cloning mirror from GitHub..."
+git clone --mirror "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_USER}/${GITHUB_REPO}.git" "$WORKDIR/repo.git"
+
+cd "$WORKDIR/repo.git"
+git remote add gitlab "https://oauth2:${GITLAB_TOKEN}@${GITLAB_URL}"
+
+echo "Pushing to GitLab..."
+git push gitlab --mirror --force
+
+echo "=== Sync complete: GitHub → GitLab ==="


### PR DESCRIPTION
## Summary
This PR implements bidirectional repository synchronization between GitHub and GitLab, enabling both push (GitLab → GitHub) and pull (GitHub → GitLab) operations.

## Key Changes

- **New sync script**: Added `ci/sync_pull.sh` to pull changes from GitHub and push them to GitLab
  - Mirrors GitHub repository using git clone --mirror
  - Authenticates with both GitHub (personal access token) and GitLab (oauth2 token)
  - Supports configurable GitHub repo name and GitLab URL via environment variables
  - Includes proper error handling and cleanup

- **Updated Makefile**: 
  - Renamed `ci-sync` target to `sync-push` for clarity
  - Added new `sync-pull` target for GitHub → GitLab synchronization
  - Updated phony targets list to reflect new naming

- **GitHub Actions workflow** (`.github/workflows/sync-to-gitlab.yml`):
  - Added pull_request trigger (on merge to main) to sync merged PRs to GitLab
  - Added conditional check to only run on merged pull requests

- **GitLab CI pipeline** (`.gitlab-ci.yml`):
  - Renamed `mirror-to-github` job to `sync-push` for consistency
  - Updated script to use new Makefile target

## Implementation Details

- Both sync scripts use git mirror cloning for complete repository synchronization
- Environment variables allow flexible configuration for different repositories
- GitHub Actions now triggers sync on both push events and merged pull requests
- Consistent naming convention across CI/CD platforms (sync-push/sync-pull)

https://claude.ai/code/session_01CzxMFuUbPjq4eNc6sy2QoB