### PR TITLE
Add Ollama performance metrics capture and dashboard

### DIFF
--- a/src/rfc/db_listener.py
+++ b/src/rfc/db_listener.py
@@ -19,6 +19,7 @@ The listener reads DATABASE_URL from the environment if no explicit
 URL is provided.
 """
 
+import json
 import os
 from datetime import datetime
 from typing import Any, Dict, List, Optional
@@ -29,7 +30,13 @@ from robot.libraries.BuiltIn import BuiltIn  # type: ignore
 
 from . import __version__
 from .git_metadata import collect_ci_metadata
-from .test_database import KeywordResult, TestDatabase, TestResult, TestRun
+from .test_database import (
+    KeywordResult,
+    OllamaMetrics,
+    TestDatabase,
+    TestResult,
+    TestRun,
+)
 
 # Prefix used by keywords to emit structured data for the listener.
 RFC_DATA_PREFIX = "RFC_DATA:"
@@ -108,6 +115,8 @@ class DbListener:
         self._keyword_results: List[Dict[str, Any]] = []
         self._current_keyword: Optional[Dict[str, Any]] = None
         self._current_test_name: Optional[str] = None
+        # Ollama performance metrics accumulated per suite.
+        self._ollama_metrics: List[Dict[str, Any]] = []
 
     def _get_db(self) -> TestDatabase:
         if self._db is None:
@@ -144,6 +153,7 @@ class DbListener:
             self._ci_info = collect_ci_metadata()
             self._test_cases = []
             self._keyword_results = []
+            self._ollama_metrics = []
             dest = self._describe_database_destination()
             banner = f"DbListener: archiving results to {dest}"
             logger.info(banner)
@@ -205,7 +215,14 @@ class DbListener:
             return
         payload = text[len(RFC_DATA_PREFIX) :]
         key, _, value = payload.partition(":")
-        if key:
+        if key == "ollama_metrics":
+            try:
+                metrics = json.loads(value)
+                metrics["test_name"] = self._current_test_name or ""
+                self._ollama_metrics.append(metrics)
+            except (json.JSONDecodeError, TypeError):
+                pass  # Skip malformed metrics JSON
+        elif key:
             self._current_test_data[key] = value
 
     def end_test(self, name: str, attributes: Dict[str, Any]) -> None:
@@ -331,10 +348,33 @@ class DbListener:
             ]
             db.add_keyword_results(kw_results)
 
+            om_results = [
+                OllamaMetrics(
+                    run_id=run_id,
+                    test_name=om.get("test_name", ""),
+                    model_name=om.get("model_name", "unknown"),
+                    prompt_text=om.get("prompt_text", "")[:500]
+                    if om.get("prompt_text")
+                    else None,
+                    total_duration_ns=om.get("total_duration_ns"),
+                    load_duration_ns=om.get("load_duration_ns"),
+                    prompt_eval_count=om.get("prompt_eval_count"),
+                    prompt_eval_duration_ns=om.get("prompt_eval_duration_ns"),
+                    prompt_eval_rate=om.get("prompt_eval_rate"),
+                    eval_count=om.get("eval_count"),
+                    eval_duration_ns=om.get("eval_duration_ns"),
+                    eval_rate=om.get("eval_rate"),
+                    rfc_version=__version__,
+                )
+                for om in self._ollama_metrics
+            ]
+            db.add_ollama_metrics(om_results)
+
             dest = self._describe_database_destination()
             summary = (
-                f"DbListener: archived {len(results)} test result(s) "
-                f"and {len(kw_results)} keyword result(s) "
+                f"DbListener: archived {len(results)} test result(s), "
+                f"{len(kw_results)} keyword result(s), "
+                f"and {len(om_results)} ollama metric(s) "
                 f"to {dest} (run_id={run_id})"
             )
             logger.info(summary)

--- a/src/rfc/keywords.py
+++ b/src/rfc/keywords.py
@@ -1,3 +1,4 @@
+import json
 from typing import List, Dict, Any
 
 from robot.api import logger
@@ -36,6 +37,10 @@ class LLMKeywords:
         response = self.client.generate(prompt)
         logger.info(response)
         logger.debug(f"RFC_DATA:actual_answer:{response}")
+        if self.client.last_metrics is not None:
+            logger.debug(
+                f"RFC_DATA:ollama_metrics:{json.dumps(self.client.last_metrics)}"
+            )
         return response
 
     @keyword("Grade Answer")

--- a/src/rfc/ollama.py
+++ b/src/rfc/ollama.py
@@ -2,10 +2,37 @@
 
 import os
 import time
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from robot.api import logger
 import requests
+
+
+def _compute_rate(count: Optional[int], duration_ns: Optional[int]) -> Optional[float]:
+    """Compute tokens/s from token count and nanosecond duration."""
+    if count is None or duration_ns is None or duration_ns <= 0:
+        return None
+    return round(count / (duration_ns / 1e9), 2)
+
+
+def _extract_metrics(data: Dict[str, Any], model: str) -> Dict[str, Any]:
+    """Extract performance metrics from an Ollama generate response."""
+    prompt_eval_count = data.get("prompt_eval_count")
+    prompt_eval_duration = data.get("prompt_eval_duration")
+    eval_count = data.get("eval_count")
+    eval_duration = data.get("eval_duration")
+
+    return {
+        "model_name": model,
+        "total_duration_ns": data.get("total_duration"),
+        "load_duration_ns": data.get("load_duration"),
+        "prompt_eval_count": prompt_eval_count,
+        "prompt_eval_duration_ns": prompt_eval_duration,
+        "prompt_eval_rate": _compute_rate(prompt_eval_count, prompt_eval_duration),
+        "eval_count": eval_count,
+        "eval_duration_ns": eval_duration,
+        "eval_rate": _compute_rate(eval_count, eval_duration),
+    }
 
 
 class OllamaClient:
@@ -42,6 +69,7 @@ class OllamaClient:
         self.max_tokens = max_tokens
         self.timeout = timeout
         self.max_retries = max_retries
+        self.last_metrics: Optional[Dict[str, Any]] = None
 
     @property
     def endpoint(self) -> str:
@@ -83,6 +111,7 @@ class OllamaClient:
             },
         }
 
+        self.last_metrics = None
         last_exception: Exception | None = None
         for attempt in range(1 + self.max_retries):
             try:
@@ -92,7 +121,9 @@ class OllamaClient:
                     timeout=self.timeout,
                 )
                 response.raise_for_status()
-                text = response.json()["response"].strip()
+                data = response.json()
+                text = data["response"].strip()
+                self.last_metrics = _extract_metrics(data, self.model)
                 logger.info(f"{self.model} >> {text}")
                 return text
             except (

--- a/src/rfc/test_database.py
+++ b/src/rfc/test_database.py
@@ -134,6 +134,27 @@ class KeywordResult:
 
 
 @dataclass
+class OllamaMetrics:
+    """Represents Ollama performance metrics from a single generate() call."""
+
+    run_id: int
+    test_name: str
+    model_name: str
+    prompt_text: Optional[str]
+    total_duration_ns: Optional[int]
+    load_duration_ns: Optional[int]
+    prompt_eval_count: Optional[int]
+    prompt_eval_duration_ns: Optional[int]
+    prompt_eval_rate: Optional[float]
+    eval_count: Optional[int]
+    eval_duration_ns: Optional[int]
+    eval_rate: Optional[float]
+    rfc_version: Optional[str] = None
+    timestamp: Optional[datetime] = None
+    id: Optional[int] = None
+
+
+@dataclass
 class ModelInfo:
     """Represents model metadata."""
 
@@ -188,6 +209,12 @@ class _Backend(abc.ABC):
 
     @abc.abstractmethod
     def get_dry_run_results(self, limit: int = 50) -> List[Dict[str, Any]]: ...
+
+    @abc.abstractmethod
+    def add_ollama_metrics(self, results: List[OllamaMetrics]) -> None: ...
+
+    @abc.abstractmethod
+    def get_ollama_metrics(self, limit: int = 50) -> List[Dict[str, Any]]: ...
 
 
 class _SQLiteBackend(_Backend):
@@ -283,6 +310,25 @@ class _SQLiteBackend(_Backend):
         FOREIGN KEY (run_id) REFERENCES test_runs(id) ON DELETE CASCADE
     );
 
+    CREATE TABLE IF NOT EXISTS ollama_metrics (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        run_id INTEGER NOT NULL,
+        test_name TEXT NOT NULL,
+        model_name TEXT NOT NULL,
+        prompt_text TEXT,
+        total_duration_ns INTEGER,
+        load_duration_ns INTEGER,
+        prompt_eval_count INTEGER,
+        prompt_eval_duration_ns INTEGER,
+        prompt_eval_rate REAL,
+        eval_count INTEGER,
+        eval_duration_ns INTEGER,
+        eval_rate REAL,
+        rfc_version TEXT,
+        timestamp DATETIME,
+        FOREIGN KEY (run_id) REFERENCES test_runs(id) ON DELETE CASCADE
+    );
+
     CREATE INDEX IF NOT EXISTS idx_test_runs_model ON test_runs(model_name);
     CREATE INDEX IF NOT EXISTS idx_test_runs_timestamp ON test_runs(timestamp);
     CREATE INDEX IF NOT EXISTS idx_test_runs_suite ON test_runs(test_suite);
@@ -294,6 +340,8 @@ class _SQLiteBackend(_Backend):
     CREATE INDEX IF NOT EXISTS idx_pipeline_results_status ON pipeline_results(status);
     CREATE INDEX IF NOT EXISTS idx_dry_run_results_timestamp ON robot_dry_run_results(timestamp);
     CREATE INDEX IF NOT EXISTS idx_dry_run_results_suite ON robot_dry_run_results(test_suite);
+    CREATE INDEX IF NOT EXISTS idx_ollama_metrics_run_id ON ollama_metrics(run_id);
+    CREATE INDEX IF NOT EXISTS idx_ollama_metrics_model ON ollama_metrics(model_name);
     """
 
     # Idempotent migrations for renaming gitlab_* columns.
