### PR TITLE
Rename database tables to remove robot_ prefix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,6 +159,9 @@ services:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
       GF_USERS_ALLOW_SIGN_UP: "false"
+      POSTGRES_USER: ${POSTGRES_USER:-rfc}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
+      POSTGRES_DB: ${POSTGRES_DB:-rfc}
     ports:
       - "${GRAFANA_PORT:-3000}:3000"
     volumes:

--- a/grafana/provisioning/dashboards/rfc_keyword_timing.json
+++ b/grafana/provisioning/dashboards/rfc_keyword_timing.json
@@ -25,7 +25,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT COUNT(*) AS \"Keywords\" FROM robot_keyword_results;",
+          "rawSql": "SELECT COUNT(*) AS \"Keywords\" FROM keyword_results;",
           "format": "table",
           "refId": "A"
         }
@@ -45,7 +45,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT ROUND(AVG(duration_seconds)::numeric, 2) AS \"Avg Duration\" FROM robot_keyword_results WHERE duration_seconds IS NOT NULL;",
+          "rawSql": "SELECT ROUND(AVG(duration_seconds)::numeric, 2) AS \"Avg Duration\" FROM keyword_results WHERE duration_seconds IS NOT NULL;",
           "format": "table",
           "refId": "A"
         }
@@ -72,7 +72,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT COUNT(DISTINCT keyword_name) AS \"Keywords\" FROM robot_keyword_results;",
+          "rawSql": "SELECT COUNT(DISTINCT keyword_name) AS \"Keywords\" FROM keyword_results;",
           "format": "table",
           "refId": "A"
         }
@@ -92,7 +92,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT ROUND(SUM(CASE WHEN status = 'FAIL' THEN 1 ELSE 0 END)::numeric / NULLIF(COUNT(*), 0) * 100, 1) AS \"Failure %\" FROM robot_keyword_results;",
+          "rawSql": "SELECT ROUND(SUM(CASE WHEN status = 'FAIL' THEN 1 ELSE 0 END)::numeric / NULLIF(COUNT(*), 0) * 100, 1) AS \"Failure %\" FROM keyword_results;",
           "format": "table",
           "refId": "A"
         }
@@ -119,7 +119,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT keyword_name AS \"Keyword\", ROUND(AVG(duration_seconds)::numeric, 3) AS \"Avg Duration (s)\" FROM robot_keyword_results WHERE duration_seconds IS NOT NULL GROUP BY keyword_name ORDER BY \"Avg Duration (s)\" DESC LIMIT 20;",
+          "rawSql": "SELECT keyword_name AS \"Keyword\", ROUND(AVG(duration_seconds)::numeric, 3) AS \"Avg Duration (s)\" FROM keyword_results WHERE duration_seconds IS NOT NULL GROUP BY keyword_name ORDER BY \"Avg Duration (s)\" DESC LIMIT 20;",
           "format": "table",
           "refId": "A"
         }
@@ -149,7 +149,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT keyword_name AS \"Keyword\", COUNT(*) AS \"Executions\", SUM(CASE WHEN status = 'PASS' THEN 1 ELSE 0 END) AS \"Passed\", SUM(CASE WHEN status = 'FAIL' THEN 1 ELSE 0 END) AS \"Failed\" FROM robot_keyword_results GROUP BY keyword_name ORDER BY \"Executions\" DESC LIMIT 20;",
+          "rawSql": "SELECT keyword_name AS \"Keyword\", COUNT(*) AS \"Executions\", SUM(CASE WHEN status = 'PASS' THEN 1 ELSE 0 END) AS \"Passed\", SUM(CASE WHEN status = 'FAIL' THEN 1 ELSE 0 END) AS \"Failed\" FROM keyword_results GROUP BY keyword_name ORDER BY \"Executions\" DESC LIMIT 20;",
           "format": "table",
           "refId": "A"
         }
@@ -183,7 +183,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT r.timestamp AS time, kw.duration_seconds AS \"Duration (s)\", r.model_name AS \"Model\" FROM robot_keyword_results kw JOIN robot_test_runs r ON kw.run_id = r.id WHERE kw.keyword_name = 'Ask LLM' AND kw.duration_seconds IS NOT NULL AND $__timeFilter(r.timestamp) ORDER BY r.timestamp;",
+          "rawSql": "SELECT r.timestamp AS time, kw.duration_seconds AS \"Duration (s)\", r.model_name AS \"Model\" FROM keyword_results kw JOIN test_runs r ON kw.run_id = r.id WHERE kw.keyword_name = 'Ask LLM' AND kw.duration_seconds IS NOT NULL AND $__timeFilter(r.timestamp) ORDER BY r.timestamp;",
           "format": "time_series",
           "refId": "A"
         }
