### PR TITLE
Handle metadata.create_all() failures gracefully in SQLAlchemy backend

### DIFF
--- a/src/rfc/test_database.py
+++ b/src/rfc/test_database.py
@@ -10,12 +10,15 @@ PostgreSQL:  postgresql://user:pass@host:5432/dbname
 
 import abc
 import json
+import logging
 import os
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
 
 try:
     from sqlalchemy import (  # type: ignore[import-not-found]
@@ -787,14 +790,20 @@ class _SQLAlchemyBackend(_Backend):
         "ALTER TABLE test_runs RENAME COLUMN gitlab_branch TO git_branch",
         "ALTER TABLE test_runs RENAME COLUMN gitlab_pipeline_url TO pipeline_url",
         # Add hostname column for host identification.
-        "ALTER TABLE test_runs ADD COLUMN hostname VARCHAR(255)",
+        "ALTER TABLE test_runs ADD COLUMN IF NOT EXISTS hostname VARCHAR(255)",
     ]
 
     def __init__(self, database_url: str):
         self.engine: Engine = create_engine(database_url)
         self.metadata = MetaData()
         self._define_tables()
-        self.metadata.create_all(self.engine)
+        try:
+            self.metadata.create_all(self.engine)
+        except Exception:
+            logger.warning(
+                "metadata.create_all() failed; continuing with migrations",
+                exc_info=True,
+            )
         self._run_migrations()
 
     def _run_migrations(self) -> None:
@@ -803,7 +812,7 @@ class _SQLAlchemyBackend(_Backend):
                 with self.engine.begin() as conn:
                     conn.execute(text(sql))
             except Exception:
-                pass  # Already applied or table doesn't exist yet
+                logger.debug("Migration skipped (already applied): %s", sql)
 
     def _define_tables(self) -> None:
         self.test_runs = Table(

--- a/tests/test_test_database.py
+++ b/tests/test_test_database.py
@@ -398,3 +398,23 @@ class TestSQLAlchemyMigrations:
             f"Only {len(executed_sql)} migrations ran after first failure, "
             f"expected {remaining}"
         )
+
+    @patch("rfc.test_database.text", create=True, side_effect=lambda s: s)
+    @patch.object(_SQLAlchemyBackend, "_run_migrations")
+    @patch.object(_SQLAlchemyBackend, "_define_tables")
+    def test_migrations_run_when_create_all_fails(
+        self,
+        _mock_define: MagicMock,
+        mock_migrations: MagicMock,
+        _mock_text: MagicMock,
+    ) -> None:
+        """_run_migrations() must execute even if metadata.create_all() raises."""
+        with patch("rfc.test_database.create_engine", create=True):
+            with patch("rfc.test_database.MetaData", create=True) as mock_meta_cls:
+                mock_meta = MagicMock()
+                mock_meta.create_all.side_effect = Exception("schema conflict")
+                mock_meta_cls.return_value = mock_meta
+
+                _SQLAlchemyBackend(database_url="postgresql://fake")
+
+        mock_migrations.assert_called_once()


### PR DESCRIPTION
## Summary
This PR improves the robustness of the SQLAlchemy database backend by ensuring migrations run even when `metadata.create_all()` fails, and enhances logging throughout the initialization process.

## Key Changes
- **Graceful failure handling**: Wrapped `metadata.create_all()` in a try-except block to catch and log failures while allowing migrations to proceed
- **Enhanced logging**: 
  - Added logging module import and logger initialization
  - Added warning-level log when `metadata.create_all()` fails
  - Changed migration skip handling from silent `pass` to debug-level logging
- **SQL migration improvement**: Updated hostname column migration to use `IF NOT EXISTS` clause to prevent errors on re-application
- **Test coverage**: Added `test_migrations_run_when_create_all_fails()` to verify migrations execute even when schema creation fails

## Implementation Details
The key change ensures that if `metadata.create_all()` raises an exception (e.g., due to schema conflicts), the backend will log the warning and continue to execute migrations. This allows the system to recover from transient schema issues and ensures critical database setup steps are not skipped due to intermediate failures.

https://claude.ai/code/session_01JtUePM5Jd4U3b3CjSJxCVK