### PR TITLE
Add Loki listener for structured logging of LLM interactions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,12 @@ GRAFANA_PORT=3000
 GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=admin
 
+# ── Loki (log aggregation) ──────────────────────────────────────────
+# LOKI_URL: Loki push API base URL used by the LokiListener.
+# Inside Docker network use http://loki:3100; from the host use localhost.
+LOKI_URL=http://localhost:3100
+LOKI_PORT=3100
+
 # ── Test runner ───────────────────────────────────────────────────────
 # DATABASE_URL tells the test harness to archive to PostgreSQL.
 # Construct from the variables above.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 
 COMPOSE  := $(shell docker compose version >/dev/null 2>&1 && echo "docker compose" || { echo "Error: Docker Compose V2 is required. Install it with: https://docs.docker.com/compose/install/" >&2; echo "false"; })
 ROBOT    := uv run robot
-LISTENER := --listener rfc.db_listener.DbListener --listener rfc.git_metadata_listener.GitMetaData --listener rfc.ollama_timestamp_listener.OllamaTimestampListener
+LISTENER := --listener rfc.db_listener.DbListener --listener rfc.git_metadata_listener.GitMetaData --listener rfc.ollama_timestamp_listener.OllamaTimestampListener --listener rfc.loki_listener.LokiListener
 DRYRUN_LISTENER := --listener rfc.dry_run_listener.DryRunListener
 
 # Load .env if present

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,12 +113,47 @@ services:
       timeout: 5s
       retries: 10
 
