### PR TITLE
Update default LLM model from llama3 to gpt-oss:20b

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ DATABASE_URL=postgresql://rfc:changeme@localhost:5432/rfc
 
 # Ollama endpoint for LLM tests
 OLLAMA_ENDPOINT=http://localhost:11434
-DEFAULT_MODEL=llama3
+DEFAULT_MODEL=gpt-oss:20b
 
 # Comma-separated list of Ollama node hostnames for dashboard monitoring.
 # With host networking (default Docker setup), localhost and LAN names

--- a/config/test_suites.yaml
+++ b/config/test_suites.yaml
@@ -9,7 +9,7 @@
 # See scripts/generate_pipeline.py for CI pipeline generation.
 
 defaults:
-  model: "llama3"
+  model: "gpt-oss:20b"
   iq_levels: ["100", "110", "120", "130", "140", "150", "160"]
   profile: "STANDARD"
   timeout_seconds: 120

--- a/robot/ci/models.yaml
+++ b/robot/ci/models.yaml
@@ -110,7 +110,7 @@ categories:
 
 # Test configuration
 test_configuration:
-  default_model: "llama3"
+  default_model: "gpt-oss:20b"
   timeout_seconds: 120
   max_retries: 2
 

--- a/robot/docker/llm/__init__.robot
+++ b/robot/docker/llm/__init__.robot
@@ -19,7 +19,7 @@ Start LLM Suite
     Set Suite Variable    ${OLLAMA_CONTAINER_NAME}    ${unique_name}
 
     # Start fresh container with unique name
-    ${container}=    Start LLM Container    OLLAMA_CPU    ${OLLAMA_CONTAINER_NAME}    llama3
+    ${container}=    Start LLM Container    OLLAMA_CPU    ${OLLAMA_CONTAINER_NAME}    %{DEFAULT_MODEL=gpt-oss:20b}
     Log    LLM suite started with container: ${container} (${OLLAMA_CONTAINER_NAME}) on port ${OLLAMA_PORT}
 
 Cleanup LLM Suite

--- a/robot/resources/llm_containers.resource
+++ b/robot/resources/llm_containers.resource
@@ -22,7 +22,7 @@ ${DEFAULT_LLM_TIMEOUT}  120
 *** Keywords ***
 Start LLM Container
     [Documentation]    Start Ollama container with specified resources on an available port
-    [Arguments]    ${profile}=OLLAMA_CPU    ${container_name}=rfc-ollama    ${pull_models}=llama3
+    [Arguments]    ${profile}=OLLAMA_CPU    ${container_name}=rfc-ollama    ${pull_models}=%{DEFAULT_MODEL=gpt-oss:20b}
 
     # Find an available port to avoid conflicts with local Ollama
     ${available_port}=    Docker.Find Available Port    11434    11500
@@ -103,7 +103,7 @@ Switch LLM Model
 
 Ask Multiple LLMs
     [Documentation]    Send same prompt to multiple models and collect responses
-    [Arguments]    ${prompt}    ${models}=llama3    ${timeout}=60
+    [Arguments]    ${prompt}    ${models}=%{DEFAULT_MODEL=gpt-oss:20b}    ${timeout}=60
 
     ${model_list}=    Split String    ${models}    ,
     ${responses}=    Create Dictionary
@@ -119,7 +119,7 @@ Ask Multiple LLMs
 
 Run Multi-Model Comparison
     [Documentation]    Run same prompt across models and compare results
-    [Arguments]    ${prompt}    ${models}=llama3,codellama    ${timeout}=60
+    [Arguments]    ${prompt}    ${models}=%{DEFAULT_MODEL=gpt-oss:20b}    ${timeout}=60
 
     # Get responses from all models
     ${responses}=    Ask Multiple LLMs    ${prompt}    ${models}    ${timeout}

--- a/scripts/generate_ci_metadata.py
+++ b/scripts/generate_ci_metadata.py
@@ -65,7 +65,7 @@ data = {
     "runner": runner_data,
     "ollama": {
         "endpoint": os.getenv("OLLAMA_ENDPOINT", "http://localhost:11434"),
-        "default_model": os.getenv("DEFAULT_MODEL", "llama3"),
+        "default_model": os.getenv("DEFAULT_MODEL", "gpt-oss:20b"),
     },
     "timestamp": datetime.utcnow().isoformat() + "Z",
 }

