### PR TITLE
Rename PATH to RESULTS_DIR in import make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,8 @@ test-dashboard: ## Run dashboard pytest unit tests
 test-dashboard-playwright: ## Run dashboard Playwright browser self-tests
 	bash ci/test_dashboard.sh playwright
 
-import: ## Import results from output.xml files: make import PATH=results/
-	uv run python scripts/import_test_results.py $(or $(PATH),results/) -r
+import: ## Import results from output.xml files: make import RESULTS_DIR=results/
+	uv run python scripts/import_test_results.py $(or $(RESULTS_DIR),results/) -r
 
 # ── Code quality ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Updated the `make import` target to use a more descriptive variable name that better reflects its purpose.

## Changes
- Renamed the `PATH` variable to `RESULTS_DIR` in the import make target
- Updated both the help text and the command invocation to use the new variable name
- The functionality remains unchanged; this is purely a naming improvement for clarity

## Details
The `PATH` variable name was ambiguous and could be confused with the system `PATH` environment variable. Renaming it to `RESULTS_DIR` makes it immediately clear that this parameter specifies the directory containing test results to import.

https://claude.ai/code/session_01WFqJ8yEmcYRsr2H9wbHuxe