### PR TITLE
Add local git metadata collection for non-CI environments

### DIFF
--- a/src/rfc/git_metadata.py
+++ b/src/rfc/git_metadata.py
@@ -7,6 +7,7 @@ the pre-run modifier.
 """
 
 import os
+import subprocess
 from datetime import datetime
 from typing import Dict, Optional
 
@@ -101,6 +102,45 @@ def _collect_github_metadata() -> Dict[str, str]:
     }
 
 
+def _git_command(*args: str) -> str:
+    """Run a git command and return its stripped stdout.
+
+    Returns an empty string if git is not installed, the working
+    directory is not a git repository, or any other error occurs.
+    """
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+    return ""
+
+
+def _collect_local_metadata() -> Dict[str, str]:
+    """Collect metadata from local git repository.
+
+    Uses ``git rev-parse`` to determine the current branch and commit SHA.
+    Falls back gracefully when git is not installed or when running
+    outside a git repository.
+    """
+    branch = _git_command("rev-parse", "--abbrev-ref", "HEAD")
+    sha = _git_command("rev-parse", "HEAD")
+
+    return {
+        "CI": "false",
+        "CI_Platform": "local",
+        "Branch": branch,
+        "Commit_SHA": sha,
+        "Commit_Short_SHA": sha[:8] if sha else "",
+    }
+
+
 def collect_ci_metadata() -> Dict[str, str]:
     """Collect metadata from the current CI environment.
 
@@ -119,7 +159,7 @@ def collect_ci_metadata() -> Dict[str, str]:
     elif platform == "gitlab":
         metadata = _collect_gitlab_metadata()
     else:
-        metadata = {"CI": "false"}
+        metadata = _collect_local_metadata()
 
     # Common fields (always present regardless of platform)
     metadata["Ollama_Endpoint"] = os.getenv("OLLAMA_ENDPOINT", "http://localhost:11434")

--- a/tests/test_git_metadata.py
+++ b/tests/test_git_metadata.py
@@ -1,9 +1,14 @@
 """Tests for rfc.git_metadata."""
 
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from rfc.git_metadata import collect_ci_metadata, detect_ci_platform
+from rfc.git_metadata import (
+    _collect_local_metadata,
+    _git_command,
+    collect_ci_metadata,
+    detect_ci_platform,
+)
 
 
 class TestDetectCiPlatform:
@@ -97,8 +102,110 @@ class TestCollectGitMetadata:
         assert result["Pipeline_URL"] == "https://gitlab.com/pipeline/1"
         assert result["Runner_ID"] == "42"
 
-    def test_no_ci_platform(self):
+    @patch("rfc.git_metadata.subprocess.run")
+    def test_no_ci_platform_uses_local_metadata(self, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="main\n"),
+            MagicMock(returncode=0, stdout="abc123def456\n"),
+        ]
         with patch.dict(os.environ, {}, clear=True):
             result = collect_ci_metadata()
         assert result.get("CI") == "false"