@@ -207,7 +207,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT r.timestamp AS time, kw.duration_seconds AS \"Duration (s)\", r.model_name AS \"Model\" FROM robot_keyword_results kw JOIN robot_test_runs r ON kw.run_id = r.id WHERE kw.keyword_name = 'Grade Answer' AND kw.duration_seconds IS NOT NULL AND $__timeFilter(r.timestamp) ORDER BY r.timestamp;",
+          "rawSql": "SELECT r.timestamp AS time, kw.duration_seconds AS \"Duration (s)\", r.model_name AS \"Model\" FROM keyword_results kw JOIN test_runs r ON kw.run_id = r.id WHERE kw.keyword_name = 'Grade Answer' AND kw.duration_seconds IS NOT NULL AND $__timeFilter(r.timestamp) ORDER BY r.timestamp;",
           "format": "time_series",
           "refId": "A"
         }
@@ -231,7 +231,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT r.model_name AS \"Model\", kw.keyword_name AS \"Keyword\", ROUND(AVG(kw.duration_seconds)::numeric, 3) AS \"Avg Duration (s)\" FROM robot_keyword_results kw JOIN robot_test_runs r ON kw.run_id = r.id WHERE kw.duration_seconds IS NOT NULL AND kw.keyword_name IN ('Ask LLM', 'Grade Answer') GROUP BY r.model_name, kw.keyword_name ORDER BY r.model_name;",
+          "rawSql": "SELECT r.model_name AS \"Model\", kw.keyword_name AS \"Keyword\", ROUND(AVG(kw.duration_seconds)::numeric, 3) AS \"Avg Duration (s)\" FROM keyword_results kw JOIN test_runs r ON kw.run_id = r.id WHERE kw.duration_seconds IS NOT NULL AND kw.keyword_name IN ('Ask LLM', 'Grade Answer') GROUP BY r.model_name, kw.keyword_name ORDER BY r.model_name;",
           "format": "table",
           "refId": "A"
         }
@@ -251,7 +251,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT kw.keyword_name AS \"Keyword\", kw.test_name AS \"Test\", kw.library_name AS \"Library\", kw.status AS \"Status\", kw.duration_seconds AS \"Duration (s)\", kw.args AS \"Args\", r.model_name AS \"Model\", r.timestamp AS \"Run Time\" FROM robot_keyword_results kw JOIN robot_test_runs r ON kw.run_id = r.id ORDER BY r.timestamp DESC, kw.id DESC LIMIT 50;",
+          "rawSql": "SELECT kw.keyword_name AS \"Keyword\", kw.test_name AS \"Test\", kw.library_name AS \"Library\", kw.status AS \"Status\", kw.duration_seconds AS \"Duration (s)\", kw.args AS \"Args\", r.model_name AS \"Model\", r.timestamp AS \"Run Time\" FROM keyword_results kw JOIN test_runs r ON kw.run_id = r.id ORDER BY r.timestamp DESC, kw.id DESC LIMIT 50;",
           "format": "table",
           "refId": "A"
         }

--- a/grafana/provisioning/dashboards/rfc_test_results.json
+++ b/grafana/provisioning/dashboards/rfc_test_results.json
@@ -25,7 +25,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT COUNT(*) AS \"Total Runs\" FROM robot_test_runs;",
+          "rawSql": "SELECT COUNT(*) AS \"Total Runs\" FROM test_runs;",
           "format": "table",
           "refId": "A"
         }
@@ -49,7 +49,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT SUM(total_tests) AS \"Total Tests\" FROM robot_test_runs;",
+          "rawSql": "SELECT SUM(total_tests) AS \"Total Tests\" FROM test_runs;",
           "format": "table",
           "refId": "A"
         }
@@ -73,7 +73,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT ROUND(SUM(passed)::numeric / NULLIF(SUM(total_tests), 0) * 100, 1) AS \"Pass Rate %\" FROM robot_test_runs;",
+          "rawSql": "SELECT ROUND(SUM(passed)::numeric / NULLIF(SUM(total_tests), 0) * 100, 1) AS \"Pass Rate %\" FROM test_runs;",
           "format": "table",
           "refId": "A"
         }
@@ -100,7 +100,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT SUM(failed) AS \"Total Failures\" FROM robot_test_runs;",
+          "rawSql": "SELECT SUM(failed) AS \"Total Failures\" FROM test_runs;",
           "format": "table",
           "refId": "A"
         }
@@ -126,7 +126,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT COUNT(DISTINCT model_name) AS \"Models\" FROM robot_test_runs;",
+          "rawSql": "SELECT COUNT(DISTINCT model_name) AS \"Models\" FROM test_runs;",
           "format": "table",
           "refId": "A"
         }
