### PR TITLE
Add LIMIT 0 column probe fallback for empty virtual datasets

### DIFF
--- a/superset/bootstrap_dashboards.py
+++ b/superset/bootstrap_dashboards.py
@@ -985,6 +985,24 @@ def _ensure_tables(pg_uri: str) -> None:
     log.info("Ensured RFC result tables exist in PostgreSQL")
 
 
+def _probe_columns(db_uri: str, sql: str) -> List[str]:
+    """Discover column names by executing a virtual dataset SQL with LIMIT 0.
+
+    PostgreSQL (and SQLite) can infer column names from the query plan
+    without returning any rows.  This is used as a fallback when Superset's
+    ``fetch_metadata()`` fails because the underlying tables are empty.
+    """
+    from sqlalchemy import create_engine, text  # type: ignore[import-untyped]
+
+    engine = create_engine(db_uri)
+    try:
+        with engine.connect() as conn:
+            result = conn.execute(text(f"SELECT * FROM ({sql}) AS _col_probe LIMIT 0"))
+            return list(result.keys())
+    finally:
+        engine.dispose()
+
+
 def _build_position_json(slices: list, title: str) -> str:
     """Build a valid Superset dashboard position_json.
 
@@ -1093,6 +1111,7 @@ def bootstrap() -> None:
         from superset import db  # type: ignore[import-untyped,attr-defined]
         from superset.connectors.sqla.models import (  # type: ignore[import-untyped]
             SqlaTable,
+            TableColumn,
         )
         from superset.models.core import Database  # type: ignore[import-untyped]
         from superset.models.dashboard import (  # type: ignore[import-untyped]
@@ -1181,6 +1200,28 @@ def bootstrap() -> None:
                 log.info("Synced columns for virtual dataset: %s", vds_name)
             except Exception as e:
                 log.warning("Could not sync columns for %s: %s", vds_name, e)
+
+            # Fallback: when fetch_metadata() fails to register columns
+            # (e.g. underlying tables are empty), probe the database with
+            # LIMIT 0 to discover column names from the query plan.
+            if not ds.columns:
+                log.info(
+                    "No columns for %s — probing via LIMIT 0",
+                    vds_name,
+                )
+                try:
+                    col_names = _probe_columns(pg_uri, sql)
+                    for col_name in col_names:
+                        db.session.add(TableColumn(column_name=col_name, table=ds))
+                    db.session.flush()
+                    log.info(
+                        "Registered %d columns for %s via LIMIT 0 probe",
+                        len(col_names),
+                        vds_name,
+                    )
+                except Exception as e:
+                    log.warning("Column probe also failed for %s: %s", vds_name, e)
+
             datasets[vds_name] = ds
 
         # ── 4. Charts ────────────────────────────────────────────────

--- a/tests/test_bootstrap_columns.py
+++ b/tests/test_bootstrap_columns.py
@@ -1,0 +1,160 @@
+"""Tests for the LIMIT 0 column probe fallback in bootstrap_dashboards.py.
+
+When Superset's fetch_metadata() fails on virtual datasets with empty
+underlying tables, _probe_columns() discovers column names by executing
+the SQL with LIMIT 0 — PostgreSQL infers types from the query plan.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, text
+
+
+# ---------------------------------------------------------------------------
+# Import the function under test.  bootstrap_dashboards lives outside
+# src/rfc/ and imports Superset internals at call-sites, so we add its
+# directory to sys.path and import the pure helper directly.
+# ---------------------------------------------------------------------------
+import sys
+from pathlib import Path
+
+_SUPERSET_DIR = str(Path(__file__).resolve().parent.parent / "superset")
+if _SUPERSET_DIR not in sys.path:
+    sys.path.insert(0, _SUPERSET_DIR)
+
+from bootstrap_dashboards import _probe_columns  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def empty_db(tmp_path: Path) -> str:
+    """SQLite database with empty tables mirroring the RFC schema."""
+    db_path = tmp_path / "test.db"
+    uri = f"sqlite:///{db_path}"
+    engine = create_engine(uri)
+    with engine.begin() as conn:
+        conn.execute(text("""
+            CREATE TABLE test_runs (
+                id INTEGER PRIMARY KEY,
+                timestamp TEXT,
+                model_name TEXT,
+                test_suite TEXT,
+                git_branch TEXT,
+                git_commit TEXT,
+                duration_seconds REAL,
+                rfc_version TEXT,
+                total_tests INTEGER DEFAULT 0,
+                passed INTEGER DEFAULT 0,
+                failed INTEGER DEFAULT 0,
+                skipped INTEGER DEFAULT 0
+            )
+        """))
+        conn.execute(text("""
+            CREATE TABLE ollama_metrics (
+                id INTEGER PRIMARY KEY,
+                run_id INTEGER REFERENCES test_runs(id),
+                test_name TEXT,
+                model_name TEXT,
+                prompt_text TEXT,
+                total_duration_ns INTEGER,
+                load_duration_ns INTEGER,
+                prompt_eval_count INTEGER,
+                prompt_eval_duration_ns INTEGER,
+                prompt_eval_rate REAL,
+                eval_count INTEGER,
+                eval_duration_ns INTEGER,
+                eval_rate REAL,
+                rfc_version TEXT,
+                timestamp TEXT
+            )
+        """))
+    engine.dispose()
+    return uri
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestProbeColumns:
+    """Unit tests for _probe_columns()."""
+
+    def test_simple_table_returns_column_names(self, empty_db: str) -> None:
+        """Probing a simple SELECT on an empty table returns column names."""
+        sql = "SELECT id, test_name, model_name FROM ollama_metrics"
+        cols = _probe_columns(empty_db, sql)
+        assert cols == ["id", "test_name", "model_name"]
+
+    def test_join_on_empty_tables(self, empty_db: str) -> None:
+        """Probing a JOIN across two empty tables still returns columns."""
+        sql = """
+            SELECT
+                om.id AS metrics_id,
+                om.test_name,
+                om.model_name,
+                runs.timestamp,
+                runs.test_suite
+            FROM ollama_metrics om
+            JOIN test_runs runs ON om.run_id = runs.id
+        """
+        cols = _probe_columns(empty_db, sql)
+        assert cols == [
+            "metrics_id",
+            "test_name",
+            "model_name",
+            "timestamp",
+            "test_suite",
+        ]
+
+    def test_aliased_expressions(self, empty_db: str) -> None:
+        """Computed/CAST columns use the AS alias as column name."""
+        sql = """
+            SELECT
+                om.total_duration_ns,
+                CAST(om.total_duration_ns AS REAL) / 1e9 AS total_duration_s
+            FROM ollama_metrics om
+        """
+        cols = _probe_columns(empty_db, sql)
+        assert cols == ["total_duration_ns", "total_duration_s"]
+
+    def test_full_ollama_performance_query(self, empty_db: str) -> None:
+        """The actual ollama_performance virtual dataset SQL returns all expected columns."""
+        from bootstrap_dashboards import _VIRTUAL_DATASETS
+
+        # Adapt the SQL slightly for SQLite (no DOUBLE PRECISION, use REAL)
+        sql = _VIRTUAL_DATASETS["ollama_performance"].replace(
+            "DOUBLE PRECISION", "REAL"
+        )
+        cols = _probe_columns(empty_db, sql)
+        expected = [
+            "metrics_id",
+            "test_name",
+            "model_name",
+            "prompt_text",
+            "total_duration_ns",
+            "load_duration_ns",
+            "prompt_eval_count",
+            "prompt_eval_duration_ns",
+            "prompt_eval_rate",
+            "eval_count",
+            "eval_duration_ns",
+            "eval_rate",
+            "rfc_version",
+            "timestamp",
+            "test_suite",
+            "git_branch",
+            "total_duration_s",
+            "load_duration_s",
+            "prompt_eval_duration_s",
+            "eval_duration_s",
+        ]
+        assert cols == expected
+
+    def test_invalid_sql_raises(self, empty_db: str) -> None:
+        """Bad SQL should propagate the exception (not be swallowed)."""
+        with pytest.raises(Exception):
+            _probe_columns(empty_db, "SELECT * FROM nonexistent_table")


