### PR TITLE
Mock monitoring config in dashboard monitoring test

### DIFF
--- a/tests/test_dashboard_monitoring.py
+++ b/tests/test_dashboard_monitoring.py
@@ -142,8 +142,18 @@ class TestPipelineMonitor:
         PipelineMonitor._instance = None
 
     @patch("dashboard.monitoring._detect_gitlab_from_git_remote")
-    def test_not_configured_when_empty(self, mock_detect):
+    @patch("dashboard.monitoring._monitoring_config")
+    def test_not_configured_when_empty(self, mock_config, mock_detect):
         mock_detect.return_value = ("", "")
+        mock_config.return_value = {
+            "poll_interval_seconds": 30,
+            "history_hours": 24,
+            "gitlab_api_url": "",
+            "gitlab_project_id": "",
+            "gitlab_token_env": "GITLAB_TOKEN",
+            "pipeline_count": 20,
+            "job_count": 50,
+        }
         with patch.dict(
             os.environ,
             {


### PR DESCRIPTION
## Summary
Updated the `test_not_configured_when_empty` test to properly mock the `_monitoring_config` function, ensuring the test has complete control over configuration values during execution.

## Key Changes
- Added `@patch("dashboard.monitoring._monitoring_config")` decorator to mock the monitoring configuration function
- Updated test method signature to accept the new `mock_config` parameter
- Configured the mock to return a complete monitoring configuration dictionary with default values including poll interval, history hours, GitLab API settings, and pipeline/job counts

## Implementation Details
The test now explicitly mocks both the GitLab detection and the monitoring configuration, ensuring that the test validates the behavior when both detection and configuration return empty/default values. This improves test isolation and prevents external configuration from affecting the test outcome.

https://claude.ai/code/session_01TjnDfrCDdFhrX4VByVuWMp