### PR TITLE
Add database destination description and console output to DbListener

### DIFF
--- a/src/rfc/db_listener.py
+++ b/src/rfc/db_listener.py
@@ -22,6 +22,7 @@ URL is provided.
 import os
 from datetime import datetime
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 from robot.api import logger  # type: ignore
 
@@ -115,6 +116,26 @@ class DbListener:
                 self._db = TestDatabase()
         return self._db
 
+    def _describe_database_destination(self) -> str:
+        """Return a human-readable description of the database target.
+
+        Does NOT trigger lazy database initialization. Parses
+        ``self._database_url`` to determine the backend and destination,
+        stripping credentials from PostgreSQL URLs.
+        """
+        url = self._database_url
+        if url and url.startswith("postgresql"):
+            parsed = urlparse(url)
+            host_part = parsed.hostname or "localhost"
+            if parsed.port:
+                host_part += f":{parsed.port}"
+            db_name = parsed.path.lstrip("/") if parsed.path else ""
+            return f"PostgreSQL: {host_part}/{db_name}"
+        if url and url.startswith("sqlite:///"):
+            path = url.replace("sqlite:///", "")
+            return f"SQLite: {path}"
+        return "SQLite: data/test_history.db (default)"
+
     def start_suite(self, name: str, attributes: Dict[str, Any]) -> None:
         self._suite_depth += 1
         if self._suite_depth == 1:
@@ -122,6 +143,10 @@ class DbListener:
             self._ci_info = collect_ci_metadata()
             self._test_cases = []
             self._keyword_results = []
+            dest = self._describe_database_destination()
+            banner = f"DbListener: archiving results to {dest}"
+            logger.info(banner)
+            logger.console(banner)
 
     def start_test(self, name: str, attributes: Dict[str, Any]) -> None:
         """Reset per-test structured data at the start of each test."""
@@ -291,13 +316,18 @@ class DbListener:
             ]
             db.add_keyword_results(kw_results)
 