### PR DESCRIPTION
## Summary
Add a fallback mechanism to discover column names for virtual datasets when Superset's `fetch_metadata()` fails due to empty underlying tables. The solution uses a `LIMIT 0` query to infer column names from the database query plan.

## Key Changes
- **New `_probe_columns()` function**: Executes virtual dataset SQL with `LIMIT 0` to discover column names without fetching rows. Works with PostgreSQL and SQLite by leveraging their query plan analysis.
- **Fallback logic in `bootstrap()`**: When `fetch_metadata()` fails to register columns for a virtual dataset, the code now attempts to probe the database and manually register `TableColumn` objects.
- **Comprehensive test suite**: Added `tests/test_bootstrap_columns.py` with unit tests covering:
  - Simple SELECT queries on empty tables
  - JOINs across empty tables
  - Aliased/computed columns
  - The full `ollama_performance` virtual dataset query
  - Error handling for invalid SQL

## Implementation Details
- The `_probe_columns()` function wraps the SQL in a subquery with `LIMIT 0` to prevent row fetching while allowing the database to infer column metadata
- The fallback only activates when `ds.columns` is empty after the initial `fetch_metadata()` attempt
- Both the initial sync and fallback probe are wrapped in try-except blocks with appropriate logging to avoid blocking dashboard creation
- Tests use an in-memory SQLite database with the RFC schema to validate the probe mechanism works correctly

https://claude.ai/code/session_019vmeC7rp3sm6waVtYvR2tJ