### PR TITLE
Add GitHub token authentication to GitLab sync workflow

### DIFF
--- a/.github/workflows/sync-from-gitlab.yml
+++ b/.github/workflows/sync-from-gitlab.yml
@@ -19,6 +19,9 @@ on:
           - "true"
           - "false"
 
+permissions:
+  contents: write
+
 jobs:
   sync:
     runs-on: self-hosted
@@ -49,6 +52,9 @@ jobs:
           fi
 
           AUTH_URL="https://oauth2:${GITLAB_TOKEN}@gitlab.com/space-nomads/robotframework-chat.git"
+
+          # Configure origin with GITHUB_TOKEN so pushes authenticate
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
 
           # Add GitLab as a remote
           if git remote get-url gitlab >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
Updated the GitLab sync workflow to properly authenticate with GitHub when pushing changes, and added the necessary permissions for the workflow to write to the repository.

## Key Changes
- Added `permissions: contents: write` to allow the workflow to push commits to the repository
- Configured the GitHub origin remote to use `GITHUB_TOKEN` for authentication, ensuring pushes to the repository are properly authenticated

## Implementation Details
The workflow now explicitly sets the origin remote URL with the GitHub token before performing any git operations. This ensures that when syncing changes from GitLab, the subsequent push to GitHub will authenticate correctly using the provided `GITHUB_TOKEN` secret, rather than relying on default authentication mechanisms that may not be available in self-hosted runner environments.

https://claude.ai/code/session_01BTpytaZ6W1cjd6kkZBtg7M