### PR TITLE
Rename GitLab-specific columns to platform-agnostic names

### DIFF
--- a/src/rfc/test_database.py
+++ b/src/rfc/test_database.py
@@ -613,6 +613,10 @@ class _SQLAlchemyBackend(_Backend):
     _PG_MIGRATIONS = [
         # pipeline_id exceeded INTEGER range (~2.1B); widen to BIGINT.
         "ALTER TABLE pipeline_results ALTER COLUMN pipeline_id TYPE BIGINT",
+        # Rename GitLab-specific columns to platform-agnostic names.
+        "ALTER TABLE test_runs RENAME COLUMN gitlab_commit TO git_commit",
+        "ALTER TABLE test_runs RENAME COLUMN gitlab_branch TO git_branch",
+        "ALTER TABLE test_runs RENAME COLUMN gitlab_pipeline_url TO pipeline_url",
     ]
 
     def __init__(self, database_url: str):


### PR DESCRIPTION
## Summary
This change adds a database migration to rename GitLab-specific column names in the `test_runs` table to platform-agnostic names, making the schema more flexible for supporting multiple Git platforms.

## Key Changes
- Added PostgreSQL migration to rename three columns in the `test_runs` table:
  - `gitlab_commit` → `git_commit`
  - `gitlab_branch` → `git_branch`
  - `gitlab_pipeline_url` → `pipeline_url`

## Implementation Details
The migration is added to the `_PG_MIGRATIONS` list in the `_SQLAlchemyBackend` class, following the existing pattern of database schema updates. This allows the test database to support multiple Git platforms while maintaining a consistent column naming convention.

https://claude.ai/code/session_01DeY9qFNGDWDEnDMZc8r6P1