### PR TITLE
Simplify code quality commands in documentation

### DIFF
--- a/ai/AGENTS.md
+++ b/ai/AGENTS.md
@@ -100,9 +100,7 @@ Read `ai/CLAUDE.md` for the full project intelligence and context document.
 2. Implement minimal code (green)
 3. Refactor if needed
 4. Run code quality checks before committing:
-   - `make code-quality-format` — auto-format code with ruff
-   - `make code-quality-check` — run all quality checks (lint + typecheck)
-   - `make code-quality-coverage` — run pytest with coverage report
+   - `make code-quality-check` — run all quality checks (lint + typecheck + coverage)
    - `pre-commit run --all-files` — final gate (yaml, json, whitespace, ruff, mypy)
 5. Commit: `<type>: <summary>`
 6. Verify user-provided information before acting on it (see § User Input Validation)
@@ -162,13 +160,8 @@ uv run robot -d results -i IQ:120 robot/docker/python
 uv sync --extra dashboard
 rfc-dashboard  # or: uv run python -m dashboard.cli
 
-# Code quality (prefer Makefile targets)
-make code-quality-format                # Auto-format with ruff
-make code-quality-lint                  # Run ruff linter
-make code-quality-typecheck             # Run mypy type checker
-make code-quality-check                 # Run all checks (lint + typecheck)
-make code-quality-coverage              # Run pytest with coverage
-make code-quality-audit                 # Audit dependencies for vulnerabilities
+# Code quality (single command — runs lint + typecheck + coverage)
+make code-quality-check
 
 # Pre-commit (final gate)
 pre-commit run --all-files
@@ -204,12 +197,7 @@ make robot-dryrun                # Validate all Robot tests (dry run)
 make import                      # Import output.xml files: make import RESULTS_DIR=results/
 
 # Layer 1: Python code quality
-make code-quality-lint           # Run ruff linter
-make code-quality-format         # Auto-format code
-make code-quality-typecheck      # Run mypy type checker
 make code-quality-check          # Run all checks (lint + typecheck + coverage)
-make code-quality-coverage       # Run pytest with coverage report
-make code-quality-audit          # Audit dependencies for vulnerabilities
 
 # Layer 2: Docker services
 make docker-up                   # Start PostgreSQL + Redis + Superset + Grafana

--- a/ai/DEV.md
+++ b/ai/DEV.md
@@ -130,9 +130,6 @@ make robot         # Run all Robot Framework test suites
 make robot-math    # Run math tests
 make robot-docker  # Run Docker tests
 make robot-safety  # Run safety tests
-make code-quality-lint     # Run ruff linter
-make code-quality-format   # Auto-format code
-make code-quality-typecheck # Run mypy type checker
 make code-quality-check    # Run all code quality checks (lint + typecheck + coverage)
 make import        # Import output.xml results: make import PATH=results/
 make version       # Print current version


### PR DESCRIPTION
## Summary
Consolidated and simplified the code quality command documentation across multiple files to reflect a unified approach where `make code-quality-check` is the primary command that runs all quality checks (lint + typecheck + coverage) in a single invocation.

## Key Changes
- **AGENTS.md**: Replaced three separate code quality commands (`code-quality-format`, `code-quality-check`, `code-quality-coverage`) with a single consolidated command that runs all checks together
- **AGENTS.md**: Removed redundant individual command documentation (format, lint, typecheck, coverage, audit) from the quick reference section, keeping only the unified `make code-quality-check` command
- **DEV.md**: Removed references to individual code quality commands (`code-quality-lint`, `code-quality-format`, `code-quality-typecheck`) and kept only the consolidated `make code-quality-check` command

## Implementation Details
- The changes are documentation-only, clarifying the intended workflow without modifying any actual Makefile targets or implementation
- This simplification reduces cognitive load for developers by establishing a single, clear entry point for all code quality checks
- The unified command approach is now consistently documented across all developer-facing documentation files

https://claude.ai/code/session_01B4rVJ59QEpjRLPJYHSewa2