### PR TITLE
Refactor CI templates: extract Python/uv base configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,6 +107,7 @@ pipeline-summary:
 
 deploy-superset:
   stage: deploy
+  tags: [deploy]
   script: [make ci-deploy]
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $SUPERSET_DEPLOY_HOST

--- a/ci/common.yml
+++ b/ci/common.yml
@@ -6,9 +6,19 @@
 #
 # All logic lives in ci/*.sh scripts. Jobs here are thin wrappers.
 
-.uv-setup:
+# Base template for all Python/uv CI jobs.
+# Provides a python:3.11 image, pins jobs to self-hosted [python] runners,
+# and installs uv if not already present (idempotent on shell runners).
+# Jobs that need uv should extend .uv-setup (not this template directly).
+.python-uv-base:
+  image: python:3.11
+  tags: [python]
   before_script:
+    - command -v uv > /dev/null 2>&1 || pip install --disable-pip-version-check uv
     - uv sync --extra dev --extra superset
+
+.uv-setup:
+  extends: .python-uv-base
 
 .robot-test:
   extends: .uv-setup


### PR DESCRIPTION
## Summary
Refactored the CI configuration to improve template reusability and maintainability by extracting common Python/uv setup logic into a dedicated base template.

## Key Changes
- Created new `.python-uv-base` template that encapsulates:
  - Python 3.11 image specification
  - Self-hosted `[python]` runner tag requirement
  - Idempotent uv installation logic
  - uv sync command with dev and superset extras
- Simplified `.uv-setup` to extend `.python-uv-base` instead of duplicating configuration
- Added `tags: [deploy]` to the `deploy-superset` job for proper runner targeting

## Implementation Details
The new base template follows GitLab CI best practices by centralizing environment setup that would otherwise be duplicated across multiple jobs. Jobs requiring uv should extend `.uv-setup` (which now extends `.python-uv-base`) rather than the base template directly, maintaining a clear inheritance hierarchy. The uv installation check uses `command -v` to ensure idempotency on shell runners.

https://claude.ai/code/session_01GmM6qSciPNnENkoVTRBYob