@@ -605,6 +653,50 @@ class _SQLiteBackend(_Backend):
             )
             return [dict(row) for row in cursor.fetchall()]
 
+    def add_ollama_metrics(self, results: List[OllamaMetrics]) -> None:
+        if not results:
+            return
+        with sqlite3.connect(self.db_path) as conn:
+            conn.executemany(
+                """
+                INSERT INTO ollama_metrics
+                (run_id, test_name, model_name, prompt_text,
+                 total_duration_ns, load_duration_ns,
+                 prompt_eval_count, prompt_eval_duration_ns, prompt_eval_rate,
+                 eval_count, eval_duration_ns, eval_rate,
+                 rfc_version, timestamp)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        r.run_id,
+                        r.test_name,
+                        r.model_name,
+                        r.prompt_text,
+                        r.total_duration_ns,
+                        r.load_duration_ns,
+                        r.prompt_eval_count,
+                        r.prompt_eval_duration_ns,
+                        r.prompt_eval_rate,
+                        r.eval_count,
+                        r.eval_duration_ns,
+                        r.eval_rate,
+                        r.rfc_version,
+                        r.timestamp.isoformat() if r.timestamp else None,
+                    )
+                    for r in results
+                ],
+            )
+
+    def get_ollama_metrics(self, limit: int = 50) -> List[Dict[str, Any]]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(
+                "SELECT * FROM ollama_metrics ORDER BY id DESC LIMIT ?",
+                (limit,),
+            )
+            return [dict(row) for row in cursor.fetchall()]
+
 
 class _SQLAlchemyBackend(_Backend):
     """PostgreSQL/SQLAlchemy backend for Superset integration."""
@@ -748,6 +840,31 @@ class _SQLAlchemyBackend(_Backend):
             Column("args", Text),
         )
 
+        self.ollama_metrics = Table(
+            "ollama_metrics",
+            self.metadata,
+            Column("id", Integer, primary_key=True, autoincrement=True),
+            Column(
+                "run_id",
+                Integer,
+                ForeignKey("test_runs.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            Column("test_name", String(255), nullable=False),
+            Column("model_name", String(255), nullable=False),
+            Column("prompt_text", Text),
+            Column("total_duration_ns", BigInteger),
+            Column("load_duration_ns", BigInteger),
+            Column("prompt_eval_count", Integer),
+            Column("prompt_eval_duration_ns", BigInteger),
+            Column("prompt_eval_rate", Float),
+            Column("eval_count", Integer),
+            Column("eval_duration_ns", BigInteger),
+            Column("eval_rate", Float),
+            Column("rfc_version", String(50)),
+            Column("timestamp", DateTime),
+        )
+
         Index("idx_pipeline_results_pipeline_id", self.pipeline_results.c.pipeline_id)
         Index("idx_pipeline_results_ref", self.pipeline_results.c.ref)
         Index("idx_pipeline_results_status", self.pipeline_results.c.status)
@@ -755,6 +872,8 @@ class _SQLAlchemyBackend(_Backend):
         Index("idx_dry_run_results_suite", self.dry_run_results.c.test_suite)
         Index("idx_keyword_results_run_id", self.keyword_results.c.run_id)
         Index("idx_keyword_results_name", self.keyword_results.c.keyword_name)
+        Index("idx_ollama_metrics_run_id", self.ollama_metrics.c.run_id)
+        Index("idx_ollama_metrics_model", self.ollama_metrics.c.model_name)
 
     def add_test_run(self, run: TestRun) -> int:
         with self.engine.begin() as conn:
@@ -1039,6 +1158,41 @@ class _SQLAlchemyBackend(_Backend):
             )
             return [dict(row._mapping) for row in result.fetchall()]
 
+    def add_ollama_metrics(self, results: List[OllamaMetrics]) -> None:
+        if not results:
+            return
+        with self.engine.begin() as conn:
+            conn.execute(
+                self.ollama_metrics.insert(),
+                [
+                    {
+                        "run_id": r.run_id,
+                        "test_name": r.test_name,
+                        "model_name": r.model_name,
+                        "prompt_text": r.prompt_text,
+                        "total_duration_ns": r.total_duration_ns,
+                        "load_duration_ns": r.load_duration_ns,
+                        "prompt_eval_count": r.prompt_eval_count,
+                        "prompt_eval_duration_ns": r.prompt_eval_duration_ns,
+                        "prompt_eval_rate": r.prompt_eval_rate,
+                        "eval_count": r.eval_count,
+                        "eval_duration_ns": r.eval_duration_ns,
+                        "eval_rate": r.eval_rate,
+                        "rfc_version": r.rfc_version,
+                        "timestamp": r.timestamp,
+                    }
+                    for r in results
+                ],
+            )
+
+    def get_ollama_metrics(self, limit: int = 50) -> List[Dict[str, Any]]:
+        with self.engine.connect() as conn:
+            result = conn.execute(
+                text("SELECT * FROM ollama_metrics ORDER BY id DESC LIMIT :lim"),
+                {"lim": limit},
+            )
+            return [dict(row._mapping) for row in result.fetchall()]
+
 
 class TestDatabase:
     """Manager for test results database.
@@ -1146,6 +1300,12 @@ class TestDatabase:
 
     def get_dry_run_results(self, limit: int = 50) -> List[Dict[str, Any]]:
         return self._backend.get_dry_run_results(limit)
+
+    def add_ollama_metrics(self, results: List[OllamaMetrics]) -> None:
+        self._backend.add_ollama_metrics(results)
+
+    def get_ollama_metrics(self, limit: int = 50) -> List[Dict[str, Any]]:
+        return self._backend.get_ollama_metrics(limit)
 
 
 def main():

--- a/superset/bootstrap_dashboards.py
+++ b/superset/bootstrap_dashboards.py
@@ -122,10 +122,32 @@ CREATE INDEX IF NOT EXISTS idx_pipeline_results_pipeline_id
 CREATE INDEX IF NOT EXISTS idx_pipeline_results_ref ON pipeline_results(ref);
 CREATE INDEX IF NOT EXISTS idx_pipeline_results_status
     ON pipeline_results(status);
+CREATE TABLE IF NOT EXISTS ollama_metrics (
+    id SERIAL PRIMARY KEY,
+    run_id INTEGER NOT NULL REFERENCES test_runs(id) ON DELETE CASCADE,
+    test_name VARCHAR(255) NOT NULL,
+    model_name VARCHAR(255) NOT NULL,
+    prompt_text TEXT,
+    total_duration_ns BIGINT,
+    load_duration_ns BIGINT,
+    prompt_eval_count INTEGER,
+    prompt_eval_duration_ns BIGINT,
+    prompt_eval_rate DOUBLE PRECISION,
+    eval_count INTEGER,
+    eval_duration_ns BIGINT,
+    eval_rate DOUBLE PRECISION,
+    rfc_version VARCHAR(50),
+    timestamp TIMESTAMP
+);
+
 CREATE INDEX IF NOT EXISTS idx_dry_run_results_timestamp
     ON robot_dry_run_results(timestamp);
 CREATE INDEX IF NOT EXISTS idx_dry_run_results_suite
     ON robot_dry_run_results(test_suite);
+CREATE INDEX IF NOT EXISTS idx_ollama_metrics_run_id
+    ON ollama_metrics(run_id);
+CREATE INDEX IF NOT EXISTS idx_ollama_metrics_model
+    ON ollama_metrics(model_name);
 """
 
 # ---------------------------------------------------------------------------
@@ -149,7 +171,8 @@ _VIRTUAL_DATASETS: Dict[str, str] = {
             runs.test_suite,
             runs.git_branch,
             runs.git_commit,
-            runs.duration_seconds AS run_duration
+            runs.duration_seconds AS run_duration,
+            runs.rfc_version
         FROM test_results tr
         JOIN test_runs runs ON tr.run_id = runs.id
     """,
@@ -182,9 +205,36 @@ _VIRTUAL_DATASETS: Dict[str, str] = {
             runs.timestamp,
             runs.model_name,
             runs.test_suite,
-            runs.git_branch
+            runs.git_branch,
+            runs.rfc_version
         FROM keyword_results kw
         JOIN test_runs runs ON kw.run_id = runs.id
+    """,
+    "ollama_performance": """
+        SELECT
+            om.id AS metrics_id,
+            om.test_name,
+            om.model_name,
+            om.prompt_text,
+            om.total_duration_ns,
+            om.load_duration_ns,
+            om.prompt_eval_count,
+            om.prompt_eval_duration_ns,
+            om.prompt_eval_rate,
+            om.eval_count,
+            om.eval_duration_ns,
+            om.eval_rate,
+            om.rfc_version,
+            runs.timestamp,
+            runs.test_suite,
+            runs.git_branch,
+            CAST(om.total_duration_ns AS DOUBLE PRECISION) / 1e9 AS total_duration_s,
+            CAST(om.load_duration_ns AS DOUBLE PRECISION) / 1e9 AS load_duration_s,
+            CAST(om.prompt_eval_duration_ns AS DOUBLE PRECISION) / 1e9
+                AS prompt_eval_duration_s,
+            CAST(om.eval_duration_ns AS DOUBLE PRECISION) / 1e9 AS eval_duration_s
+        FROM ollama_metrics om
+        JOIN test_runs runs ON om.run_id = runs.id
     """,
 }
 
@@ -791,6 +841,134 @@ def _model_analytics_charts(datasets: Dict[str, Any]) -> List[Dict[str, Any]]:
     ]
 
 
+def _ollama_performance_charts(datasets: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Charts for the Ollama Performance dashboard."""
+    return [
+        {
+            "name": "Eval Rate by Model (tokens/s)",
+            "viz_type": "bar",
+            "datasource": datasets["ollama_performance"],
+            "params": {
+                "viz_type": "bar",
+                "metrics": [
+                    {
+                        "label": "avg_eval_rate",
+                        "expressionType": "SQL",
+                        "sqlExpression": "AVG(eval_rate)",
+                    }
+                ],
+                "groupby": ["model_name"],
+                "row_limit": 50,
+                "color_scheme": "supersetColors",
+                "y_axis_label": "Avg Eval Rate (tokens/s)",
+            },
+        },
+        {
+            "name": "Prompt Eval Rate by Model (tokens/s)",
+            "viz_type": "bar",
+            "datasource": datasets["ollama_performance"],
+            "params": {
+                "viz_type": "bar",
+                "metrics": [
+                    {
+                        "label": "avg_prompt_eval_rate",
+                        "expressionType": "SQL",
+                        "sqlExpression": "AVG(prompt_eval_rate)",
+                    }
+                ],
+                "groupby": ["model_name"],
+                "row_limit": 50,
+                "color_scheme": "supersetColors",
+                "y_axis_label": "Avg Prompt Eval Rate (tokens/s)",
+            },
+        },
+        {
+            "name": "Token Throughput Over Time",
+            "viz_type": "line",
+            "datasource": datasets["ollama_performance"],
+            "params": {
+                "viz_type": "line",
+                "granularity_sqla": "timestamp",
+                "time_grain_sqla": "P1D",
+                "metrics": [
+                    {
+                        "label": "avg_eval_rate",
+                        "expressionType": "SQL",
+                        "sqlExpression": "AVG(eval_rate)",
+                    }
+                ],
+                "groupby": ["model_name"],
+                "row_limit": 10000,
+                "color_scheme": "supersetColors",
+                "show_legend": True,
+                "y_axis_label": "Avg Eval Rate (tokens/s)",
+            },
+        },
+        {
+            "name": "Total Duration by Model",
+            "viz_type": "bar",
+            "datasource": datasets["ollama_performance"],
+            "params": {
+                "viz_type": "bar",
+                "metrics": [
+                    {
+                        "label": "avg_total_duration_s",
+                        "expressionType": "SQL",
+                        "sqlExpression": "AVG(total_duration_s)",
+                    }
+                ],
+                "groupby": ["model_name"],
+                "row_limit": 50,
+                "color_scheme": "supersetColors",
+                "y_axis_label": "Avg Total Duration (s)",
+            },
+        },
+        {
+            "name": "Model Load Time",
+            "viz_type": "bar",
+            "datasource": datasets["ollama_performance"],
+            "params": {
+                "viz_type": "bar",
+                "metrics": [
+                    {
+                        "label": "avg_load_duration_s",
+                        "expressionType": "SQL",
+                        "sqlExpression": "AVG(load_duration_s)",
+                    }
+                ],
+                "groupby": ["model_name"],
+                "row_limit": 50,
+                "color_scheme": "supersetColors",
+                "y_axis_label": "Avg Load Duration (s)",
+            },
+        },
+        {
+            "name": "Ollama Metrics Detail",
+            "viz_type": "table",
+            "datasource": datasets["ollama_performance"],
+            "params": {
+                "viz_type": "table",
+                "all_columns": [
+                    "timestamp",
+                    "model_name",
+                    "test_suite",
+                    "test_name",
+                    "total_duration_s",
+                    "load_duration_s",
+                    "prompt_eval_count",
+                    "prompt_eval_rate",
+                    "eval_count",
+                    "eval_rate",
+                    "rfc_version",
+                ],
+                "order_desc": True,
+                "row_limit": 100,
+                "order_by_cols": '["timestamp"]',
+            },
+        },
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -955,6 +1133,7 @@ def bootstrap() -> None:
             "pipeline_results",
             "robot_dry_run_results",
             "keyword_results",
+            "ollama_metrics",
         ):
             ds = (
                 db.session.query(SqlaTable)
@@ -1017,6 +1196,10 @@ def bootstrap() -> None:
             _get_or_create_slice(db, Slice, cdef)
             for cdef in _model_analytics_charts(datasets)
         ]
+        ollama_slices = [
+            _get_or_create_slice(db, Slice, cdef)
+            for cdef in _ollama_performance_charts(datasets)
+        ]
 
         # ── 5. Dashboards ───────────────────────────────────────────
         _get_or_create_dashboard(
@@ -1040,9 +1223,16 @@ def bootstrap() -> None:
             "rfc-models",
             model_slices,
         )
+        _get_or_create_dashboard(
+            db,
+            Dashboard,
+            "Ollama Performance",
+            "rfc-ollama",
+            ollama_slices,
+        )
 
         db.session.commit()
-        log.info("Bootstrap complete — 3 dashboards created")
+        log.info("Bootstrap complete — 4 dashboards created")
 
 
 if __name__ == "__main__":

--- a/tests/test_db_listener.py
+++ b/tests/test_db_listener.py
@@ -1,5 +1,6 @@
 """Tests for rfc.db_listener.DbListener."""
 
+import json
 import os
 from unittest.mock import MagicMock, patch
 
@@ -242,9 +243,7 @@ class TestDbListenerEndSuiteArchival:
             listener.start_suite("Suite", {})
             listener.end_test("T1", _test_attrs())
             # Simulate Robot variable override (as set by --variable flag)
-            with patch(
-                "rfc.db_listener.BuiltIn"
-            ) as mock_builtin_cls:
+            with patch("rfc.db_listener.BuiltIn") as mock_builtin_cls:
                 mock_builtin_cls.return_value.get_variable_value.return_value = "llama3"
                 listener.end_suite("Suite", _suite_attrs())
 
@@ -263,9 +262,7 @@ class TestDbListenerEndSuiteArchival:
             listener.start_suite("Suite", {})
             listener.end_test("T1", _test_attrs())
             # Simulate BuiltIn not available (outside Robot context)
-            with patch(
-                "rfc.db_listener.BuiltIn"
-            ) as mock_builtin_cls:
+            with patch("rfc.db_listener.BuiltIn") as mock_builtin_cls:
                 mock_builtin_cls.return_value.get_variable_value.side_effect = (
                     RuntimeError("Not in RF context")
                 )
@@ -757,3 +754,105 @@ class TestDbListenerConsoleOutput:
         full_output = " ".join(console_calls)
         assert "FAILED" in full_output
         assert "connection refused" in full_output
+
+
+class TestDbListenerOllamaMetrics:
+    """Tests for Ollama performance metrics capture via RFC_DATA:ollama_metrics."""
+
+    def test_initial_ollama_metrics_list_is_empty(self):
+        listener = DbListener()
+        assert listener._ollama_metrics == []
+
+    def test_captures_ollama_metrics_from_log_message(self):
+        listener = DbListener()
+        listener.start_test("T", {})
+        metrics = {
+            "model_name": "llama3",
+            "total_duration_ns": 17607688368,
+            "eval_rate": 11.0,
+        }
+        listener.log_message(
+            {"message": f"RFC_DATA:ollama_metrics:{json.dumps(metrics)}"}
+        )
+        assert len(listener._ollama_metrics) == 1
+        assert listener._ollama_metrics[0]["model_name"] == "llama3"
+        assert listener._ollama_metrics[0]["test_name"] == "T"
+
+    def test_accumulates_metrics_across_calls(self):
+        listener = DbListener()
+        listener.start_test("T", {})
+        for i in range(3):
+            metrics = {"model_name": f"model_{i}", "eval_rate": float(i)}
+            listener.log_message(
+                {"message": f"RFC_DATA:ollama_metrics:{json.dumps(metrics)}"}
+            )
+        assert len(listener._ollama_metrics) == 3
+
+    @patch("rfc.db_listener.collect_ci_metadata", return_value={})
+    def test_resets_metrics_on_start_suite(self, _mock_ci):
+        listener = DbListener()
+        listener._ollama_metrics = [{"stale": "data"}]
+        listener.start_suite("Suite", {})
+        assert listener._ollama_metrics == []
+
+    @patch("rfc.db_listener.collect_ci_metadata", return_value={})
+    def test_metrics_archived_to_database(self, _mock_ci, tmp_path):
+        import sqlite3
+
+        db_path = str(tmp_path / "test.db")
+        listener = DbListener(database_url=f"sqlite:///{db_path}")
+
+        listener.start_suite("Suite", {})
+        listener.start_test("Math Test", {})
+        metrics = {
+            "model_name": "llama3",
+            "total_duration_ns": 17607688368,
+            "load_duration_ns": 108889428,
+            "prompt_eval_count": 73,
+            "prompt_eval_duration_ns": 489998464,
+            "prompt_eval_rate": 148.98,
+            "eval_count": 186,
+            "eval_duration_ns": 16907870673,
+            "eval_rate": 11.0,
+        }
+        listener.log_message(
+            {"message": f"RFC_DATA:ollama_metrics:{json.dumps(metrics)}"}
+        )
+        listener.end_test("Math Test", _test_attrs(status="PASS"))
+        listener.end_suite("Suite", _suite_attrs(totaltests=1))
+
+        with sqlite3.connect(db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute("SELECT * FROM ollama_metrics").fetchall()
+            assert len(rows) == 1
+            row = rows[0]
+            assert row["model_name"] == "llama3"
+            assert row["total_duration_ns"] == 17607688368
+            assert row["eval_rate"] == 11.0
+            assert row["test_name"] == "Math Test"
+
+    @patch("rfc.db_listener.collect_ci_metadata", return_value={})
+    def test_metrics_include_rfc_version(self, _mock_ci, tmp_path):
+        import sqlite3
+
+        db_path = str(tmp_path / "test.db")
+        listener = DbListener(database_url=f"sqlite:///{db_path}")
+
+        listener.start_suite("Suite", {})
+        listener.start_test("T", {})
+        listener.log_message(
+            {"message": 'RFC_DATA:ollama_metrics:{"model_name": "llama3"}'}
+        )
+        listener.end_test("T", _test_attrs())
+        listener.end_suite("Suite", _suite_attrs(totaltests=1))
+
+        with sqlite3.connect(db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute("SELECT * FROM ollama_metrics").fetchone()
+            assert row["rfc_version"] is not None
+
+    def test_ignores_invalid_json_in_ollama_metrics(self):
+        listener = DbListener()
+        listener.start_test("T", {})
+        listener.log_message({"message": "RFC_DATA:ollama_metrics:not-valid-json"})
+        assert len(listener._ollama_metrics) == 0

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -1,5 +1,6 @@
 """Tests for rfc.keywords.LLMKeywords."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 from rfc.keywords import LLMKeywords
@@ -50,9 +51,50 @@ class TestLLMKeywordsAsk:
     def test_ask_llm(self, MockGrader, MockClient):
         kw = LLMKeywords()
         kw.client.generate.return_value = "42"
+        kw.client.last_metrics = None
         result = kw.ask_llm("What is 6 * 7?")
         kw.client.generate.assert_called_once_with("What is 6 * 7?")
         assert result == "42"
+
+    @patch("rfc.keywords.logger")
+    @patch("rfc.keywords.OllamaClient")
+    @patch("rfc.keywords.Grader")
+    def test_ask_llm_emits_ollama_metrics(self, MockGrader, MockClient, mock_logger):
+        kw = LLMKeywords()
+        kw.client.generate.return_value = "42"
+        kw.client.last_metrics = {
+            "model_name": "llama3",
+            "total_duration_ns": 17607688368,
+            "eval_rate": 11.0,
+        }
+
+        kw.ask_llm("What is 6 * 7?")
+
+        # Find the RFC_DATA:ollama_metrics call
+        debug_calls = [str(c) for c in mock_logger.debug.call_args_list]
+        metrics_calls = [c for c in debug_calls if "RFC_DATA:ollama_metrics:" in c]
+        assert len(metrics_calls) == 1
+
+        # Parse and verify the JSON payload
+        raw = mock_logger.debug.call_args_list[-1].args[0]
+        payload = raw.split("RFC_DATA:ollama_metrics:", 1)[1]
+        data = json.loads(payload)
+        assert data["model_name"] == "llama3"
+        assert data["total_duration_ns"] == 17607688368
+
+    @patch("rfc.keywords.logger")
+    @patch("rfc.keywords.OllamaClient")
+    @patch("rfc.keywords.Grader")
+    def test_ask_llm_skips_metrics_when_none(self, MockGrader, MockClient, mock_logger):
+        kw = LLMKeywords()
+        kw.client.generate.return_value = "42"
+        kw.client.last_metrics = None
+
+        kw.ask_llm("test")
+
+        debug_calls = [str(c) for c in mock_logger.debug.call_args_list]
+        metrics_calls = [c for c in debug_calls if "RFC_DATA:ollama_metrics:" in c]
+        assert len(metrics_calls) == 0
 
 
 class TestLLMKeywordsGrade:

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -336,6 +336,126 @@ class TestWaitUntilReady:
             OllamaClient().wait_until_ready(poll_interval=0)
 
 
+class TestGenerateMetrics:
+    """Tests for last_metrics capture from generate() responses."""
+
+    @patch("rfc.ollama.logger")
+    @patch("rfc.ollama.requests.post")
+    def test_stores_last_metrics(self, mock_post, mock_logger):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "response": "hello",
+            "total_duration": 17607688368,
+            "load_duration": 108889428,
+            "prompt_eval_count": 73,
+            "prompt_eval_duration": 489998464,
+            "eval_count": 186,
+            "eval_duration": 16907870673,
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_post.return_value = mock_resp
+
+        client = OllamaClient()
+        client.generate("test prompt")
+
+        assert client.last_metrics is not None
+        assert client.last_metrics["total_duration_ns"] == 17607688368
+        assert client.last_metrics["load_duration_ns"] == 108889428
+        assert client.last_metrics["prompt_eval_count"] == 73
+        assert client.last_metrics["prompt_eval_duration_ns"] == 489998464
+        assert client.last_metrics["eval_count"] == 186
+        assert client.last_metrics["eval_duration_ns"] == 16907870673
+
+    @patch("rfc.ollama.logger")
+    @patch("rfc.ollama.requests.post")
+    def test_computes_eval_rate(self, mock_post, mock_logger):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "response": "hello",
+            "eval_count": 186,
+            "eval_duration": 16907870673,
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_post.return_value = mock_resp
+
+        client = OllamaClient()
+        client.generate("test")
+
+        assert client.last_metrics is not None
+        # 186 / (16907870673 / 1e9) ≈ 11.00
+        assert abs(client.last_metrics["eval_rate"] - 11.00) < 0.1
+
+    @patch("rfc.ollama.logger")
+    @patch("rfc.ollama.requests.post")
+    def test_computes_prompt_eval_rate(self, mock_post, mock_logger):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "response": "hello",
+            "prompt_eval_count": 73,
+            "prompt_eval_duration": 489998464,
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_post.return_value = mock_resp
+
+        client = OllamaClient()
+        client.generate("test")
+
+        assert client.last_metrics is not None
+        # 73 / (489998464 / 1e9) ≈ 148.98
+        assert abs(client.last_metrics["prompt_eval_rate"] - 148.98) < 0.5
+
+    @patch("rfc.ollama.logger")
+    @patch("rfc.ollama.requests.post")
+    def test_missing_metrics_fields_are_none(self, mock_post, mock_logger):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"response": "hello"}
+        mock_resp.raise_for_status = MagicMock()
+        mock_post.return_value = mock_resp
+
+        client = OllamaClient()
+        client.generate("test")
+
+        assert client.last_metrics is not None
+        assert client.last_metrics["total_duration_ns"] is None
+        assert client.last_metrics["eval_rate"] is None
+
+    @patch("rfc.ollama.logger")
+    @patch("rfc.ollama.requests.post")
+    def test_zero_duration_gives_none_rate(self, mock_post, mock_logger):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "response": "hello",
+            "eval_count": 10,
+            "eval_duration": 0,
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_post.return_value = mock_resp
+
+        client = OllamaClient()
+        client.generate("test")
+
+        assert client.last_metrics is not None
+        assert client.last_metrics["eval_rate"] is None
+
+    def test_last_metrics_none_initially(self):
+        client = OllamaClient()
+        assert client.last_metrics is None
+
+    @patch("rfc.ollama.logger")
+    @patch("rfc.ollama.requests.post")
+    def test_last_metrics_includes_model_name(self, mock_post, mock_logger):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"response": "hello"}
+        mock_resp.raise_for_status = MagicMock()
+        mock_post.return_value = mock_resp
+
+        client = OllamaClient(model="llama3")
+        client.generate("test")
+
+        assert client.last_metrics is not None
+        assert client.last_metrics["model_name"] == "llama3"
+
+
 class TestLLMClientAlias:
     def test_alias(self):
         assert LLMClient is OllamaClient

--- a/tests/test_test_database.py
+++ b/tests/test_test_database.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from rfc.test_database import TestDatabase, TestResult, TestRun
+from rfc.test_database import OllamaMetrics, TestDatabase, TestResult, TestRun
 
 
 def _make_run(**overrides):
@@ -159,3 +159,101 @@ class TestTestResultDataclass:
         assert result.run_id == 1
         assert result.test_name == "Test One"
         assert result.score is None
+
+
+def _make_metrics(**overrides):
+    defaults = dict(
+        run_id=1,
+        test_name="Math Test",
+        model_name="llama3",
+        prompt_text="What is 2+2?",
+        total_duration_ns=17607688368,
+        load_duration_ns=108889428,
+        prompt_eval_count=73,
+        prompt_eval_duration_ns=489998464,
+        prompt_eval_rate=148.98,
+        eval_count=186,
+        eval_duration_ns=16907870673,
+        eval_rate=11.00,
+        rfc_version="0.2.0",
+    )
+    defaults.update(overrides)
+    return OllamaMetrics(**defaults)
+
+
+class TestOllamaMetricsDataclass:
+    def test_required_fields(self):
+        m = _make_metrics()
+        assert m.run_id == 1
+        assert m.test_name == "Math Test"
+        assert m.model_name == "llama3"
+        assert m.total_duration_ns == 17607688368
+        assert m.eval_rate == 11.00
+        assert m.rfc_version == "0.2.0"
+
+    def test_optional_fields_default_none(self):
+        m = _make_metrics()
+        assert m.timestamp is None
+        assert m.id is None
+
+    def test_nullable_metrics(self):
+        m = _make_metrics(
+            total_duration_ns=None,
+            load_duration_ns=None,
+            prompt_eval_count=None,
+            prompt_eval_duration_ns=None,
+            prompt_eval_rate=None,
+            eval_count=None,
+            eval_duration_ns=None,
+            eval_rate=None,
+        )
+        assert m.total_duration_ns is None
+        assert m.eval_rate is None
+
+
+class TestOllamaMetricsDatabase:
+    def test_add_ollama_metrics(self, tmp_path):
+        db = TestDatabase(db_path=str(tmp_path / "test.db"))
+        run_id = db.add_test_run(_make_run())
+        metrics = [_make_metrics(run_id=run_id)]
+        db.add_ollama_metrics(metrics)
+
+    def test_add_empty_ollama_metrics(self, tmp_path):
+        db = TestDatabase(db_path=str(tmp_path / "test.db"))
+        db.add_ollama_metrics([])
+
+    def test_get_ollama_metrics(self, tmp_path):
+        db = TestDatabase(db_path=str(tmp_path / "test.db"))
+        run_id = db.add_test_run(_make_run())
+        db.add_ollama_metrics([_make_metrics(run_id=run_id)])
+
+        rows = db.get_ollama_metrics(limit=10)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["model_name"] == "llama3"
+        assert row["total_duration_ns"] == 17607688368
+        assert row["eval_rate"] == 11.00
+        assert row["rfc_version"] == "0.2.0"
+        assert row["prompt_text"] == "What is 2+2?"
+
+    def test_get_ollama_metrics_respects_limit(self, tmp_path):
+        db = TestDatabase(db_path=str(tmp_path / "test.db"))
+        run_id = db.add_test_run(_make_run())
+        for i in range(5):
+            db.add_ollama_metrics([_make_metrics(run_id=run_id, test_name=f"Test {i}")])
+
+        rows = db.get_ollama_metrics(limit=2)
+        assert len(rows) == 2
+
+    def test_multiple_metrics_per_run(self, tmp_path):
+        db = TestDatabase(db_path=str(tmp_path / "test.db"))
+        run_id = db.add_test_run(_make_run())
+        db.add_ollama_metrics(
+            [
+                _make_metrics(run_id=run_id, test_name="Test A", eval_rate=11.0),
+                _make_metrics(run_id=run_id, test_name="Test B", eval_rate=15.5),
+            ]
+        )
+
+        rows = db.get_ollama_metrics(limit=10)
+        assert len(rows) == 2


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for capturing and visualizing Ollama LLM performance metrics. It introduces a new database table for storing metrics, extends the test database layer to persist these metrics, and creates a new Superset dashboard for analyzing Ollama model performance.

## Key Changes

### Database & Data Model
- Added `ollama_metrics` table to store performance metrics from Ollama `generate()` calls, including:
  - Token counts and evaluation rates (tokens/second)
  - Duration measurements (total, load, prompt eval, eval)
  - Model name, test name, and RFC version tracking
- Implemented in both SQLite and SQLAlchemy backends with appropriate indexes
- Created `OllamaMetrics` dataclass for type-safe metric handling

### Ollama Client Enhancement
- Extended `OllamaClient.generate()` to capture and store metrics in `last_metrics` property
- Added `_extract_metrics()` helper to parse Ollama response data
- Added `_compute_rate()` helper to calculate token throughput (tokens/second) from counts and durations
- Handles missing/zero values gracefully (returns `None` for invalid rates)

### Test Listener Integration
- Extended `DbListener` to capture Ollama metrics from `RFC_DATA:ollama_metrics:` log messages
- Accumulates metrics per test suite and persists them to database on suite completion
- Includes RFC version tracking with each metric record
- Gracefully handles malformed JSON in metric messages

### Keywords & Test Support
- Updated `LLMKeywords.ask_llm()` to emit captured metrics as structured log messages
- Metrics are only emitted when available (when `last_metrics` is not `None`)

### Superset Dashboard
- Created new "Ollama Performance" dashboard with 6 visualization charts:
  - Eval Rate by Model (bar chart)
  - Prompt Eval Rate by Model (bar chart)
  - Token Throughput Over Time (line chart)
  - Total Duration by Model (bar chart)
  - Model Load Time (bar chart)
  - Ollama Metrics Detail (table view)
- Added `ollama_performance` dataset with computed duration fields (nanoseconds → seconds)
- Updated bootstrap to create the new dashboard and dataset

### Testing
- Added comprehensive test coverage for metrics capture in `TestGenerateMetrics`
- Added tests for `DbListener` Ollama metrics handling
- Added tests for `OllamaMetrics` dataclass and database operations
- Added tests for keyword-level metrics emission

## Implementation Details
- Metrics are stored with nanosecond precision in the database but converted to seconds for visualization
- Token rates are computed as `count / (duration_ns / 1e9)` and rounded to 2 decimal places
- Prompt text is truncated to 500 characters when stored to manage database size
- All metrics fields are nullable to handle cases where Ollama doesn't return certain values
- Metrics are accumulated per test suite and cleared on each new suite start

https://claude.ai/code/session_019dfxij6P7CBAGVavE4Wa1C