### PR TITLE
Clarify code quality workflow with Makefile targets

### DIFF
--- a/ai/AGENTS.md
+++ b/ai/AGENTS.md
@@ -43,15 +43,20 @@ Test results are archived to SQL and visualized in Apache Superset dashboards.
 1. Write failing test first (red)
 2. Implement minimal code (green)
 3. Refactor if needed
-4. Run `pre-commit run --all-files`
+4. Run code quality checks before committing:
+   - `make code-format` — auto-format code with ruff
+   - `make code-check` — run all quality checks (lint + typecheck)
+   - `make code-coverage` — run pytest with coverage report
+   - `pre-commit run --all-files` — final gate (yaml, json, whitespace, ruff, mypy)
 5. Commit: `<type>: <summary>`
 
 **Prohibited:**
 - Skip tests
 - Commit failing code
+- Commit code that fails `make code-check`
 - Bundle unrelated changes
 - Mix formatting + logic
-- Bypass pre-commit
+- Bypass pre-commit or Makefile quality checks
 
 **Commit Types:**
 - `test:` - Add/update tests
@@ -99,13 +104,15 @@ uv run robot -d results -i IQ:120 robot/docker/python
 uv sync --extra dashboard
 rfc-dashboard  # or: uv run python -m dashboard.cli
 
-# Lint & format
-uv run ruff check .
-uv run ruff check --fix .
-uv run ruff format .
-uv run mypy src/
+# Code quality (prefer Makefile targets)
+make code-format                # Auto-format with ruff
+make code-lint                  # Run ruff linter
+make code-typecheck             # Run mypy type checker
+make code-check                 # Run all checks (lint + typecheck)
+make code-coverage              # Run pytest with coverage
+make code-audit                 # Audit dependencies for vulnerabilities
 
-# Pre-commit
+# Pre-commit (final gate)
 pre-commit run --all-files
 ```
 


### PR DESCRIPTION
## Summary
Updated the AGENTS.md documentation to clarify the code quality and testing workflow by promoting Makefile targets as the primary interface for code quality checks, while maintaining pre-commit as a final validation gate.

## Key Changes
- **Expanded TDD workflow guidance**: Added detailed steps for running code quality checks (`make code-format`, `make code-check`, `make code-coverage`) before committing, with clear descriptions of what each target does
- **Enhanced prohibited practices**: Added explicit prohibition against committing code that fails `make code-check` and bypassing Makefile quality checks
- **Reorganized command reference**: Replaced raw `ruff` and `mypy` commands with Makefile targets as the preferred approach, including new targets for `code-lint`, `code-typecheck`, `code-audit`, and `code-coverage`
- **Clarified tool hierarchy**: Positioned pre-commit as a "final gate" rather than the primary quality check mechanism, with Makefile targets as the developer-facing interface

## Implementation Details
- All code quality operations now have corresponding Makefile targets that developers should use
- Pre-commit remains as a safety net for catching issues before they reach version control
- Documentation now clearly distinguishes between formatting (`code-format`), linting (`code-lint`), type checking (`code-typecheck`), and comprehensive checks (`code-check`)

https://claude.ai/code/session_01SiSvMzVx5Z2sSTJ3WQUWER