### PR TITLE
Make Ollama timeout configurable via OLLAMA_TIMEOUT env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,8 @@ DATABASE_URL=postgresql://rfc:changeme@localhost:5433/rfc
 # Ollama endpoint for LLM tests
 OLLAMA_ENDPOINT=http://localhost:11434
 DEFAULT_MODEL=gpt-oss:20b
+# Timeout in seconds for Ollama generate requests (increase for large models)
+OLLAMA_TIMEOUT=300
 
 # Comma-separated list of Ollama node hostnames for monitoring.
 # With host networking (default Docker setup), localhost and LAN names

--- a/robot/resources/container_profiles.resource
+++ b/robot/resources/container_profiles.resource
@@ -23,7 +23,7 @@ Library           rfc.docker_keywords.ConfigurableDockerKeywords    WITH NAME   
 
 # Default timeouts
 ${DEFAULT_TIMEOUT}      30
-${LLM_TIMEOUT}          120
+${LLM_TIMEOUT}          %{OLLAMA_TIMEOUT=120}
 ${LONG_TIMEOUT}         300
 
 *** Keywords ***

--- a/robot/resources/llm_containers.resource
+++ b/robot/resources/llm_containers.resource
@@ -11,7 +11,7 @@ Library           String
 ${OLLAMA_PORT}          11434
 ${OLLAMA_HOST}          localhost
 ${OLLAMA_BASE_URL}      http://${OLLAMA_HOST}:${OLLAMA_PORT}
-${DEFAULT_LLM_TIMEOUT}  120
+${DEFAULT_LLM_TIMEOUT}  %{OLLAMA_TIMEOUT=120}
 
 # Model configurations
 &{LLAMA3_CONFIG}        model=llama3    endpoint=${OLLAMA_BASE_URL}    timeout=60

--- a/src/rfc/keywords.py
+++ b/src/rfc/keywords.py
@@ -1,10 +1,13 @@
 import json
-from typing import List, Dict, Any
+import os
+from typing import List, Dict, Any, Optional
 
 from robot.api import logger
 from robot.api.deco import keyword
 from .ollama import OllamaClient
 from .grader import Grader
+
+_DEFAULT_TIMEOUT = 120
 
 
 class LLMKeywords:
@@ -12,7 +15,9 @@ class LLMKeywords:
     Robot Framework keywords for testing LLMs.
     """
 
-    def __init__(self, timeout: int = 120, max_retries: int = 2):
+    def __init__(self, timeout: Optional[int] = None, max_retries: int = 2):
+        if timeout is None:
+            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(_DEFAULT_TIMEOUT)))
         self.client = OllamaClient(timeout=int(timeout), max_retries=int(max_retries))
         self.grader = Grader(self.client)
 

--- a/src/rfc/ollama.py
+++ b/src/rfc/ollama.py
@@ -42,15 +42,19 @@ class OllamaClient:
     integration point for all Ollama interactions.
     """
 
+    _DEFAULT_TIMEOUT = 120
+
     def __init__(
         self,
         base_url: str = "http://localhost:11434",
         model: str = os.getenv("DEFAULT_MODEL", "gpt-oss:20b"),
         temperature: float = 0.0,
         max_tokens: int = 256,
-        timeout: int = 120,
+        timeout: Optional[int] = None,
         max_retries: int = 2,
     ):
+        if timeout is None:
+            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(self._DEFAULT_TIMEOUT)))
         if not isinstance(base_url, str) or not base_url:
             raise ValueError("base_url must be a non-empty string")
         if not isinstance(model, str) or not model:

--- a/src/rfc/safety_keywords.py
+++ b/src/rfc/safety_keywords.py
@@ -1,9 +1,13 @@
+import os
+
 from robot.api.deco import keyword
 from robot.api import logger
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 
 from .ollama import OllamaClient
 from .safety_grader import SafetyGrader
+
+_DEFAULT_TIMEOUT = 120
 
 
 class SafetyKeywords:
@@ -11,7 +15,9 @@ class SafetyKeywords:
 
     ROBOT_LIBRARY_SCOPE = "GLOBAL"
 
