### PR TITLE
Pass model and endpoint environment variables to subprocess

### DIFF
--- a/scripts/run_local_models.py
+++ b/scripts/run_local_models.py
@@ -310,7 +310,8 @@ def run_model_suites(
                 )
                 print(f"  > {' '.join(cmd)}\n")
 
-                proc = subprocess.run(cmd, cwd=str(_project_root))
+                env = {**os.environ, "DEFAULT_MODEL": model, "OLLAMA_ENDPOINT": endpoint}
+                proc = subprocess.run(cmd, cwd=str(_project_root), env=env)
 
                 results.append(
                     RunResult(

--- a/tests/test_run_local_models.py
+++ b/tests/test_run_local_models.py
@@ -240,6 +240,36 @@ class TestRunModelSuites:
         assert r.returncode == 0
 
     @patch("scripts.run_local_models.subprocess.run")
+    def test_passes_env_with_model_and_endpoint(self, mock_run: MagicMock) -> None:
+        """subprocess.run receives env with DEFAULT_MODEL and OLLAMA_ENDPOINT."""
+        mock_run.return_value = MagicMock(returncode=0)
+        config = {
+            "test_suites": [
+                {"name": "math", "path": "robot/math/tests/", "timeout_seconds": 300},
+            ],
+            "execution": {
+                "output_dir": "results/local/{node}/{model}",
+                "extra_args": [],
+                "listeners": [],
+                "continue_on_failure": True,
+                "parallel": 1,
+            },
+        }
+        nodes_with_models = [
+            {
+                "endpoint": "http://host1:11434",
+                "hostname": "host1",
+                "models": ["llama3"],
+            },
+        ]
+        run_model_suites(config, nodes_with_models)
+        call_kwargs = mock_run.call_args
+        env = call_kwargs.kwargs.get("env")
+        assert env is not None, "subprocess.run must be called with env= keyword"
+        assert env["DEFAULT_MODEL"] == "llama3"
+        assert env["OLLAMA_ENDPOINT"] == "http://host1:11434"
+
+    @patch("scripts.run_local_models.subprocess.run")
     def test_no_models_no_runs(self, mock_run: MagicMock) -> None:
         config = {
             "test_suites": [


### PR DESCRIPTION
## Summary
Updated the `run_model_suites` function to pass the current model and endpoint information as environment variables to the subprocess running the test suites.

## Key Changes
- Modified `subprocess.run()` call to include an `env` parameter that extends the current environment with `DEFAULT_MODEL` and `OLLAMA_ENDPOINT` variables
- Added corresponding test case `test_passes_env_with_model_and_endpoint` to verify that the environment variables are correctly passed to the subprocess

## Implementation Details
- The environment is constructed by merging the current process environment (`os.environ`) with the model and endpoint values specific to the current iteration
- This allows test suites running in the subprocess to access the model and endpoint information through environment variables rather than command-line arguments
- The change maintains backward compatibility by preserving all existing environment variables while adding the two new ones

https://claude.ai/code/session_01EgFVnaooRfgdZu51ZQ61qR