--- a/scripts/generate_pipeline.py
+++ b/scripts/generate_pipeline.py
@@ -65,7 +65,7 @@ def generate_regular(config: dict[str, Any]) -> dict[str, Any]:
     defs = config.get("defaults", {})
     listeners = ci.get("listeners", [])
     job_groups = ci.get("job_groups", {})
-    model = defs.get("model", "llama3")
+    model = defs.get("model", "gpt-oss:20b")
     endpoint = defs.get("ollama_endpoint", "http://localhost:11434")
 
     pipeline: dict[str, Any] = {
@@ -226,7 +226,7 @@ def generate_dynamic(config: dict[str, Any]) -> dict[str, Any]:
 
 def _report_job(
     upstream_jobs: list[str],
-    model: str = "llama3",
+    model: str = "gpt-oss:20b",
     output_pattern: str | None = None,
     combined_dir: str = "results/combined",
 ) -> dict[str, Any]:

--- a/src/rfc/git_metadata.py
+++ b/src/rfc/git_metadata.py
@@ -123,7 +123,7 @@ def collect_ci_metadata() -> Dict[str, str]:
 
     # Common fields (always present regardless of platform)
     metadata["Ollama_Endpoint"] = os.getenv("OLLAMA_ENDPOINT", "http://localhost:11434")
-    metadata["Default_Model"] = os.getenv("DEFAULT_MODEL", "llama3")
+    metadata["Default_Model"] = os.getenv("DEFAULT_MODEL", "gpt-oss:20b")
     metadata["Timestamp"] = datetime.utcnow().isoformat() + "Z"
 
     return {k: v for k, v in metadata.items() if v}

--- a/src/rfc/ollama.py
+++ b/src/rfc/ollama.py
@@ -1,5 +1,6 @@
 """Ollama API client for LLM generation and model discovery."""
 
+import os
 import time
 from typing import Any, Dict, List
 
@@ -17,7 +18,7 @@ class OllamaClient:
     def __init__(
         self,
         base_url: str = "http://localhost:11434",
-        model: str = "llama3",
+        model: str = os.getenv("DEFAULT_MODEL", "gpt-oss:20b"),
         temperature: float = 0.0,
         max_tokens: int = 256,
         timeout: int = 120,

--- a/src/rfc/pre_run_modifier.py
+++ b/src/rfc/pre_run_modifier.py
@@ -33,13 +33,13 @@ class ModelAwarePreRunModifier:
         Args:
             ollama_endpoint: Ollama API endpoint (default: env OLLAMA_ENDPOINT or localhost:11434)
             config_path: Path to models.yaml config file
-            default_model: Default model to use (default: env DEFAULT_MODEL or llama3)
+            default_model: Default model to use (default: env DEFAULT_MODEL or gpt-oss:20b)
         """
         self.ollama_endpoint = (
             ollama_endpoint or os.getenv("OLLAMA_ENDPOINT") or "http://localhost:11434"
         )
         self.config_path = config_path or "robot/ci/models.yaml"
-        self.default_model = default_model or os.getenv("DEFAULT_MODEL") or "llama3"
+        self.default_model = default_model or os.getenv("DEFAULT_MODEL") or "gpt-oss:20b"
 
         self._client = OllamaClient(
             base_url=self.ollama_endpoint, model=self.default_model
@@ -97,9 +97,9 @@ class ModelAwarePreRunModifier:
             )
         except Exception as e:
             logger.error(f"Error querying Ollama models: {e}")
-            self.available_models = [self.default_model or "llama3"]
+            self.available_models = [self.default_model or "gpt-oss:20b"]
             logger.info(
-                f"Falling back to default model: {self.default_model or 'llama3'}"
+                f"Falling back to default model: {self.default_model or 'gpt-oss:20b'}"
             )
 
     def _filter_tests_by_models(self, suite: TestSuite) -> None:

--- a/src/rfc/suite_config.py
+++ b/src/rfc/suite_config.py
@@ -158,7 +158,7 @@ def node_dropdown_options() -> list[dict[str, str]]:
 
 
 def default_model() -> str:
-    return defaults().get("model", "llama3")
+    return defaults().get("model", "gpt-oss:20b")
 
 
 def default_iq_levels() -> list[str]:

--- a/tests/test_generate_ci_metadata.py
+++ b/tests/test_generate_ci_metadata.py
@@ -150,7 +150,7 @@ class TestDefaults:
             (tmp_path / "results" / "combined" / "ci_metadata.json").read_text()
         )
         assert data["ollama"]["endpoint"] == "http://localhost:11434"
-        assert data["ollama"]["default_model"] == "llama3"
+        assert data["ollama"]["default_model"] == "gpt-oss:20b"
 
     def test_creates_output_directory(self, tmp_path):
         env = _clean_env()

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -1,5 +1,7 @@
 """Tests for rfc.ollama.OllamaClient."""
 
+import os
+
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -12,7 +14,7 @@ class TestOllamaClientInit:
     def test_defaults(self):
         client = OllamaClient()
         assert client.base_url == "http://localhost:11434"
-        assert client.model == "llama3"
+        assert client.model == os.getenv("DEFAULT_MODEL", "gpt-oss:20b")
         assert client.temperature == 0.0
         assert client.max_tokens == 256
         assert client.timeout == 120

--- a/tests/test_pre_run_modifier.py
+++ b/tests/test_pre_run_modifier.py
@@ -14,7 +14,7 @@ class TestPreRunModifierInit:
         mod = ModelAwarePreRunModifier()
         assert mod.ollama_endpoint == "http://localhost:11434"
         assert mod.config_path == "robot/ci/models.yaml"
-        assert mod.default_model == "llama3"
+        assert mod.default_model == "gpt-oss:20b"
         assert mod.available_models == []
         assert mod.model_config == {}
 

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -27,12 +27,12 @@ class TestSessionConfig:
         return_value={"math": {"path": "robot/math/tests"}},
     )
     @patch("dashboard.core.session_manager.default_iq_levels", return_value=["100"])
-    @patch("dashboard.core.session_manager.default_model", return_value="llama3")
+    @patch("dashboard.core.session_manager.default_model", return_value="gpt-oss:20b")
     @patch("dashboard.core.session_manager.default_profile", return_value="STANDARD")
     def test_default_values(self, _prof, _model, _iq, _suites):
         cfg = SessionConfig()
         assert cfg.suite == "robot/math/tests"
-        assert cfg.model == "llama3"
+        assert cfg.model == "gpt-oss:20b"
         assert cfg.log_level == "INFO"
         assert cfg.auto_recover is False
         assert cfg.dry_run is False
@@ -164,7 +164,7 @@ class TestSessionManager:
         return_value={"math": {"path": "robot/math/tests"}},
     )
     @patch("dashboard.core.session_manager.default_iq_levels", return_value=["100"])
-    @patch("dashboard.core.session_manager.default_model", return_value="llama3")
+    @patch("dashboard.core.session_manager.default_model", return_value="gpt-oss:20b")
     @patch("dashboard.core.session_manager.default_profile", return_value="STANDARD")
     def _make_manager(self, _prof, _model, _iq, _suites):
         return SessionManager()


### PR DESCRIPTION
## Summary
This PR updates the default LLM model used throughout the codebase from `llama3` to `gpt-oss:20b`. This change affects configuration files, environment variables, test fixtures, and default parameter values across multiple modules.

## Key Changes
- Updated `DEFAULT_MODEL` environment variable default from `llama3` to `gpt-oss:20b` in `.env.example`
- Modified default model parameter in core modules:
  - `OllamaClient` class in `src/rfc/ollama.py` now uses environment variable with fallback to `gpt-oss:20b`
  - `PreRunModifier` class in `src/rfc/pre_run_modifier.py` updated to use new default
  - `suite_config.py` default model function updated
- Updated configuration files:
  - `config/test_suites.yaml` - defaults section
  - `robot/ci/models.yaml` - test configuration
- Updated Robot Framework resource files:
  - `robot/resources/llm_containers.resource` - keyword arguments now use environment variable with fallback
  - `robot/docker/llm/__init__.robot` - suite initialization
- Updated pipeline generation scripts:
  - `scripts/generate_pipeline.py` - default model in pipeline generation
  - `scripts/generate_ci_metadata.py` - metadata collection
- Updated test fixtures and assertions in:
  - `tests/test_session_manager.py`
  - `tests/test_ollama.py`
  - `tests/test_pre_run_modifier.py`
  - `tests/test_generate_ci_metadata.py`
- Updated `src/rfc/git_metadata.py` - metadata collection

## Implementation Details
- The change leverages environment variable `DEFAULT_MODEL` with `gpt-oss:20b` as the fallback default
- Robot Framework keywords now use `%{DEFAULT_MODEL=gpt-oss:20b}` syntax for environment variable substitution with defaults
- All test mocks and assertions have been updated to reflect the new default model
- The change is backward compatible - if `DEFAULT_MODEL` environment variable is set, it will be used instead

https://claude.ai/code/session_01RTNUSttvBSc2iy8pM4HxAy