-        assert "CI_Platform" not in result
+        assert result.get("CI_Platform") == "local"
+        assert result.get("Branch") == "main"
+        assert result.get("Commit_SHA") == "abc123def456"
+
+
+class TestCollectLocalMetadata:
+    @patch("rfc.git_metadata.subprocess.run")
+    def test_has_branch(self, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="feature-branch\n"),
+            MagicMock(returncode=0, stdout="abc123def456\n"),
+        ]
+        result = _collect_local_metadata()
+        assert result["Branch"] == "feature-branch"
+
+    @patch("rfc.git_metadata.subprocess.run")
+    def test_has_commit_sha(self, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="main\n"),
+            MagicMock(returncode=0, stdout="abc123def456789000\n"),
+        ]
+        result = _collect_local_metadata()
+        assert result["Commit_SHA"] == "abc123def456789000"
+        assert result["Commit_Short_SHA"] == "abc123de"
+
+    @patch("rfc.git_metadata.subprocess.run")
+    def test_ci_platform_is_local(self, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="main\n"),
+            MagicMock(returncode=0, stdout="abc123\n"),
+        ]
+        result = _collect_local_metadata()
+        assert result["CI"] == "false"
+        assert result["CI_Platform"] == "local"
+
+    @patch("rfc.git_metadata.subprocess.run")
+    def test_git_not_installed(self, mock_run):
+        mock_run.side_effect = FileNotFoundError("git not found")
+        result = _collect_local_metadata()
+        assert result["CI"] == "false"
+        assert result["CI_Platform"] == "local"
+        assert result["Branch"] == ""
+        assert result["Commit_SHA"] == ""
+
+    @patch("rfc.git_metadata.subprocess.run")
+    def test_not_a_git_repo(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=128, stdout="")
+        result = _collect_local_metadata()
+        assert result["Branch"] == ""
+        assert result["Commit_SHA"] == ""
+
+    @patch("rfc.git_metadata.subprocess.run")
+    def test_strips_whitespace(self, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="  main  \n"),
+            MagicMock(returncode=0, stdout="  abc123  \n"),
+        ]
+        result = _collect_local_metadata()
+        assert result["Branch"] == "main"
+        assert result["Commit_SHA"] == "abc123"
+
+    @patch("rfc.git_metadata.subprocess.run")
+    def test_detached_head(self, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="HEAD\n"),
+            MagicMock(returncode=0, stdout="abc123def456\n"),
+        ]
+        result = _collect_local_metadata()
+        assert result["Branch"] == "HEAD"
+
+
+class TestGitCommand:
+    @patch("rfc.git_metadata.subprocess.run")
+    def test_returns_stdout_on_success(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="main\n")
+        assert _git_command("rev-parse", "--abbrev-ref", "HEAD") == "main"
+
+    @patch("rfc.git_metadata.subprocess.run")
+    def test_returns_empty_on_nonzero_exit(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=128, stdout="")
+        assert _git_command("rev-parse", "HEAD") == ""
+
+    @patch("rfc.git_metadata.subprocess.run")
+    def test_returns_empty_on_file_not_found(self, mock_run):
+        mock_run.side_effect = FileNotFoundError
+        assert _git_command("rev-parse", "HEAD") == ""
+
+    @patch("rfc.git_metadata.subprocess.run")
+    def test_returns_empty_on_timeout(self, mock_run):
+        import subprocess
+
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="git", timeout=5)
+        assert _git_command("rev-parse", "HEAD") == ""
+
+    @patch("rfc.git_metadata.subprocess.run")
+    def test_returns_empty_on_os_error(self, mock_run):
+        mock_run.side_effect = OSError("permission denied")
+        assert _git_command("rev-parse", "HEAD") == ""


### PR DESCRIPTION
## Summary
This PR adds support for collecting git metadata (branch and commit SHA) from local git repositories when running outside of CI/CD environments. Previously, when no CI platform was detected, minimal metadata was returned. Now the system gracefully falls back to extracting git information directly from the local repository.

## Key Changes
- **New `_git_command()` helper function**: Executes git commands with proper error handling, returning stripped output or empty string on failure. Handles cases where git is not installed, the directory is not a git repository, or commands timeout.
- **New `_collect_local_metadata()` function**: Collects branch name and commit SHA from the local git repository using `git rev-parse`. Returns consistent metadata structure with `CI: "false"` and `CI_Platform: "local"`. Also computes short SHA (first 8 characters).
- **Updated `collect_ci_metadata()`**: Changed fallback behavior to call `_collect_local_metadata()` instead of returning minimal metadata when no CI platform is detected.
- **Comprehensive test coverage**: Added 13 new tests covering success cases, error handling (git not installed, not a git repo, timeouts), whitespace stripping, and detached HEAD states.

## Implementation Details
- Git commands are executed with a 5-second timeout to prevent hanging
- Errors are caught gracefully: `FileNotFoundError` (git not installed), `subprocess.TimeoutExpired`, and `OSError`
- Short SHA is computed as the first 8 characters of the full SHA, or empty string if SHA is unavailable
- All git command output is stripped of whitespace before being returned

https://claude.ai/code/session_01FfqkL2LQmhA95b4LKkhdp7