### PR TITLE
Fix database initialization to prioritize explicit db_path parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ export
 
 .PHONY: help install docker-up docker-down docker-restart docker-logs bootstrap \
         robot robot-math robot-docker robot-safety robot-dryrun \
+        robot-math-import robot-import \
         test-dashboard test-dashboard-playwright \
         import code-lint code-format code-typecheck code-check code-coverage code-audit version \
         ci-lint ci-test ci-generate ci-report ci-deploy ci-test-dashboard \
@@ -60,6 +61,16 @@ robot-docker: ## Run Docker tests (Robot Framework)
 
 robot-safety: ## Run safety tests (Robot Framework)
 	$(ROBOT) -d results/safety $(LISTENER) robot/safety/
+
+robot-math-import: ## Run math tests then import results (continues on test failures)
+	-$(ROBOT) -d results/math $(LISTENER) robot/math/tests/
+	$(MAKE) import
+
+robot-import: ## Run all tests then import results (continues on test failures)
+	-$(ROBOT) -d results/math $(LISTENER) robot/math/tests/
+	-$(ROBOT) -d results/docker $(LISTENER) robot/docker/
+	-$(ROBOT) -d results/safety $(LISTENER) robot/safety/
+	$(MAKE) import
 
 robot-dryrun: ## Validate all Robot tests (dry run, no execution)
 	$(ROBOT) --dryrun -d results/dryrun $(DRYRUN_LISTENER) robot/


### PR DESCRIPTION
## Summary
This PR fixes the database initialization logic to ensure that an explicitly provided `db_path` parameter always takes precedence and creates a SQLite backend, regardless of environment variables or the `database_url` parameter. This is important for test isolation and predictable behavior.

## Key Changes

### Database Initialization Logic (`src/rfc/test_database.py`)
- **Reordered initialization flow**: Moved the explicit `db_path` check to the beginning of `__init__`, before any environment variable or `database_url` processing
- **Clarified parameter precedence**: Updated docstrings to explicitly document that `db_path` always creates SQLite and takes precedence over `database_url`
- **Improved variable naming**: Renamed internal `db_path` variable to `sqlite_path` in the SQLite fallback path to avoid confusion with the parameter
- **Early return**: Added early return when `db_path` is explicitly provided, simplifying the control flow

### Build Configuration (`Makefile`)
- **Added new test targets**: 
  - `robot-math-import`: Runs math tests and imports results (continues on failures)
  - `robot-import`: Runs all test suites and imports results (continues on failures)
- These targets use the `-` prefix to allow the import step to run even if tests fail

## Implementation Details
The key insight is that when callers explicitly pass a file path (e.g., tests using `tmp_path`), they expect a local SQLite database. By checking this condition first and returning early, we prevent environment variables or other configuration from overriding this expectation. The refactored SQLite fallback path now uses a local `sqlite_path` variable to track the resolved path, making the logic clearer and avoiding shadowing of the parameter.

https://claude.ai/code/session_0145c5AgyAQkwEhkH74rYKZa