+  # ── Loki (log aggregation) ──────────────────────────────────────────
+  loki:
+    image: grafana/loki:3.4.2
+    restart: unless-stopped
+    command: -config.file=/etc/loki/loki-config.yaml
+    ports:
+      - "${LOKI_PORT:-3100}:3100"
+    volumes:
+      - ./loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro
+      - loki-data:/loki
+    networks:
+      - rfc-net
+    healthcheck:
+      test: ["CMD-SHELL", "wget --quiet --tries=1 --output-document=- http://localhost:3100/ready || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+
+  # ── Promtail (log shipper → Loki) ─────────────────────────────────
+  promtail:
+    image: grafana/promtail:3.4.2
+    restart: unless-stopped
+    command: -config.file=/etc/promtail/promtail-config.yaml
+    depends_on:
+      loki:
+        condition: service_healthy
+    volumes:
+      - ./loki/promtail-config.yaml:/etc/promtail/promtail-config.yaml:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - rfc-net
+
   # ── Grafana ────────────────────────────────────────────────────────
   grafana:
     image: grafana/grafana-oss:11.4.0
     restart: unless-stopped
     depends_on:
       postgres:
+        condition: service_healthy
+      loki:
         condition: service_healthy
     environment:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
@@ -145,3 +180,4 @@ networks:
 volumes:
   pgdata:
   grafana-data:
+  loki-data:

--- a/grafana/provisioning/datasources/loki.yaml
+++ b/grafana/provisioning/datasources/loki.yaml
@@ -1,0 +1,11 @@
+# Grafana datasource provisioning for Loki log aggregation.
+# Auto-configures the Loki connection for log exploration and dashboards.
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: true

--- a/loki/loki-config.yaml
+++ b/loki/loki-config.yaml
@@ -1,0 +1,42 @@
+# Loki configuration for robotframework-chat.
+# Single-tenant local mode with filesystem storage.
+#
+# Docs: https://grafana.com/docs/loki/latest/configure/
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: "2024-01-01"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 168h
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h
+  delete_request_store: filesystem

--- a/loki/promtail-config.yaml
+++ b/loki/promtail-config.yaml
@@ -1,0 +1,40 @@
+# Promtail configuration for robotframework-chat.
+# Scrapes Docker container logs and ships them to Loki.
+#
+# Docs: https://grafana.com/docs/loki/latest/send-data/promtail/configuration/
+
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  # Scrape Docker container logs via mounted log directory.
+  - job_name: docker
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: docker
+          __path__: /var/lib/docker/containers/*/*-json.log
+
+    pipeline_stages:
+      # Parse Docker JSON log format.
+      - docker: {}
+
+      # Extract compose labels for service identification.
+      - regex:
+          source: filename
+          expression: '/var/lib/docker/containers/(?P<container_id>[a-f0-9]+)/'
+
+      # Drop empty log lines.
+      - match:
+          selector: '{job="docker"}'
+          stages:
+            - drop:
+                expression: '^\s*$'

--- a/src/rfc/loki_listener.py
+++ b/src/rfc/loki_listener.py
@@ -1,0 +1,250 @@
+"""Robot Framework listener that pushes log entries to Grafana Loki.
+
+Sends structured log entries for all Ollama interactions directly to
+Loki via its HTTP push API.  Entries are batched during the test run
+and flushed at the end of the top-level suite.
+
+Labels attached to each log stream:
+    job            - always ``robotframework``
+    suite          - top-level suite name
+    model          - active LLM model name
+    event_type     - input | output | config | grading | system
+
+Gracefully degrades when Loki is unreachable — a warning is logged
+but test execution is never interrupted.
+
+Usage:
+    robot --listener rfc.loki_listener.LokiListener tests/
+    robot --listener rfc.loki_listener.LokiListener:loki_url=http://loki:3100 tests/
+
+The listener reads ``LOKI_URL`` from the environment if no explicit
+URL is provided.  Default: ``http://localhost:3100``.
+"""
+
+import json
+import os
+import time
+from collections import defaultdict
+from typing import Any, Dict, List, Optional
+
+import requests
+from robot.api import logger  # type: ignore
+
+# Keywords worth logging and their event types.
+_KEYWORD_TYPES: Dict[str, str] = {
+    "Ask LLM": "input",
+    "Grade Answer": "grading",
+    "Set LLM Endpoint": "config",
+    "Set LLM Model": "config",
+    "Set LLM Parameters": "config",
+    "Wait For LLM": "system",
+    "Get Running Models": "system",
+    "LLM Is Busy": "system",
+}
+
+# Timeout for HTTP push to avoid blocking test execution.
+_HTTP_TIMEOUT_SECONDS = 5
+
+
+class LokiListener:
+    """Listener that pushes Robot Framework log entries to Grafana Loki.
+
+    Hooks into keyword start/end events to capture Ollama interactions,
+    batches the entries, and pushes them to Loki's ``/loki/api/v1/push``
+    endpoint when the top-level suite finishes.
+
+    Usage:
+        robot --listener rfc.loki_listener.LokiListener tests/
+        robot --listener rfc.loki_listener.LokiListener:loki_url=<URL> tests/
+    """
+
+    ROBOT_LISTENER_API_VERSION = 2
+
+    def __init__(self, loki_url: Optional[str] = None) -> None:
+        self._loki_url = loki_url or os.getenv("LOKI_URL", "http://localhost:3100")
+        self._model: str = os.getenv("DEFAULT_MODEL", "unknown")
+        self._entries: List[Dict[str, str]] = []
+        self._in_tracked_keyword: Optional[str] = None
+        self._suite_depth: int = 0
+        self._suite_name: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Suite tracking
+    # ------------------------------------------------------------------
+
+    def start_suite(self, name: str, attributes: Dict[str, Any]) -> None:
+        self._suite_depth += 1
+        if self._suite_depth == 1:
+            self._suite_name = name
+            push_url = f"{self._loki_url}/loki/api/v1/push"
+            banner = f"LokiListener: pushing logs to {push_url}"
+            logger.info(banner)
+            logger.console(banner)
+
+    def end_suite(self, name: str, attributes: Dict[str, Any]) -> None:
+        self._suite_depth -= 1
+        if self._suite_depth > 0:
+            return
+        if not self._entries:
+            return
+        self._flush_to_loki()
+
+    # ------------------------------------------------------------------
+    # Keyword tracking
+    # ------------------------------------------------------------------
+
+    def start_keyword(self, name: str, attributes: Dict[str, Any]) -> None:
+        event_type = _KEYWORD_TYPES.get(name)
+        if event_type is None:
+            return
+
+        self._in_tracked_keyword = name
+        args = attributes.get("args", [])
+
+        if name == "Set LLM Model":
+            if args:
+                self._model = args[0]
+            self._add_entry("config", f"model={args[0] if args else 'unknown'}")
+
+        elif name == "Set LLM Endpoint":
+            self._add_entry("config", f"endpoint={args[0] if args else 'unknown'}")
+
+        elif name == "Set LLM Parameters":
+            params = ", ".join(str(a) for a in args)
+            self._add_entry("config", f"parameters={params}")
+
+        elif name == "Ask LLM":
+            prompt = args[0] if args else ""
+            self._add_entry("input", prompt)
+
+        elif name == "Grade Answer":
+            question = args[0] if args else ""
+            self._add_entry("grading", question)
+
+        elif name == "Wait For LLM":
+            self._add_entry("system", "waiting for LLM")
+
+        elif name == "Get Running Models":
+            self._add_entry("system", "querying running models")
+
+        elif name == "LLM Is Busy":
+            self._add_entry("system", "checking busy status")
+
+    def end_keyword(self, name: str, attributes: Dict[str, Any]) -> None:
+        if self._in_tracked_keyword == name:
+            self._in_tracked_keyword = None
+
+    # ------------------------------------------------------------------
+    # Log message capture (for LLM responses)
+    # ------------------------------------------------------------------
+
+    def log_message(self, message: Dict[str, Any]) -> None:
+        """Capture LLM responses logged by OllamaClient.generate().
+
+        The client logs ``"{model} >> {text}"`` on successful generation.
+        """
+        if self._in_tracked_keyword not in ("Ask LLM", "Grade Answer"):
+            return
+
+        text = message.get("message", "")
+        if " >> " in text:
+            response = text.split(" >> ", 1)[1]
+            self._add_entry("output", response)
+
+    # ------------------------------------------------------------------
+    # Loki payload building
+    # ------------------------------------------------------------------
+
+    def _build_push_payload(self) -> Dict[str, Any]:
+        """Build a Loki push API payload from buffered entries.
+
+        Groups entries by ``event_type`` into separate streams, each
+        with labels for ``job``, ``suite``, ``model``, and ``event_type``.
+
+        Returns:
+            Dict matching the Loki ``/loki/api/v1/push`` JSON schema.
+        """
+        if not self._entries:
+            return {"streams": []}
+
+        # Group entries by event_type for separate label streams.
+        grouped: Dict[str, List[Dict[str, str]]] = defaultdict(list)
+        for entry in self._entries:
+            grouped[entry["event_type"]].append(entry)
+
+        streams = []
+        for event_type, entries in grouped.items():
+            # Use the model from the first entry in the group.
+            model = entries[0]["model"]
+            values = [[e["timestamp"], e["message"]] for e in entries]
+            streams.append(
+                {
+                    "stream": {
+                        "job": "robotframework",
+                        "suite": self._suite_name or "unknown",
+                        "model": model,
+                        "event_type": event_type,
+                    },
+                    "values": values,
+                }
+            )
+
+        return {"streams": streams}
+
+    # ------------------------------------------------------------------
+    # HTTP push
+    # ------------------------------------------------------------------
+
+    def _flush_to_loki(self) -> None:
+        """Push buffered entries to Loki and clear the buffer."""
+        payload = self._build_push_payload()
+        push_url = f"{self._loki_url}/loki/api/v1/push"
+
+        try:
+            resp = requests.post(
+                push_url,
+                headers={"Content-Type": "application/json"},
+                data=json.dumps(payload),
+                timeout=_HTTP_TIMEOUT_SECONDS,
+            )
+            if resp.status_code < 300:
+                count = len(self._entries)
+                summary = f"LokiListener: pushed {count} entries to {push_url}"
+                logger.info(summary)
+                logger.console(summary)
+            else:
+                logger.warn(
+                    f"LokiListener: Loki returned HTTP {resp.status_code}: "
+                    f"{resp.text[:200]}"
+                )
+        except requests.ConnectionError:
+            logger.warn(
+                f"LokiListener: could not connect to Loki at {push_url} "
+                "(is Loki running?)"
+            )
+        except requests.Timeout:
+            logger.warn(
+                f"LokiListener: request to {push_url} timed out "
+                f"after {_HTTP_TIMEOUT_SECONDS}s"
+            )
+        except Exception as e:
+            logger.warn(f"LokiListener: failed to push logs: {e}")
+        finally:
+            self._entries = []
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _add_entry(self, event_type: str, message: str) -> None:
+        """Append a structured log entry."""
+        # Loki expects nanosecond-precision timestamps as strings.
+        timestamp_ns = str(int(time.time() * 1_000_000_000))
+        self._entries.append(
+            {
+                "timestamp": timestamp_ns,
+                "event_type": event_type,
+                "message": message,
+                "model": self._model,
+            }
+        )

--- a/tests/test_loki_listener.py
+++ b/tests/test_loki_listener.py
@@ -1,0 +1,422 @@
+"""Tests for LokiListener."""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from rfc.loki_listener import LokiListener
+
+
+class TestLokiListenerInit:
+    """Tests for LokiListener initialization and configuration."""
+
+    def test_robot_listener_api_version(self):
+        listener = LokiListener()
+        assert listener.ROBOT_LISTENER_API_VERSION == 2
+
+    def test_initial_state(self):
+        listener = LokiListener()
+        assert listener._entries == []
+        assert listener._in_tracked_keyword is None
+        assert listener._suite_depth == 0
+        assert listener._suite_name is None
+
+    def test_default_loki_url(self):
+        with patch.dict(os.environ, {}, clear=True):
+            listener = LokiListener()
+        assert listener._loki_url == "http://localhost:3100"
+
+    def test_loki_url_from_env(self):
+        with patch.dict(os.environ, {"LOKI_URL": "http://loki:3100"}):
+            listener = LokiListener()
+        assert listener._loki_url == "http://loki:3100"
+
+    def test_loki_url_from_constructor(self):
+        listener = LokiListener(loki_url="http://custom:3100")
+        assert listener._loki_url == "http://custom:3100"
+
+    def test_default_model_from_env(self):
+        with patch.dict(os.environ, {"DEFAULT_MODEL": "mistral"}):
+            listener = LokiListener()
+        assert listener._model == "mistral"
+
+    def test_default_model_fallback(self):
+        with patch.dict(os.environ, {}, clear=True):
+            listener = LokiListener()
+        assert listener._model == "unknown"
+
+
+class TestLokiListenerKeywordTracking:
+    """Tests for keyword detection and entry creation."""
+
+    def test_ask_llm_creates_input_entry(self):
+        listener = LokiListener()
+        listener.start_keyword("Ask LLM", {"args": ["What is 2+2?"]})
+        assert len(listener._entries) == 1
+        entry = listener._entries[0]
+        assert entry["event_type"] == "input"
+        assert entry["message"] == "What is 2+2?"
+
+    def test_set_llm_model_creates_config_entry(self):
+        listener = LokiListener()
+        listener.start_keyword("Set LLM Model", {"args": ["llama3"]})
+        assert len(listener._entries) == 1
+        entry = listener._entries[0]
+        assert entry["event_type"] == "config"
+        assert "model=llama3" in entry["message"]
+
+    def test_set_llm_model_updates_model(self):
+        listener = LokiListener()
+        listener.start_keyword("Set LLM Model", {"args": ["phi3"]})
+        assert listener._model == "phi3"
+
+    def test_set_llm_endpoint_creates_config_entry(self):
+        listener = LokiListener()
+        listener.start_keyword("Set LLM Endpoint", {"args": ["http://ai1:11434"]})
+        assert len(listener._entries) == 1
+        entry = listener._entries[0]
+        assert entry["event_type"] == "config"
+        assert "endpoint=http://ai1:11434" in entry["message"]
+
+    def test_set_llm_parameters_creates_config_entry(self):
+        listener = LokiListener()
+        listener.start_keyword("Set LLM Parameters", {"args": ["0.5", "512"]})
+        entry = listener._entries[0]
+        assert entry["event_type"] == "config"
+        assert "parameters=" in entry["message"]
+
+    def test_grade_answer_creates_grading_entry(self):
+        listener = LokiListener()
+        listener.start_keyword("Grade Answer", {"args": ["What is 2+2?", "4", "4"]})
+        entry = listener._entries[0]
+        assert entry["event_type"] == "grading"
+        assert entry["message"] == "What is 2+2?"
+
+    def test_wait_for_llm_creates_system_entry(self):
+        listener = LokiListener()
+        listener.start_keyword("Wait For LLM", {"args": []})
+        entry = listener._entries[0]
+        assert entry["event_type"] == "system"
+
+    def test_get_running_models_creates_system_entry(self):
+        listener = LokiListener()
+        listener.start_keyword("Get Running Models", {"args": []})
+        entry = listener._entries[0]
+        assert entry["event_type"] == "system"
+
+    def test_llm_is_busy_creates_system_entry(self):
+        listener = LokiListener()
+        listener.start_keyword("LLM Is Busy", {"args": []})
+        entry = listener._entries[0]
+        assert entry["event_type"] == "system"
+
+    def test_ignores_non_tracked_keywords(self):
+        listener = LokiListener()
+        listener.start_keyword("Should Be Equal", {"args": ["a", "b"]})
+        assert listener._in_tracked_keyword is None
+        assert len(listener._entries) == 0
+
+    def test_end_keyword_clears_tracked(self):
+        listener = LokiListener()
+        listener.start_keyword("Ask LLM", {"args": ["test"]})
+        assert listener._in_tracked_keyword == "Ask LLM"
+        listener.end_keyword("Ask LLM", {})
+        assert listener._in_tracked_keyword is None
+
+    def test_end_keyword_mismatched_name_no_clear(self):
+        listener = LokiListener()
+        listener.start_keyword("Ask LLM", {"args": ["test"]})
+        listener.end_keyword("Wait For LLM", {})
+        assert listener._in_tracked_keyword == "Ask LLM"
+
+    def test_empty_args_handled(self):
+        listener = LokiListener()
+        listener.start_keyword("Ask LLM", {"args": []})
+        entry = listener._entries[0]
+        assert entry["event_type"] == "input"
+        assert entry["message"] == ""
+
+    def test_no_args_key_handled(self):
+        listener = LokiListener()
+        listener.start_keyword("Ask LLM", {})
+        entry = listener._entries[0]
+        assert entry["event_type"] == "input"
+        assert entry["message"] == ""
+
+
+class TestLokiListenerLogMessage:
+    """Tests for LLM response capture via log_message."""
+
+    def test_captures_llm_output_during_ask(self):
+        listener = LokiListener()
+        listener.start_keyword("Ask LLM", {"args": ["What is 2+2?"]})
+        listener.log_message({"message": "llama3 >> The answer is 4.", "level": "INFO"})
+        assert len(listener._entries) == 2
+        entry = listener._entries[1]
+        assert entry["event_type"] == "output"
+        assert entry["message"] == "The answer is 4."
+
+    def test_captures_llm_output_during_grade(self):
+        listener = LokiListener()
+        listener.start_keyword("Grade Answer", {"args": ["Q?", "A", "A"]})
+        listener.log_message(
+            {"message": 'llama3 >> {"score": 1}', "level": "INFO"}
+        )
+        assert len(listener._entries) == 2
+        entry = listener._entries[1]
+        assert entry["event_type"] == "output"
+
+    def test_ignores_log_message_outside_tracked_keyword(self):
+        listener = LokiListener()
+        listener.log_message({"message": "llama3 >> hello", "level": "INFO"})
+        assert len(listener._entries) == 0
+
+    def test_ignores_log_message_without_arrow(self):
+        listener = LokiListener()
+        listener.start_keyword("Ask LLM", {"args": ["test"]})
+        listener.log_message({"message": "some other log", "level": "INFO"})
+        assert len(listener._entries) == 1  # only the input entry
+
+
+class TestLokiListenerEntryFormat:
+    """Tests for the Loki push API payload format."""
+
+    def test_entry_has_required_fields(self):
+        listener = LokiListener()
+        listener.start_keyword("Ask LLM", {"args": ["Hello"]})
+        entry = listener._entries[0]
+        assert "timestamp" in entry
+        assert "event_type" in entry
+        assert "message" in entry
+        assert "model" in entry
+
+    def test_entry_timestamp_is_nanoseconds(self):
+        listener = LokiListener()
+        listener.start_keyword("Ask LLM", {"args": ["Hello"]})
+        entry = listener._entries[0]
+        # Loki expects nanosecond timestamps as strings
+        ts = entry["timestamp"]
+        assert isinstance(ts, str)
+        assert len(ts) >= 19  # nanosecond precision
+
+    def test_build_push_payload_structure(self):
+        listener = LokiListener()
+        listener._suite_name = "Math Tests"
+        listener.start_keyword("Ask LLM", {"args": ["What is 2+2?"]})
+        listener.log_message({"message": "llama3 >> 4", "level": "INFO"})
+
+        payload = listener._build_push_payload()
+        assert "streams" in payload
+        assert len(payload["streams"]) > 0
+
+        stream = payload["streams"][0]
+        assert "stream" in stream
+        assert "values" in stream
+        assert stream["stream"]["job"] == "robotframework"
+        assert stream["stream"]["suite"] == "Math Tests"
+
+    def test_build_push_payload_groups_by_event_type(self):
+        listener = LokiListener()
+        listener._suite_name = "Tests"
+        listener.start_keyword("Ask LLM", {"args": ["q1"]})
+        listener.end_keyword("Ask LLM", {})
+        listener.start_keyword("Set LLM Model", {"args": ["llama3"]})
+        listener.end_keyword("Set LLM Model", {})
+
+        payload = listener._build_push_payload()
+        # Should have separate streams for different event types
+        event_types = {s["stream"]["event_type"] for s in payload["streams"]}
+        assert "input" in event_types
+        assert "config" in event_types
+
+    def test_build_push_payload_values_format(self):
+        """Each value should be [timestamp_ns, log_line]."""
+        listener = LokiListener()
+        listener._suite_name = "Tests"
+        listener.start_keyword("Ask LLM", {"args": ["Hello"]})
+
+        payload = listener._build_push_payload()
+        stream = payload["streams"][0]
+        assert len(stream["values"]) == 1
+        ts, line = stream["values"][0]
+        assert isinstance(ts, str)
+        assert isinstance(line, str)
+        assert "Hello" in line
+
+    def test_empty_entries_produces_empty_streams(self):
+        listener = LokiListener()
+        payload = listener._build_push_payload()
+        assert payload == {"streams": []}
+
+
+class TestLokiListenerSuiteTracking:
+    """Tests for suite depth tracking and flush behavior."""
+
+    def test_start_suite_increments_depth(self):
+        listener = LokiListener()
+        listener.start_suite("Top", {})
+        assert listener._suite_depth == 1
+
+    def test_start_suite_captures_name(self):
+        listener = LokiListener()
+        listener.start_suite("Math Tests", {})
+        assert listener._suite_name == "Math Tests"
+
+    def test_nested_suite_does_not_flush(self):
+        listener = LokiListener()
+        listener.start_suite("Top", {})
+        listener.start_suite("Nested", {})
+        listener.start_keyword("Ask LLM", {"args": ["test"]})
+        listener.end_keyword("Ask LLM", {})
+
+        with patch.object(listener, "_flush_to_loki") as mock_flush:
+            listener.end_suite("Nested", {"totaltests": 1})
+            mock_flush.assert_not_called()
+
+    def test_top_level_suite_flushes(self):
+        listener = LokiListener()
+        listener.start_suite("Top", {})
+        listener.start_keyword("Ask LLM", {"args": ["test"]})
+        listener.end_keyword("Ask LLM", {})
+
+        with patch.object(listener, "_flush_to_loki") as mock_flush:
+            listener.end_suite("Top", {"totaltests": 1})
+            mock_flush.assert_called_once()
+
+    def test_no_entries_no_flush(self):
+        listener = LokiListener()
+        listener.start_suite("Top", {})
+        with patch.object(listener, "_flush_to_loki") as mock_flush:
+            listener.end_suite("Top", {"totaltests": 0})
+            mock_flush.assert_not_called()
+
+    def test_flush_clears_entries(self):
+        listener = LokiListener()
+        listener.start_suite("Top", {})
+        listener.start_keyword("Ask LLM", {"args": ["test"]})
+        listener.end_keyword("Ask LLM", {})
+
+        with patch("rfc.loki_listener.requests.post"):
+            listener.end_suite("Top", {"totaltests": 1})
+
+        assert listener._entries == []
+
+
+class TestLokiListenerHTTPPush:
+    """Tests for the HTTP push to Loki."""
+
+    def test_flush_posts_to_loki_push_endpoint(self):
+        listener = LokiListener(loki_url="http://loki:3100")
+        listener.start_suite("Tests", {})
+        listener.start_keyword("Ask LLM", {"args": ["Hello"]})
+        listener.end_keyword("Ask LLM", {})
+
+        with patch("rfc.loki_listener.requests.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=204)
+            listener.end_suite("Tests", {"totaltests": 1})
+
+            mock_post.assert_called_once()
+            url = mock_post.call_args[0][0]
+            assert url == "http://loki:3100/loki/api/v1/push"
+
+            kwargs = mock_post.call_args[1]
+            assert kwargs["headers"]["Content-Type"] == "application/json"
+            payload = json.loads(kwargs["data"])
+            assert "streams" in payload
+
+    def test_flush_graceful_on_connection_error(self):
+        """Loki being unreachable should not raise."""
+        listener = LokiListener()
+        listener.start_suite("Tests", {})
+        listener.start_keyword("Ask LLM", {"args": ["Hello"]})
+        listener.end_keyword("Ask LLM", {})
+
+        with patch("rfc.loki_listener.requests.post") as mock_post:
+            mock_post.side_effect = requests.ConnectionError("refused")
+            # Should not raise
+            listener.end_suite("Tests", {"totaltests": 1})
+
+    def test_flush_graceful_on_http_error(self):
+        """Non-2xx response should not raise."""
+        listener = LokiListener()
+        listener.start_suite("Tests", {})
+        listener.start_keyword("Ask LLM", {"args": ["Hello"]})
+        listener.end_keyword("Ask LLM", {})
+
+        with patch("rfc.loki_listener.requests.post") as mock_post:
+            mock_post.return_value = MagicMock(
+                status_code=500, text="Internal Server Error"
+            )
+            # Should not raise
+            listener.end_suite("Tests", {"totaltests": 1})
+
+    def test_flush_graceful_on_timeout(self):
+        """Timeout should not raise."""
+        listener = LokiListener()
+        listener.start_suite("Tests", {})
+        listener.start_keyword("Ask LLM", {"args": ["Hello"]})
+        listener.end_keyword("Ask LLM", {})
+
+        with patch("rfc.loki_listener.requests.post") as mock_post:
+            mock_post.side_effect = requests.Timeout("timed out")
+            listener.end_suite("Tests", {"totaltests": 1})
+
+    def test_flush_uses_short_timeout(self):
+        """HTTP push should use a reasonable timeout to avoid blocking tests."""
+        listener = LokiListener()
+        listener.start_suite("Tests", {})
+        listener.start_keyword("Ask LLM", {"args": ["Hello"]})
+        listener.end_keyword("Ask LLM", {})
+
+        with patch("rfc.loki_listener.requests.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=204)
+            listener.end_suite("Tests", {"totaltests": 1})
+
+            kwargs = mock_post.call_args[1]
+            assert kwargs["timeout"] <= 5
+
+
+class TestLokiListenerFullFlow:
+    """End-to-end flow tests simulating realistic test runs."""
+
+    def test_full_conversation_flow(self):
+        listener = LokiListener()
+        listener.start_suite("Math Tests", {})
+
+        # Configure
+        listener.start_keyword("Set LLM Model", {"args": ["llama3"]})
+        listener.end_keyword("Set LLM Model", {})
+
+        # Ask a question
+        listener.start_keyword("Ask LLM", {"args": ["What is 2+2?"]})
+        listener.log_message({"message": "llama3 >> 4", "level": "INFO"})
+        listener.end_keyword("Ask LLM", {})
+
+        # Grade the answer
+        listener.start_keyword("Grade Answer", {"args": ["What is 2+2?", "4", "4"]})
+        listener.log_message(
+            {"message": 'llama3 >> {"score": 1, "reason": "correct"}', "level": "INFO"}
+        )
+        listener.end_keyword("Grade Answer", {})
+
+        assert len(listener._entries) == 5
+        event_types = [e["event_type"] for e in listener._entries]
+        assert event_types == ["config", "input", "output", "grading", "output"]
+
+        # Verify model label is updated after Set LLM Model
+        for entry in listener._entries[1:]:
+            assert entry["model"] == "llama3"
+
+        # Verify push payload
+        payload = listener._build_push_payload()
+        assert len(payload["streams"]) > 0
+        all_labels = {s["stream"]["event_type"] for s in payload["streams"]}
+        assert all_labels == {"config", "input", "output", "grading"}
+
+    def test_multiline_message_preserved_in_entry(self):
+        listener = LokiListener()
+        listener.start_keyword("Ask LLM", {"args": ["line1\nline2\nline3"]})
+        entry = listener._entries[0]
+        assert entry["message"] == "line1\nline2\nline3"


### PR DESCRIPTION
## Summary

Adds a Robot Framework listener that captures and pushes structured logs of all Ollama/LLM interactions to Grafana Loki for centralized log aggregation and analysis.

## Key Changes

- **LokiListener** (`src/rfc/loki_listener.py`): New Robot Framework listener that:
  - Hooks into keyword start/end events to capture tracked LLM keywords (Ask LLM, Grade Answer, Set LLM Model, etc.)
  - Captures LLM responses from log messages via pattern matching (`"{model} >> {response}"`)
  - Batches entries with structured metadata (timestamp, event_type, message, model)
  - Pushes entries to Loki's `/loki/api/v1/push` endpoint when the top-level suite completes
  - Groups entries by event_type into separate label streams for better queryability
  - Gracefully handles connection errors, timeouts, and HTTP errors without interrupting test execution
  - Configurable via constructor argument or `LOKI_URL` environment variable (defaults to `http://localhost:3100`)

- **Comprehensive test suite** (`tests/test_loki_listener.py`): 422 lines of tests covering:
  - Initialization and configuration
  - Keyword tracking and entry creation for all tracked keywords
  - LLM response capture via log_message
  - Entry format and Loki push API payload structure
  - Suite depth tracking and flush behavior
  - HTTP push with error handling
  - End-to-end flow scenarios

- **Docker Compose integration**:
  - Added Loki service (v3.4.2) with filesystem storage
  - Added Promtail service (v3.4.2) for log shipping
  - Configured Grafana datasource provisioning for Loki
  - Updated Grafana to depend on Loki health check

- **Configuration files**:
  - `loki/loki-config.yaml`: Single-tenant local Loki configuration with 168h retention
  - `loki/promtail-config.yaml`: Docker container log scraping and shipping to Loki
  - `grafana/provisioning/datasources/loki.yaml`: Auto-provisioned Loki datasource in Grafana

- **Environment configuration**: Added `LOKI_URL` to `.env.example` with documentation

## Implementation Details

- Entries are stored with nanosecond-precision timestamps (as strings) per Loki API requirements
- Event types include: `input` (Ask LLM), `output` (LLM responses), `config` (model/endpoint/parameters), `grading` (Grade Answer), `system` (Wait For LLM, Get Running Models, LLM Is Busy)
- HTTP push uses a 5-second timeout to avoid blocking test execution
- Entries are cleared after each flush to prevent duplicate pushes
- Suite depth tracking ensures only the top-level suite triggers a flush
- All network errors are caught and logged as warnings without raising exceptions

https://claude.ai/code/session_0152BzXCLuRHyL6sdLvrskaF