### PR TITLE
Add UID to Loki datasource configuration

### DIFF
--- a/grafana/provisioning/datasources/loki.yaml
+++ b/grafana/provisioning/datasources/loki.yaml
@@ -4,6 +4,7 @@ apiVersion: 1
 
 datasources:
   - name: Loki
+    uid: rfc-loki
     type: loki
     access: proxy
     url: http://loki:3100


### PR DESCRIPTION
## Summary
Added a unique identifier (UID) to the Loki datasource in the Grafana provisioning configuration.

## Changes
- Added `uid: rfc-loki` to the Loki datasource configuration in `grafana/provisioning/datasources/loki.yaml`

## Details
This change assigns a stable, human-readable UID to the Loki datasource, which allows for more reliable references to this datasource across Grafana dashboards and alerts. The UID `rfc-loki` follows a descriptive naming convention and ensures the datasource can be consistently identified even if the display name changes.

https://claude.ai/code/session_01Y9aQ2so6qravN2DQYTxvHx