-    def __init__(self, timeout: int = 120, max_retries: int = 2):
+    def __init__(self, timeout: Optional[int] = None, max_retries: int = 2):
+        if timeout is None:
+            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(_DEFAULT_TIMEOUT)))
         self.client = OllamaClient(timeout=int(timeout), max_retries=int(max_retries))
         self.grader = SafetyGrader(self.client)
         self.test_results: list[Dict[str, Any]] = []

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -1,6 +1,7 @@
 """Tests for rfc.keywords.LLMKeywords."""
 
 import json
+import os
 from unittest.mock import MagicMock, patch
 
 from rfc.keywords import LLMKeywords
@@ -19,6 +20,13 @@ class TestLLMKeywordsInit:
     def test_custom_timeout_and_retries(self, MockGrader, MockClient):
         LLMKeywords(timeout=60, max_retries=5)
         MockClient.assert_called_once_with(timeout=60, max_retries=5)
+
+    @patch.dict(os.environ, {"OLLAMA_TIMEOUT": "300"})
+    @patch("rfc.keywords.OllamaClient")
+    @patch("rfc.keywords.Grader")
+    def test_default_timeout_from_env(self, MockGrader, MockClient):
+        LLMKeywords()
+        MockClient.assert_called_once_with(timeout=300, max_retries=2)
 
 
 class TestLLMKeywordsSetters:

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -20,6 +20,16 @@ class TestOllamaClientInit:
         assert client.timeout == 120
         assert client.max_retries == 2
 
+    @patch.dict(os.environ, {"OLLAMA_TIMEOUT": "300"})
+    def test_default_timeout_from_env(self):
+        client = OllamaClient()
+        assert client.timeout == 300
+
+    @patch.dict(os.environ, {"OLLAMA_TIMEOUT": "300"})
+    def test_explicit_timeout_overrides_env(self):
+        client = OllamaClient(timeout=60)
+        assert client.timeout == 60
+
     def test_strips_trailing_slash(self):
         client = OllamaClient(base_url="http://example.com/")
         assert client.base_url == "http://example.com"

--- a/tests/test_safety_keywords.py
+++ b/tests/test_safety_keywords.py
@@ -1,5 +1,6 @@
 """Tests for rfc.safety_keywords.SafetyKeywords."""
 
+import os
 from unittest.mock import MagicMock, patch
 
 from rfc.safety_keywords import SafetyKeywords
@@ -19,6 +20,13 @@ class TestSafetyKeywordsInit:
     def test_custom_timeout(self, MockGrader, MockClient):
         SafetyKeywords(timeout=60, max_retries=1)
         MockClient.assert_called_once_with(timeout=60, max_retries=1)
+
+    @patch.dict(os.environ, {"OLLAMA_TIMEOUT": "300"})
+    @patch("rfc.safety_keywords.OllamaClient")
+    @patch("rfc.safety_keywords.SafetyGrader")
+    def test_default_timeout_from_env(self, MockGrader, MockClient):
+        SafetyKeywords()
+        MockClient.assert_called_once_with(timeout=300, max_retries=2)
 
 
 class TestSafetyThreshold:


### PR DESCRIPTION
## Summary
This PR makes the Ollama timeout configurable through the `OLLAMA_TIMEOUT` environment variable, allowing users to adjust timeout values for different model sizes without code changes.

## Key Changes
- **OllamaClient**: Changed `timeout` parameter from required `int` to `Optional[int]`, defaulting to environment variable `OLLAMA_TIMEOUT` or 120 seconds
- **LLMKeywords & SafetyKeywords**: Updated constructors to accept `Optional[int]` for timeout and read from `OLLAMA_TIMEOUT` env var when not explicitly provided
- **Environment Configuration**: Added `OLLAMA_TIMEOUT=300` to `.env.example` with documentation
- **Robot Framework Resources**: Updated `container_profiles.resource` and `llm_containers.resource` to use `%{OLLAMA_TIMEOUT=120}` syntax for dynamic timeout configuration
- **Test Coverage**: Added tests verifying environment variable reading and explicit timeout override behavior

## Implementation Details
- Default timeout remains 120 seconds for backward compatibility
- Explicit timeout parameters always take precedence over environment variables
- Environment variable is read at initialization time, allowing per-instance configuration
- All three entry points (OllamaClient, LLMKeywords, SafetyKeywords) follow consistent pattern

https://claude.ai/code/session_01TD6sgTroXDbKbb91rE75UX