### PR TITLE
Change PostgreSQL port from 5432 to 5433

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 POSTGRES_USER=rfc
 POSTGRES_PASSWORD=changeme
 POSTGRES_DB=rfc
-POSTGRES_PORT=5432
+POSTGRES_PORT=5433
 
 # ── Superset ──────────────────────────────────────────────────────────
 SUPERSET_SECRET_KEY=generate-a-random-secret-here
@@ -25,7 +25,7 @@ DASHBOARD_PORT=8050
 # ── Test runner ───────────────────────────────────────────────────────
 # DATABASE_URL tells the test harness to archive to PostgreSQL.
 # Construct from the variables above.
-DATABASE_URL=postgresql://rfc:changeme@localhost:5432/rfc
+DATABASE_URL=postgresql://rfc:changeme@localhost:5433/rfc
 
 # Ollama endpoint for LLM tests
 OLLAMA_ENDPOINT=http://localhost:11434

--- a/ai/AGENTS.md
+++ b/ai/AGENTS.md
@@ -421,7 +421,7 @@ Set `DATABASE_URL` in your environment or `.env` to switch backends:
 
 ```bash
 # PostgreSQL (for Superset)
-DATABASE_URL=postgresql://rfc:changeme@localhost:5432/rfc
+DATABASE_URL=postgresql://rfc:changeme@localhost:5433/rfc
 
 # SQLite (default when DATABASE_URL is unset)
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
       POSTGRES_DB: ${POSTGRES_DB:-rfc}
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+      - "${POSTGRES_PORT:-5433}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     networks:
@@ -158,7 +158,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
-      DATABASE_URL: "postgresql://${POSTGRES_USER:-rfc}:${POSTGRES_PASSWORD:-changeme}@localhost:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-rfc}"
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-rfc}:${POSTGRES_PASSWORD:-changeme}@localhost:${POSTGRES_PORT:-5433}/${POSTGRES_DB:-rfc}"
       OLLAMA_ENDPOINT: ${OLLAMA_ENDPOINT:-http://localhost:11434}
       DEFAULT_MODEL: ${DEFAULT_MODEL:-llama3}
       # Comma-separated list of Ollama node hostnames.

--- a/docs/TEST_DATABASE.md
+++ b/docs/TEST_DATABASE.md
@@ -22,7 +22,7 @@ Backend selection is automatic based on the `DATABASE_URL` environment variable:
 
 ```bash
 # PostgreSQL (used with Superset)
-export DATABASE_URL=postgresql://rfc:changeme@localhost:5432/rfc
+export DATABASE_URL=postgresql://rfc:changeme@localhost:5433/rfc
 
 # SQLite (default - no configuration needed)
 # Stores to data/test_history.db
@@ -156,7 +156,7 @@ from rfc.test_database import TestDatabase
 db = TestDatabase()
 
 # PostgreSQL
-db = TestDatabase(database_url="postgresql://rfc:changeme@localhost:5432/rfc")
+db = TestDatabase(database_url="postgresql://rfc:changeme@localhost:5433/rfc")
 
 # Get performance stats
 stats = db.get_model_performance()


### PR DESCRIPTION
## Summary
Updates the default PostgreSQL port from the standard 5432 to 5433 across all configuration files and documentation.

## Changes
- Updated `.env.example` to use `POSTGRES_PORT=5433` and corresponding `DATABASE_URL`
- Modified `docker-compose.yml` to expose PostgreSQL on port 5433 instead of 5432
- Updated test runner `DATABASE_URL` configuration to use the new port
- Updated documentation in `docs/TEST_DATABASE.md` with new port in examples
- Updated `ai/AGENTS.md` documentation with new port in PostgreSQL connection examples

## Details
This change affects:
- Local development environment configuration
- Docker Compose service port mapping
- Test database connection strings
- All related documentation and code examples

The port change applies consistently across environment variables, Docker configuration, and documentation to ensure a unified development experience.

https://claude.ai/code/session_01X4CiaDRaMXsqhMZDFjKg5i