### PR TITLE
Add cross-platform Node.js binary download support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,11 +116,14 @@ dashboard-playwright:
   tags: [nodejs]
   needs: []
   before_script:
+    - mkdir -p results/dashboard/playwright
     - . ci/ensure_node.sh
     - uv sync --extra dev --extra dashboard
     - uv pip install robotframework-browser
     - uv run rfbrowser init chromium
   script: [bash ci/test_dashboard.sh playwright]
+  after_script:
+    - mkdir -p results/dashboard/playwright
   artifacts:
     when: always
     paths:


### PR DESCRIPTION
## Summary
Enhanced the Node.js fallback installation script to support multiple platforms (Linux and macOS) and architectures (x64 and arm64), making CI more flexible and portable.

## Key Changes
- **Platform detection**: Added `_node_platform()` function to detect OS (Darwin/Linux) and architecture (arm64/x64) and determine appropriate download URL and archive format
- **Dynamic download URLs**: Modified fallback download logic to construct platform-specific URLs and handle both `.tar.gz` (macOS) and `.tar.xz` (Linux) archive formats
- **Updated documentation**: Clarified in comments that the fallback strategy supports both Linux and macOS
- **CI improvements**: Added explicit directory creation in `dashboard-playwright` job's before_script and after_script to ensure results directory exists

## Implementation Details
- The `_node_platform()` function uses `uname -s` to detect OS and `uname -m` to detect architecture
- Archive extraction uses conditional logic: `tar -xz` for gzip files and `tar -xJ` for xz files
- The platform string is used consistently in both the temporary directory path and download URL construction

https://claude.ai/code/session_01MPUoJFTTpGKzPktUyW43GV