### PR TITLE
Add GitHub Actions workflow to mirror staging branch to GitLab

### DIFF
--- a/.github/workflows/mirror-staging-to-gitlab.yml
+++ b/.github/workflows/mirror-staging-to-gitlab.yml
@@ -1,0 +1,46 @@
+name: Mirror claude-code-staging to GitLab
+
+on:
+  push:
+    branches:
+      - claude-code-staging
+  workflow_dispatch:
+
+jobs:
+  mirror:
+    runs-on: self-hosted
+    environment: robotframework
+    steps:
+      - name: Checkout claude-code-staging (full history)
+        uses: actions/checkout@v4
+        with:
+          ref: claude-code-staging
+          fetch-depth: 0
+
+      - name: Push to GitLab
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          echo "::add-mask::${GITLAB_TOKEN}"
+
+          if [ -z "${GITLAB_TOKEN:-}" ]; then
+            echo "::error::GITLAB_TOKEN secret must be configured."
+            echo "Create a GitLab personal access token with write_repository scope"
+            echo "and add it as a repository secret named GITLAB_TOKEN."
+            exit 1
+          fi
+
+          AUTH_URL="https://oauth2:${GITLAB_TOKEN}@gitlab.com/space-nomads/robotframework-chat.git"
+
+          if git remote get-url gitlab >/dev/null 2>&1; then
+            git remote set-url gitlab "${AUTH_URL}"
+          else
+            git remote add gitlab "${AUTH_URL}"
+          fi
+
+          echo "Mirroring claude-code-staging to GitLab"
+          git push gitlab refs/heads/claude-code-staging:refs/heads/claude-code-staging --force
+
+          echo "Mirror complete."


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that automatically mirrors the `claude-code-staging` branch to a GitLab repository whenever changes are pushed to that branch.

## Key Changes
- Added `.github/workflows/mirror-staging-to-gitlab.yml` workflow file that:
  - Triggers on pushes to the `claude-code-staging` branch or manual workflow dispatch
  - Checks out the full git history of the staging branch
  - Authenticates with GitLab using a personal access token stored as a repository secret
  - Adds or updates a GitLab remote and force-pushes the staging branch to `space-nomads/robotframework-chat` on GitLab
  - Includes proper error handling and token masking for security

## Implementation Details
- Uses `self-hosted` runner with the `robotframework` environment
- Fetches full history (`fetch-depth: 0`) to preserve complete git history during mirroring
- Implements token validation with helpful error messages if `GITLAB_TOKEN` secret is not configured
- Uses force push to ensure the GitLab mirror stays in sync with the GitHub staging branch
- Masks the GitLab token in logs to prevent accidental exposure

https://claude.ai/code/session_01KQ6vwnbQuLXUt38dmLtvhc