### PR TITLE
Fix environment variable isolation in tests

### DIFF
--- a/tests/test_db_listener.py
+++ b/tests/test_db_listener.py
@@ -636,10 +636,12 @@ class TestDbListenerDatabaseDescription:
     """Tests for _describe_database_destination helper."""
 
     def test_default_sqlite_when_no_url(self):
-        listener = DbListener()
-        desc = listener._describe_database_destination()
-        assert "SQLite" in desc
-        assert "test_history.db" in desc
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("DATABASE_URL", None)
+            listener = DbListener()
+            desc = listener._describe_database_destination()
+            assert "SQLite" in desc
+            assert "test_history.db" in desc
 
     def test_explicit_sqlite_url(self):
         listener = DbListener(database_url="sqlite:///path/to/my.db")

--- a/tests/test_pre_run_modifier.py
+++ b/tests/test_pre_run_modifier.py
@@ -11,12 +11,15 @@ from rfc.pre_run_modifier import ModelAwarePreRunModifier
 class TestPreRunModifierInit:
     @patch("rfc.pre_run_modifier.OllamaClient")
     def test_defaults(self, MockClient):
-        mod = ModelAwarePreRunModifier()
-        assert mod.ollama_endpoint == "http://localhost:11434"
-        assert mod.config_path == "robot/ci/models.yaml"
-        assert mod.default_model == "gpt-oss:20b"
-        assert mod.available_models == []
-        assert mod.model_config == {}
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("OLLAMA_ENDPOINT", None)
+            os.environ.pop("DEFAULT_MODEL", None)
+            mod = ModelAwarePreRunModifier()
+            assert mod.ollama_endpoint == "http://localhost:11434"
+            assert mod.config_path == "robot/ci/models.yaml"
+            assert mod.default_model == "gpt-oss:20b"
+            assert mod.available_models == []
+            assert mod.model_config == {}
 
     @patch("rfc.pre_run_modifier.OllamaClient")
     def test_custom_args(self, MockClient):

--- a/tests/test_suite_config.py
+++ b/tests/test_suite_config.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from rfc.suite_config import (
     _apply_env_overrides,
     defaults,
-    test_suites,
+    test_suites as get_test_suites,
     run_all_entry,
     iq_levels,
     container_profiles,
@@ -37,7 +37,7 @@ class TestConvenienceAccessors:
         assert "model" in result
 
     def test_test_suites_returns_dict(self, mock_suite_config):
-        result = test_suites()
+        result = get_test_suites()
         assert isinstance(result, dict)
         assert "math" in result
 


### PR DESCRIPTION
## Summary
This PR fixes test isolation issues by ensuring environment variables don't leak between tests. Tests were failing when run in certain environments due to uncontrolled environment variable state.

## Key Changes
- **test_pre_run_modifier.py**: Wrapped `test_defaults()` with `patch.dict()` to isolate environment variables, explicitly removing `OLLAMA_ENDPOINT` and `DEFAULT_MODEL` to ensure default values are tested
- **test_db_listener.py**: Wrapped `test_default_sqlite_when_no_url()` with `patch.dict()` to isolate environment variables, explicitly removing `DATABASE_URL` to ensure SQLite defaults are tested
- **test_suite_config.py**: Renamed import `test_suites` to `get_test_suites` to avoid shadowing the function name and improve code clarity

## Implementation Details
The environment variable isolation uses `patch.dict(os.environ, {}, clear=False)` combined with explicit `pop()` calls to remove specific variables while preserving the rest of the environment. This ensures tests verify default behavior without being affected by environment variables set in the test runner's environment.

https://claude.ai/code/session_01YSFszqKM76dJ3MXrTGjR5E