### PR TITLE
Update docker-restart to rebuild images before restarting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,8 @@ docker-up: .env ## Start PostgreSQL + Redis + Superset + Grafana + Dashboard
 docker-down: ## Stop all services
 	$(COMPOSE) down
 
-docker-restart: ## Restart all services
-	$(COMPOSE) restart
+docker-restart: ## Rebuild images and restart all services
+	$(COMPOSE) up -d --build
 
 docker-logs: ## Tail service logs
 	$(COMPOSE) logs -f


### PR DESCRIPTION
## Summary
Modified the `docker-restart` make target to rebuild Docker images before restarting services, ensuring that any code or configuration changes are reflected in the running containers.

## Key Changes
- Changed `docker-restart` command from `$(COMPOSE) restart` to `$(COMPOSE) up -d --build`
- Updated the help text to reflect that the target now rebuilds images in addition to restarting services

## Implementation Details
The previous implementation used `docker-compose restart`, which only restarts existing containers without rebuilding images. The new implementation uses `docker-compose up -d --build`, which:
- Rebuilds any images that have changes
- Starts/restarts all services in detached mode
- Ensures the running containers reflect the latest code and configuration changes

This is particularly useful during development when code changes need to be immediately reflected in the running services.

https://claude.ai/code/session_01WwrwtnivDvbzzKY6rLLeLJ