### PR TITLE
docs: add CLAUDE.md with persistent AI agent instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md — Claude Code persistent instructions
+
+Read and follow `@ai/AGENTS.md` for project philosophy, architecture, code style,
+commit conventions, and the full agent contract.
+
+Read `@ai/DEV.md` for development workflow, TDD discipline, and definition of done.
+
+---
+
+## Quick reference
+
+```bash
+make install                  # Install all dependencies (dev + dashboard + superset)
+pre-commit install            # Install git hooks (required before first commit)
+uv run pytest                 # Run Python unit tests
+pre-commit run --all-files    # Run all pre-commit checks
+make code-check               # Lint (ruff) + typecheck (mypy)
+make robot-dryrun             # Validate Robot tests without execution
+```
+
+---
+
+## Rules
+
+- **Always run tests after changes.** `uv run pytest` for Python, `make robot-dryrun` for Robot Framework.
+- **Always run `pre-commit run --all-files` before committing.** Never bypass hooks.
+- **Don't remove functionality without explicit approval.**
+- **Be verbose in CLI output** — when running commands, show what's happening.
+- **TDD is mandatory.** Write a failing test first, then implement, then refactor.
+- **Atomic commits only.** One idea per commit, using conventional format: `<type>: <summary>`.
+- **Never bundle unrelated changes** in a single commit.
+- **Never mix formatting changes with logic changes.**
+- **Type hints are required** on all new Python code. mypy must pass.
+- **Use `RETURN` (not `[Return]`)** in Robot Framework keywords.
+
+---
+
+## Architecture guardrails
+
+- `src/rfc/` is the single source of truth for all Python code.
+- `robot/` is the single home for all Robot Framework test suites.
+- Never duplicate logic outside these directories.
+- Listeners are always active in make targets — don't strip them.
+
+---
+
+## Environment
+
+Copy `.env.example` to `.env` and edit before running integration tests.
+Key variables: `OLLAMA_ENDPOINT`, `DEFAULT_MODEL`, `DATABASE_URL`.
+See `ai/DEV.md` § Environment Configuration for the full list.


### PR DESCRIPTION
## Summary
Add `CLAUDE.md` as a persistent instruction file for AI agents working on this codebase. This document establishes clear guidelines for development practices, testing discipline, code quality standards, and architectural constraints.

## Key Changes
- **New file: `CLAUDE.md`** — Comprehensive reference guide for AI agents covering:
  - Quick reference commands for common development tasks (install, test, lint, pre-commit)
  - Mandatory development rules (TDD, atomic commits, type hints, pre-commit enforcement)
  - Architecture guardrails (source of truth directories, no logic duplication)
  - Environment setup requirements
  - Cross-references to `@ai/AGENTS.md` and `@ai/DEV.md` for extended documentation

## Notable Details
- Establishes TDD as mandatory discipline with explicit test-first workflow
- Enforces conventional commit format and atomic commit practices
- Requires type hints on all new Python code with mypy validation
- Clarifies directory structure (`src/rfc/` for Python, `robot/` for tests)
- Documents pre-commit hook requirements and testing commands
- Provides environment configuration guidance with reference to detailed setup docs

https://claude.ai/code/session_01UpqKbMZJ8YPPboaZoG6Kr7