### PR TITLE
Sync column metadata when bootstrapping datasets

### DIFF
--- a/superset/bootstrap_dashboards.py
+++ b/superset/bootstrap_dashboards.py
@@ -76,6 +76,13 @@ def bootstrap() -> None:
                 db.session.add(ds)
                 db.session.flush()
                 log.info("Created dataset: %s", table_name)
+            # Sync column metadata so Superset knows the schema
+            try:
+                ds.fetch_metadata()
+                db.session.flush()
+                log.info("Synced columns for: %s", table_name)
+            except Exception as e:
+                log.warning("Could not sync columns for %s: %s", table_name, e)
             datasets[table_name] = ds
 
         # ── 3. Charts (Slices) ─────────────────────────────────────


### PR DESCRIPTION
## Summary
Added automatic column metadata synchronization when creating datasets during the bootstrap process. This ensures that Superset properly recognizes the schema and column information for newly created datasets.

## Key Changes
- Added `fetch_metadata()` call after dataset creation to sync column information
- Wrapped metadata sync in try-except block to gracefully handle failures
- Added logging for successful syncs and warnings for failures

## Implementation Details
The metadata synchronization is performed immediately after a dataset is created and flushed to the database. This ensures that Superset has complete schema information available for the dataset before proceeding with other bootstrap operations (such as chart creation). The error handling prevents bootstrap failures if metadata synchronization encounters issues with specific datasets, while still logging warnings for visibility into any problems.

https://claude.ai/code/session_014iZtcAc5btLniT79QGLSAy