### PR TITLE
Add results upload capability via rsync to remote server

### DIFF
--- a/.env.remote.example
+++ b/.env.remote.example
@@ -1,0 +1,34 @@
+# Remote node environment configuration
+#
+# Copy to .env on each remote Ollama node and edit:
+#   cp .env.remote.example .env
+#
+# A "remote node" is any machine in the fleet (e.g. ai1, Mini1s-Mac-Mini)
+# that runs Ollama and executes Robot Framework tests locally, then sends
+# results back to the central server.
+
+# ── Node Identity ────────────────────────────────────────────────────
+# Friendly name for this node (used in result paths and metadata).
+# Should match the hostname in config/test_suites.yaml.
+NODE_NAME=my-node
+
+# ── Ollama (local to this node) ─────────────────────────────────────
+OLLAMA_ENDPOINT=http://localhost:11434
+DEFAULT_MODEL=llama3.2:latest
+
+# Comma-separated list of Ollama nodes to probe.
+# Set to just "localhost" when this node only tests its own models.
+OLLAMA_NODES_LIST=localhost
+
+# ── Central Database ────────────────────────────────────────────────
+# PostgreSQL connection string for the central results database.
+# Point this at the server running docker-compose (PostgreSQL + Superset).
+# Leave empty to fall back to local SQLite (data/test_history.db).
+DATABASE_URL=postgresql://rfc:changeme@central-server:5433/rfc
+
+# ── Results Server (for make send-results) ──────────────────────────
+# SSH connection details for rsync-ing results to the central server.
+RESULTS_SERVER=central-server
+RESULTS_SERVER_USER=rfc
+RESULTS_SERVER_PATH=/opt/rfc/results/
+RESULTS_SERVER_PORT=22

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ export
 .PHONY: help install \
         robot robot-math robot-docker robot-safety robot-dryrun \
         robot-math-import robot-import import \
+        send-results \
         discover-local-nodes discover-local-models run-local-models \
         code-quality-lint code-quality-format code-quality-typecheck \
         code-quality-check code-quality-coverage code-quality-audit \
@@ -69,6 +70,9 @@ robot-dryrun: ## Validate all Robot tests (dry run, no execution)
 
 import: ## Import results from output.xml files: make import RESULTS_DIR=results/
 	uv run python scripts/import_test_results.py $(or $(RESULTS_DIR),results/) -r
+
+send-results: ## Send results to remote server via rsync (set RESULTS_SERVER_* env vars)
+	bash ci/send_results.sh
 
 # ── Local Node Discovery & Model Runs ─────────────────────────────────
 

--- a/ci/send_results.sh
+++ b/ci/send_results.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# ci/send_results.sh - Send Robot Framework results to a remote server
+#
+# Syncs the local results directory to a remote host via rsync over SSH.
+# Only transfers output.xml, log.html, and report.html files.
+#
+# Required env vars:
+#   RESULTS_SERVER       - Target hostname or IP
+#   RESULTS_SERVER_USER  - SSH user on the remote host
+#   RESULTS_SERVER_PATH  - Remote directory to receive results
+#
+# Optional env vars:
+#   RESULTS_SERVER_PORT  - SSH port (default: 22)
+#   RESULTS_DIR          - Local results directory (default: results/)
+#
+# Usage:
+#   bash ci/send_results.sh
+#   RESULTS_DIR=results/math bash ci/send_results.sh
+
+set -euo pipefail
+
+echo "=== Send Results to Remote Server ==="
+
+for var in RESULTS_SERVER RESULTS_SERVER_USER RESULTS_SERVER_PATH; do
+    if [ -z "${!var:-}" ]; then
+        echo "ERROR: $var is not set"
+        echo "Hint: copy .env.remote.example to .env and fill in the RESULTS_SERVER_* variables"
+        exit 1
+    fi
+done
+
+RESULTS_DIR="${RESULTS_DIR:-results/}"
+RESULTS_SERVER_PORT="${RESULTS_SERVER_PORT:-22}"
+
+if [ ! -d "$RESULTS_DIR" ]; then
+    echo "ERROR: Results directory not found: $RESULTS_DIR"
+    echo "Run tests first (e.g. make robot) to generate results."
+    exit 1
+fi
+
+# Count result files before sending
+file_count=$(find "$RESULTS_DIR" -name "output.xml" -o -name "log.html" -o -name "report.html" | wc -l)
+if [ "$file_count" -eq 0 ]; then
+    echo "WARNING: No result files (output.xml, log.html, report.html) found in $RESULTS_DIR"
+    exit 0
+fi
+
+TARGET="${RESULTS_SERVER_USER}@${RESULTS_SERVER}:${RESULTS_SERVER_PATH}"
+
+echo "Source:      $RESULTS_DIR"
+echo "Destination: $TARGET"
+echo "SSH port:    $RESULTS_SERVER_PORT"
+echo "Files:       $file_count result file(s)"
+echo ""
+
+rsync -avz --progress \
+    -e "ssh -p ${RESULTS_SERVER_PORT}" \
+    --include='*/' \
+    --include='output.xml' \
+    --include='log.html' \
+    --include='report.html' \
+    --exclude='*' \
+    "$RESULTS_DIR" "$TARGET"
+
+echo ""
+echo "=== Results sent successfully ==="


### PR DESCRIPTION
## Summary
This PR adds the ability to send Robot Framework test results to a remote server via rsync over SSH, enabling distributed test execution with centralized result collection.

## Key Changes
- **New script `ci/send_results.sh`**: Bash script that syncs local test results (output.xml, log.html, report.html) to a remote server using rsync over SSH
  - Validates required environment variables (RESULTS_SERVER, RESULTS_SERVER_USER, RESULTS_SERVER_PATH)
  - Supports optional configuration (custom SSH port, custom results directory)
  - Includes pre-flight checks (directory existence, file count validation)
  - Provides clear logging of source, destination, and transfer progress

- **New config template `.env.remote.example`**: Environment configuration template for remote Ollama nodes
  - Documents node identity, local Ollama configuration, and central database connection
  - Includes results server SSH connection details for result uploads
  - Provides clear guidance on setup and usage

- **Updated Makefile**: Added `send-results` target
  - New phony target that invokes the results upload script
  - Includes help text documenting required environment variables

## Implementation Details
- The rsync command uses selective inclusion filters to transfer only the three result file types (output.xml, log.html, report.html), reducing transfer size
- Script uses `set -euo pipefail` for robust error handling
- Pre-execution validation counts result files and warns if none are found
- SSH port is configurable via environment variable with sensible default (22)
- Results directory defaults to `results/` but can be overridden per invocation

https://claude.ai/code/session_018DcxnxC424w1Gbv6uSYEjT