### PR TITLE
Log RFC_DATA messages at INFO level and include prompt text in metrics

### DIFF
--- a/src/rfc/keywords.py
+++ b/src/rfc/keywords.py
@@ -36,9 +36,10 @@ class LLMKeywords:
         logger.info(prompt)
         response = self.client.generate(prompt)
         logger.info(response)
-        logger.debug(f"RFC_DATA:actual_answer:{response}")
+        logger.info(f"RFC_DATA:actual_answer:{response}")
         if self.client.last_metrics is not None:
-            logger.debug(
+            self.client.last_metrics["prompt_text"] = prompt
+            logger.info(
                 f"RFC_DATA:ollama_metrics:{json.dumps(self.client.last_metrics)}"
             )
         return response
@@ -46,8 +47,8 @@ class LLMKeywords:
     @keyword("Grade Answer")
     def grade_answer(self, question: str, expected: str, actual: str):
         result = self.grader.grade(question, expected, actual)
-        logger.debug(f"RFC_DATA:expected_answer:{expected}")
-        logger.debug(f"RFC_DATA:grading_reason:{result.reason}")
+        logger.info(f"RFC_DATA:expected_answer:{expected}")
+        logger.info(f"RFC_DATA:grading_reason:{result.reason}")
         return result.score, result.reason
 
     @keyword("Wait For LLM")

--- a/tests/test_db_listener.py
+++ b/tests/test_db_listener.py
@@ -851,6 +851,31 @@ class TestDbListenerOllamaMetrics:
             row = conn.execute("SELECT * FROM ollama_metrics").fetchone()
             assert row["rfc_version"] is not None
 
+    @patch("rfc.db_listener.collect_ci_metadata", return_value={})
+    def test_prompt_text_archived_to_database(self, _mock_ci, tmp_path):
+        import sqlite3
+
+        db_path = str(tmp_path / "test.db")
+        listener = DbListener(database_url=f"sqlite:///{db_path}")
+
+        listener.start_suite("Suite", {})
+        listener.start_test("T", {})
+        metrics = {
+            "model_name": "llama3",
+            "prompt_text": "What is 6 * 7?",
+            "eval_rate": 11.0,
+        }
+        listener.log_message(
+            {"message": f"RFC_DATA:ollama_metrics:{json.dumps(metrics)}"}
+        )
+        listener.end_test("T", _test_attrs())
+        listener.end_suite("Suite", _suite_attrs(totaltests=1))
+
+        with sqlite3.connect(db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute("SELECT * FROM ollama_metrics").fetchone()
+            assert row["prompt_text"] == "What is 6 * 7?"
+
     def test_ignores_invalid_json_in_ollama_metrics(self):
         listener = DbListener()
         listener.start_test("T", {})

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -70,17 +70,23 @@ class TestLLMKeywordsAsk:
 
         kw.ask_llm("What is 6 * 7?")
 
-        # Find the RFC_DATA:ollama_metrics call
-        debug_calls = [str(c) for c in mock_logger.debug.call_args_list]
-        metrics_calls = [c for c in debug_calls if "RFC_DATA:ollama_metrics:" in c]
+        # RFC_DATA messages must be emitted at INFO level so the
+        # DbListener.log_message() receives them at the default --loglevel.
+        info_calls = [str(c) for c in mock_logger.info.call_args_list]
+        metrics_calls = [c for c in info_calls if "RFC_DATA:ollama_metrics:" in c]
         assert len(metrics_calls) == 1
 
         # Parse and verify the JSON payload
-        raw = mock_logger.debug.call_args_list[-1].args[0]
+        raw = [
+            c.args[0]
+            for c in mock_logger.info.call_args_list
+            if "RFC_DATA:ollama_metrics:" in str(c)
+        ][0]
         payload = raw.split("RFC_DATA:ollama_metrics:", 1)[1]
         data = json.loads(payload)
         assert data["model_name"] == "llama3"
         assert data["total_duration_ns"] == 17607688368
+        assert data["prompt_text"] == "What is 6 * 7?"
 
     @patch("rfc.keywords.logger")
     @patch("rfc.keywords.OllamaClient")
@@ -92,8 +98,8 @@ class TestLLMKeywordsAsk:
 
         kw.ask_llm("test")
 
-        debug_calls = [str(c) for c in mock_logger.debug.call_args_list]
-        metrics_calls = [c for c in debug_calls if "RFC_DATA:ollama_metrics:" in c]
+        info_calls = [str(c) for c in mock_logger.info.call_args_list]
+        metrics_calls = [c for c in info_calls if "RFC_DATA:ollama_metrics:" in c]
         assert len(metrics_calls) == 0
 
 


### PR DESCRIPTION
## Summary
Changed RFC_DATA logging from DEBUG to INFO level to ensure metrics are captured by the default log level, and added prompt text to ollama_metrics for better traceability.

## Key Changes
- **Logging Level**: Changed all `RFC_DATA:*` messages from `logger.debug()` to `logger.info()` in `keywords.py`
  - This ensures RFC_DATA messages are emitted at INFO level so DbListener receives them at the default `--loglevel`
  - Affected messages: `actual_answer`, `ollama_metrics`, `expected_answer`, and `grading_reason`

- **Metrics Enhancement**: Added `prompt_text` field to ollama_metrics
  - The prompt text is now captured and included in the metrics JSON payload
  - This provides better context for analyzing LLM interactions

- **Test Updates**: Updated test assertions to reflect the logging level change
  - Changed from checking `mock_logger.debug.call_args_list` to `mock_logger.info.call_args_list`
  - Added assertion to verify `prompt_text` is included in metrics payload
  - Added new test case `test_prompt_text_archived_to_database` to verify prompt text is persisted to the database

## Implementation Details
- The prompt text is captured at the point where metrics are logged in the `ask_llm` keyword
- This change ensures RFC_DATA messages are visible at standard logging levels without requiring DEBUG mode
- All RFC_DATA messages now use consistent INFO level logging for better observability

https://claude.ai/code/session_01FPoZMC6uNPbRUmUMMFEBDY