### PR TITLE
Include readme.md in Docker build context

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 RUN pip install --no-cache-dir uv
 
 # Copy project files
-COPY pyproject.toml ./
+COPY pyproject.toml readme.md ./
 COPY src/ src/
 COPY dashboard/ dashboard/
 COPY config/ config/


### PR DESCRIPTION
## Summary
Updated the Dockerfile to include `readme.md` in the files copied during the Docker build process.

## Changes
- Modified the `COPY` instruction in the dashboard Dockerfile to include `readme.md` alongside `pyproject.toml`

## Details
This change ensures that the readme documentation file is available within the Docker image, which may be needed for runtime reference or documentation purposes within the container.

https://claude.ai/code/session_017EMNvMJF7KVBSgm8uJa5pa