-            logger.info(
-                f"Archived {len(results)} test results and "
-                f"{len(kw_results)} keyword results "
-                f"to database (run_id={run_id})"
+            dest = self._describe_database_destination()
+            summary = (
+                f"DbListener: archived {len(results)} test result(s) "
+                f"and {len(kw_results)} keyword result(s) "
+                f"to {dest} (run_id={run_id})"
             )
+            logger.info(summary)
+            logger.console(summary)
         except Exception as e:
-            logger.warn(f"Failed to archive results to database: {e}")
+            error_msg = f"DbListener: FAILED to archive results: {e}"
+            logger.warn(error_msg)
+            logger.console(error_msg)
 
 
 def _compute_duration(start: str, end: str) -> Optional[float]:

--- a/tests/test_db_listener.py
+++ b/tests/test_db_listener.py
@@ -591,3 +591,127 @@ class TestDbListenerGetDb:
         db1 = listener._get_db()
         db2 = listener._get_db()
         assert db1 is db2
+
+
+class TestDbListenerDatabaseDescription:
+    """Tests for _describe_database_destination helper."""
+
+    def test_default_sqlite_when_no_url(self):
+        listener = DbListener()
+        desc = listener._describe_database_destination()
+        assert "SQLite" in desc
+        assert "test_history.db" in desc
+
+    def test_explicit_sqlite_url(self):
+        listener = DbListener(database_url="sqlite:///path/to/my.db")
+        desc = listener._describe_database_destination()
+        assert "SQLite" in desc
+        assert "path/to/my.db" in desc
+
+    def test_postgresql_url_strips_credentials(self):
+        listener = DbListener(
+            database_url="postgresql://user:secret@localhost:5433/rfc"
+        )
+        desc = listener._describe_database_destination()
+        assert "PostgreSQL" in desc
+        assert "localhost:5433/rfc" in desc
+        assert "secret" not in desc
+        assert "user" not in desc
+
+    def test_postgresql_url_without_credentials(self):
+        listener = DbListener(database_url="postgresql://localhost:5433/rfc")
+        desc = listener._describe_database_destination()
+        assert "PostgreSQL" in desc
+        assert "localhost:5433/rfc" in desc
+
+    def test_does_not_trigger_db_init(self):
+        listener = DbListener(database_url="sqlite:///whatever.db")
+        listener._describe_database_destination()
+        assert listener._db is None
+
+
+class TestDbListenerConsoleOutput:
+    """Tests for console output visibility."""
+
+    @patch("rfc.db_listener.logger")
+    @patch("rfc.db_listener.collect_ci_metadata", return_value={})
+    def test_start_suite_emits_console_banner(self, _mock_ci, mock_logger):
+        listener = DbListener(database_url="sqlite:///test.db")
+        listener.start_suite("My Suite", {})
+
+        mock_logger.console.assert_called()
+        console_calls = [str(call) for call in mock_logger.console.call_args_list]
+        full_output = " ".join(console_calls)
+        assert "SQLite" in full_output
+
+    @patch("rfc.db_listener.logger")
+    @patch("rfc.db_listener.collect_ci_metadata", return_value={})
+    def test_start_suite_banner_not_repeated_for_nested(self, _mock_ci, mock_logger):
+        listener = DbListener(database_url="sqlite:///test.db")
+        listener.start_suite("Top", {})
+        mock_logger.console.reset_mock()
+        listener.start_suite("Nested", {})
+        mock_logger.console.assert_not_called()
+
+    @patch("rfc.db_listener.logger")
+    @patch("rfc.db_listener.collect_ci_metadata", return_value={})
+    def test_end_suite_emits_console_summary(self, _mock_ci, mock_logger, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        listener = DbListener(database_url=f"sqlite:///{db_path}")
+
+        listener.start_suite("Suite", {})
+        listener.end_test("T1", _test_attrs(status="PASS"))
+        listener.end_test("T2", _test_attrs(status="FAIL"))
+        mock_logger.console.reset_mock()
+        listener.end_suite("Suite", _suite_attrs(totaltests=2))
+
+        mock_logger.console.assert_called()
+        console_calls = [str(call) for call in mock_logger.console.call_args_list]
+        full_output = " ".join(console_calls)
+        assert "2 test" in full_output
+        assert "run_id=" in full_output
+
+    @patch("rfc.db_listener.logger")
+    @patch("rfc.db_listener.collect_ci_metadata", return_value={})
+    def test_end_suite_console_includes_keyword_count(
+        self, _mock_ci, mock_logger, tmp_path
+    ):
+        db_path = str(tmp_path / "test.db")
+        listener = DbListener(database_url=f"sqlite:///{db_path}")
+
+        listener.start_suite("Suite", {})
+        listener.start_test("T", {})
+        listener.start_keyword(
+            "Ask LLM",
+            _kw_attrs(kwname="Ask LLM", libname="rfc.keywords"),
+        )
+        listener.end_keyword(
+            "Ask LLM",
+            _kw_attrs(kwname="Ask LLM", libname="rfc.keywords"),
+        )
+        listener.end_test("T", _test_attrs())
+        mock_logger.console.reset_mock()
+        listener.end_suite("Suite", _suite_attrs(totaltests=1))
+
+        console_calls = [str(call) for call in mock_logger.console.call_args_list]
+        full_output = " ".join(console_calls)
+        assert "1 keyword" in full_output
+
+    @patch("rfc.db_listener.logger")
+    @patch("rfc.db_listener.collect_ci_metadata", return_value={})
+    def test_database_error_emits_console_warning(self, _mock_ci, mock_logger):
+        listener = DbListener()
+        mock_db = MagicMock()
+        mock_db.add_test_run.side_effect = Exception("connection refused")
+        listener._db = mock_db
+
+        listener.start_suite("Suite", {})
+        listener.end_test("T1", _test_attrs())
+        mock_logger.console.reset_mock()
+        listener.end_suite("Suite", _suite_attrs())
+
+        mock_logger.console.assert_called()
+        console_calls = [str(call) for call in mock_logger.console.call_args_list]
+        full_output = " ".join(console_calls)
+        assert "FAILED" in full_output
+        assert "connection refused" in full_output


### PR DESCRIPTION
## Summary
Enhanced the `DbListener` class to provide better visibility into database operations by adding human-readable descriptions of the database destination and emitting console output at key lifecycle events.

## Key Changes
- **New `_describe_database_destination()` method**: Generates a human-readable description of the database target without triggering lazy initialization. Intelligently parses database URLs to:
  - Display PostgreSQL connection details (host, port, database name) while stripping credentials
  - Display SQLite file paths
  - Fall back to default SQLite path when no URL is configured

- **Enhanced console output**: 
  - `start_suite()` now emits a banner message indicating where results will be archived
  - `end_suite()` now emits a summary message with test/keyword counts and the run ID
  - Error handling in `end_suite()` now logs failures to console for visibility
  - Banner is only shown for top-level suites (not repeated for nested suites)

- **Improved logging messages**: Updated log messages to be more descriptive and consistent, including the database destination in the summary output

## Implementation Details
- Uses `urllib.parse.urlparse()` to safely extract connection details from database URLs
- Credential stripping for PostgreSQL URLs prevents sensitive information from appearing in logs
- Console output uses `logger.console()` in addition to `logger.info()` for better visibility in test execution output
- The `_describe_database_destination()` method is non-invasive and does not trigger database initialization

https://claude.ai/code/session_017SUtT1z8LDJt2hZcQvPo9W