### PR TITLE
Prioritize Robot --variable DEFAULT_MODEL over env vars

### DIFF
--- a/src/rfc/db_listener.py
+++ b/src/rfc/db_listener.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
 from robot.api import logger  # type: ignore
+from robot.libraries.BuiltIn import BuiltIn  # type: ignore
 
 from . import __version__
 from .git_metadata import collect_ci_metadata
@@ -260,8 +261,18 @@ class DbListener:
         if total == 0:
             total = len(self._test_cases)
 
+        # Prefer the Robot variable (set via --variable DEFAULT_MODEL:<model>)
+        # over env-var / CI metadata so that run_local_models correctly
+        # records the actual model under test.
+        robot_model: Optional[str] = None
+        try:
+            robot_model = BuiltIn().get_variable_value("${DEFAULT_MODEL}")
+        except Exception:
+            pass  # Not running inside Robot context (e.g. unit tests)
+
         model_name: str = (
-            self._ci_info.get("Default_Model")
+            robot_model
+            or self._ci_info.get("Default_Model")
             or os.getenv("DEFAULT_MODEL")
             or "unknown"
         )

--- a/tests/test_db_listener.py
+++ b/tests/test_db_listener.py
@@ -233,6 +233,48 @@ class TestDbListenerEndSuiteArchival:
         assert runs[0]["model_name"] == "mistral"
 
     @patch("rfc.db_listener.collect_ci_metadata", return_value={})
+    def test_model_name_from_robot_variable_overrides_env(self, _mock_ci, tmp_path):
+        """Robot --variable DEFAULT_MODEL:llama3 should override the env var."""
+        db_path = str(tmp_path / "test.db")
+        listener = DbListener(database_url=f"sqlite:///{db_path}")
+
+        with patch.dict(os.environ, {"DEFAULT_MODEL": "gpt-oss:20b"}):
+            listener.start_suite("Suite", {})
+            listener.end_test("T1", _test_attrs())
+            # Simulate Robot variable override (as set by --variable flag)
+            with patch(
+                "rfc.db_listener.BuiltIn"
+            ) as mock_builtin_cls:
+                mock_builtin_cls.return_value.get_variable_value.return_value = "llama3"
+                listener.end_suite("Suite", _suite_attrs())
+
+        runs = listener._get_db().get_recent_runs(limit=1)
+        assert runs[0]["model_name"] == "llama3"
+
+    @patch("rfc.db_listener.collect_ci_metadata", return_value={})
+    def test_model_name_falls_back_when_robot_variable_unavailable(
+        self, _mock_ci, tmp_path
+    ):
+        """When BuiltIn is not available (e.g. unit tests), fall back to env/ci_info."""
+        db_path = str(tmp_path / "test.db")
+        listener = DbListener(database_url=f"sqlite:///{db_path}")
+
+        with patch.dict(os.environ, {"DEFAULT_MODEL": "mistral"}):
+            listener.start_suite("Suite", {})
+            listener.end_test("T1", _test_attrs())
+            # Simulate BuiltIn not available (outside Robot context)
+            with patch(
+                "rfc.db_listener.BuiltIn"
+            ) as mock_builtin_cls:
+                mock_builtin_cls.return_value.get_variable_value.side_effect = (
+                    RuntimeError("Not in RF context")
+                )
+                listener.end_suite("Suite", _suite_attrs())
+
+        runs = listener._get_db().get_recent_runs(limit=1)
+        assert runs[0]["model_name"] == "mistral"
+
+    @patch("rfc.db_listener.collect_ci_metadata", return_value={})
     def test_database_error_does_not_raise(self, _mock_ci):
         listener = DbListener()
         mock_db = MagicMock()


### PR DESCRIPTION
## Summary
Updated the model name resolution logic in `DbListener` to prioritize Robot framework variables (set via `--variable DEFAULT_MODEL:<model>`) over environment variables and CI metadata. This ensures that when running tests with Robot's variable override flag, the correct model name is recorded in the database.

## Changes
- **Model name resolution priority**: Changed the precedence order to check Robot variables first, then fall back to CI metadata, then environment variables, and finally default to "unknown"
- **Robot BuiltIn integration**: Added import and usage of `robot.libraries.BuiltIn` to retrieve the `DEFAULT_MODEL` variable at suite end time
- **Graceful fallback**: Wrapped the BuiltIn call in a try-except block to handle cases where Robot context is unavailable (e.g., unit tests), allowing the code to fall back to environment variables
- **Test coverage**: Added two new test cases:
  - `test_model_name_from_robot_variable_overrides_env`: Verifies that Robot variables override environment variables
  - `test_model_name_falls_back_when_robot_variable_unavailable`: Verifies graceful fallback when BuiltIn is not available

## Implementation Details
The change ensures that `run_local_models` correctly records the actual model under test when users specify a model via Robot's `--variable` flag, which takes precedence over environment-based configuration.

https://claude.ai/code/session_01LwEiqCRmhRi2eEDCM5ahjK