@@ -150,7 +150,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT ROUND(AVG(duration_seconds)::numeric, 1) AS \"Avg Seconds\" FROM robot_test_runs;",
+          "rawSql": "SELECT ROUND(AVG(duration_seconds)::numeric, 1) AS \"Avg Seconds\" FROM test_runs;",
           "format": "table",
           "refId": "A"
         }
@@ -177,7 +177,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT timestamp AS time, passed AS \"Passed\", failed AS \"Failed\", skipped AS \"Skipped\" FROM robot_test_runs WHERE $__timeFilter(timestamp) ORDER BY timestamp;",
+          "rawSql": "SELECT timestamp AS time, passed AS \"Passed\", failed AS \"Failed\", skipped AS \"Skipped\" FROM test_runs WHERE $__timeFilter(timestamp) ORDER BY timestamp;",
           "format": "time_series",
           "refId": "A"
         }
@@ -213,7 +213,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT timestamp AS time, duration_seconds AS \"Duration (s)\", test_suite AS \"Suite\" FROM robot_test_runs WHERE $__timeFilter(timestamp) ORDER BY timestamp;",
+          "rawSql": "SELECT timestamp AS time, duration_seconds AS \"Duration (s)\", test_suite AS \"Suite\" FROM test_runs WHERE $__timeFilter(timestamp) ORDER BY timestamp;",
           "format": "time_series",
           "refId": "A"
         }
@@ -238,7 +238,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT model_name AS \"Model\", ROUND(SUM(passed)::numeric / NULLIF(SUM(total_tests), 0) * 100, 1) AS \"Pass Rate %\" FROM robot_test_runs GROUP BY model_name ORDER BY \"Pass Rate %\" DESC;",
+          "rawSql": "SELECT model_name AS \"Model\", ROUND(SUM(passed)::numeric / NULLIF(SUM(total_tests), 0) * 100, 1) AS \"Pass Rate %\" FROM test_runs GROUP BY model_name ORDER BY \"Pass Rate %\" DESC;",
           "format": "table",
           "refId": "A"
         }
@@ -264,7 +264,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT test_suite AS \"Suite\", ROUND(SUM(passed)::numeric / NULLIF(SUM(total_tests), 0) * 100, 1) AS \"Pass Rate %\" FROM robot_test_runs GROUP BY test_suite ORDER BY \"Pass Rate %\" DESC;",
+          "rawSql": "SELECT test_suite AS \"Suite\", ROUND(SUM(passed)::numeric / NULLIF(SUM(total_tests), 0) * 100, 1) AS \"Pass Rate %\" FROM test_runs GROUP BY test_suite ORDER BY \"Pass Rate %\" DESC;",
           "format": "table",
           "refId": "A"
         }
@@ -290,7 +290,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT timestamp, model_name AS \"Model\", test_suite AS \"Suite\", total_tests AS \"Total\", passed AS \"Pass\", failed AS \"Fail\", skipped AS \"Skip\", ROUND(duration_seconds::numeric, 1) AS \"Duration (s)\", git_branch AS \"Branch\", SUBSTRING(git_commit, 1, 8) AS \"Commit\" FROM robot_test_runs ORDER BY timestamp DESC LIMIT 25;",
+          "rawSql": "SELECT timestamp, model_name AS \"Model\", test_suite AS \"Suite\", total_tests AS \"Total\", passed AS \"Pass\", failed AS \"Fail\", skipped AS \"Skip\", ROUND(duration_seconds::numeric, 1) AS \"Duration (s)\", git_branch AS \"Branch\", SUBSTRING(git_commit, 1, 8) AS \"Commit\" FROM test_runs ORDER BY timestamp DESC LIMIT 25;",
           "format": "table",
           "refId": "A"
         }
@@ -307,7 +307,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT tr.test_name AS \"Test\", tr.test_status AS \"Status\", tr.score AS \"Score\", tr.question AS \"Question\", SUBSTRING(tr.actual_answer, 1, 100) AS \"Actual Answer\", SUBSTRING(tr.expected_answer, 1, 100) AS \"Expected Answer\", tr.grading_reason AS \"Grading Reason\" FROM robot_test_results tr JOIN robot_test_runs r ON tr.run_id = r.id WHERE r.id = (SELECT MAX(id) FROM robot_test_runs) ORDER BY tr.test_name;",
+          "rawSql": "SELECT tr.test_name AS \"Test\", tr.test_status AS \"Status\", tr.score AS \"Score\", tr.question AS \"Question\", SUBSTRING(tr.actual_answer, 1, 100) AS \"Actual Answer\", SUBSTRING(tr.expected_answer, 1, 100) AS \"Expected Answer\", tr.grading_reason AS \"Grading Reason\" FROM test_results tr JOIN test_runs r ON tr.run_id = r.id WHERE r.id = (SELECT MAX(id) FROM test_runs) ORDER BY tr.test_name;",
           "format": "table",
           "refId": "A"
         }
