### PR TITLE
fix: use per-migration transactions in PostgreSQL backend

### DIFF
--- a/src/rfc/test_database.py
+++ b/src/rfc/test_database.py
@@ -798,12 +798,12 @@ class _SQLAlchemyBackend(_Backend):
         self._run_migrations()
 
     def _run_migrations(self) -> None:
-        with self.engine.begin() as conn:
-            for sql in self._PG_MIGRATIONS:
-                try:
+        for sql in self._PG_MIGRATIONS:
+            try:
+                with self.engine.begin() as conn:
                     conn.execute(text(sql))
-                except Exception:
-                    pass  # Column already BIGINT or table doesn't exist yet
+            except Exception:
+                pass  # Already applied or table doesn't exist yet
 
     def _define_tables(self) -> None:
         self.test_runs = Table(

--- a/tests/test_test_database.py
+++ b/tests/test_test_database.py
@@ -1,8 +1,16 @@
 """Tests for rfc.test_database."""
 
 from datetime import datetime
+from unittest.mock import MagicMock, patch
 
-from rfc.test_database import HostInfo, OllamaMetrics, TestDatabase, TestResult, TestRun
+from rfc.test_database import (
+    HostInfo,
+    OllamaMetrics,
+    TestDatabase,
+    TestResult,
+    TestRun,
+    _SQLAlchemyBackend,
+)
 
 
 def _make_run(**overrides):
@@ -330,3 +338,63 @@ class TestHostInfoDatabase:
         runs = db.get_recent_runs(limit=1)
         assert len(runs) == 1
         assert runs[0]["hostname"] == "dev1"
+
+
+class TestSQLAlchemyMigrations:
+    """Verify each PG migration runs in its own transaction."""
+
+    @patch("rfc.test_database.text", create=True, side_effect=lambda s: s)
+    @patch.object(_SQLAlchemyBackend, "__init__", lambda self, url: None)
+    def test_each_migration_uses_own_transaction(self, _mock_text: MagicMock) -> None:
+        """engine.begin() must be called once per migration, not once total."""
+        backend = _SQLAlchemyBackend.__new__(_SQLAlchemyBackend)
+        backend.engine = MagicMock()
+
+        backend._run_migrations()
+
+        expected_calls = len(_SQLAlchemyBackend._PG_MIGRATIONS)
+        actual_calls = backend.engine.begin.call_count
+        assert actual_calls == expected_calls, (
+            f"engine.begin() called {actual_calls} times, "
+            f"expected {expected_calls} (once per migration)"
+        )
+
+    @patch("rfc.test_database.text", create=True, side_effect=lambda s: s)
+    @patch.object(_SQLAlchemyBackend, "__init__", lambda self, url: None)
+    def test_later_migrations_run_after_earlier_failure(
+        self, _mock_text: MagicMock
+    ) -> None:
+        """A failing migration must not prevent subsequent migrations."""
+        backend = _SQLAlchemyBackend.__new__(_SQLAlchemyBackend)
+        backend.engine = MagicMock()
+
+        executed_sql: list[str] = []
+
+        call_count = 0
+
+        def fake_begin():
+            nonlocal call_count
+            call_count += 1
+            ctx = MagicMock()
+            conn = MagicMock()
+
+            if call_count == 1:
+                # First migration fails
+                conn.execute.side_effect = Exception("already applied")
+            else:
+                conn.execute.side_effect = lambda sql: executed_sql.append(str(sql))
+
+            ctx.__enter__.return_value = conn
+            ctx.__exit__.return_value = False
+            return ctx
+
+        backend.engine.begin = fake_begin
+
+        backend._run_migrations()
+
+        # Even though the first migration failed, the rest should have run.
+        remaining = len(_SQLAlchemyBackend._PG_MIGRATIONS) - 1
+        assert len(executed_sql) == remaining, (
+            f"Only {len(executed_sql)} migrations ran after first failure, "
+            f"expected {remaining}"
+        )


### PR DESCRIPTION
In PostgreSQL, a failed statement aborts the entire transaction — no further statements can execute. _run_migrations() ran all migrations in a single transaction, so when an earlier migration failed (e.g. pipeline_id already BIGINT), subsequent migrations like ADD COLUMN hostname were silently skipped, causing the "column hostname does not exist" error at insert time.

Move each migration into its own transaction so failures are isolated.

https://claude.ai/code/session_01BFivp84kkQ7eACP1bdix9V