@@ -336,7 +336,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT r.timestamp AS time, AVG(tr.score) AS \"Avg Score\" FROM robot_test_results tr JOIN robot_test_runs r ON tr.run_id = r.id WHERE tr.score IS NOT NULL AND $__timeFilter(r.timestamp) GROUP BY r.timestamp ORDER BY r.timestamp;",
+          "rawSql": "SELECT r.timestamp AS time, AVG(tr.score) AS \"Avg Score\" FROM test_results tr JOIN test_runs r ON tr.run_id = r.id WHERE tr.score IS NOT NULL AND $__timeFilter(r.timestamp) GROUP BY r.timestamp ORDER BY r.timestamp;",
           "format": "time_series",
           "refId": "A"
         }
@@ -361,7 +361,7 @@
       "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
       "targets": [
         {
-          "rawSql": "SELECT test_status AS \"Status\", COUNT(*) AS \"Count\" FROM robot_test_results GROUP BY test_status;",
+          "rawSql": "SELECT test_status AS \"Status\", COUNT(*) AS \"Count\" FROM test_results GROUP BY test_status;",
           "format": "table",
           "refId": "A"
         }
@@ -390,22 +390,22 @@
       {
         "current": {},
         "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
-        "definition": "SELECT DISTINCT model_name FROM robot_test_runs ORDER BY model_name;",
+        "definition": "SELECT DISTINCT model_name FROM test_runs ORDER BY model_name;",
         "includeAll": true,
         "multi": true,
         "name": "model",
-        "query": "SELECT DISTINCT model_name FROM robot_test_runs ORDER BY model_name;",
+        "query": "SELECT DISTINCT model_name FROM test_runs ORDER BY model_name;",
         "refresh": 2,
         "type": "query"
       },
       {
         "current": {},
         "datasource": { "type": "postgres", "uid": "${DS_RFC_POSTGRESQL}" },
-        "definition": "SELECT DISTINCT test_suite FROM robot_test_runs ORDER BY test_suite;",
+        "definition": "SELECT DISTINCT test_suite FROM test_runs ORDER BY test_suite;",
         "includeAll": true,
         "multi": true,
         "name": "suite",
-        "query": "SELECT DISTINCT test_suite FROM robot_test_runs ORDER BY test_suite;",
+        "query": "SELECT DISTINCT test_suite FROM test_runs ORDER BY test_suite;",
         "refresh": 2,
         "type": "query"
       }

--- a/grafana/provisioning/datasources/rfc.yaml
+++ b/grafana/provisioning/datasources/rfc.yaml
@@ -7,10 +7,10 @@ datasources:
     type: postgres
     access: proxy
     url: postgres:5432
-    database: ${POSTGRES_DB:-rfc}
-    user: ${POSTGRES_USER:-rfc}
+    database: $POSTGRES_DB
+    user: $POSTGRES_USER
     secureJsonData:
-      password: ${POSTGRES_PASSWORD:-changeme}
+      password: $POSTGRES_PASSWORD
     jsonData:
       sslmode: disable
       maxOpenConns: 5


### PR DESCRIPTION
## Summary
This PR updates all Grafana dashboard queries and datasource configurations to use the new simplified database table names, removing the `robot_` prefix from table references.

## Key Changes
- **Dashboard queries**: Updated all SQL queries in `rfc_test_results.json` and `rfc_keyword_timing.json` to reference:
  - `test_runs` instead of `robot_test_runs`
  - `test_results` instead of `robot_test_results`
  - `keyword_results` instead of `robot_keyword_results`
- **Datasource configuration**: Updated `rfc.yaml` to use environment variables without default fallbacks:
  - Changed `${POSTGRES_DB:-rfc}` to `$POSTGRES_DB`
  - Changed `${POSTGRES_USER:-rfc}` to `$POSTGRES_USER`
  - Changed `${POSTGRES_PASSWORD:-changeme}` to `$POSTGRES_PASSWORD`
- **Docker Compose**: Added explicit environment variable passing to Grafana service to ensure database credentials are properly propagated

## Implementation Details
- All 14 SQL queries across both dashboard files have been updated to use the new table names
- The datasource configuration now requires explicit environment variable values rather than relying on defaults
- Grafana container now receives `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` environment variables to support the updated datasource configuration

https://claude.ai/code/session_01TmPVaAVhRZRNc7aUVGJYyU