### PR TITLE
Add PostgreSQL database configuration to CI/CD pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,8 @@ stages:
 variables:
   OLLAMA_ENDPOINT: "http://localhost:11434"
   DEFAULT_MODEL: "llama3"
+  DATABASE_HOST: "localhost"
+  DATABASE_URL: "postgresql://rfc:changeme@${DATABASE_HOST}:5433/rfc"
   ROBOT_OPTIONS: "--metadata CI:true"
 
 # ── Lint ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Added PostgreSQL database configuration variables to the GitLab CI/CD pipeline to support database-dependent tests and services.

## Key Changes
- Added `DATABASE_HOST` variable set to `"localhost"`
- Added `DATABASE_URL` variable with PostgreSQL connection string pointing to a local database instance on port 5433

## Implementation Details
The database configuration uses a PostgreSQL connection string format with:
- Username: `rfc`
- Password: `changeme` (placeholder credentials for CI environment)
- Host: `localhost` (referenced via the `DATABASE_HOST` variable)
- Port: `5433`
- Database name: `rfc`

These variables are now available to all CI/CD jobs and can be used by services or test suites that require database connectivity.

https://claude.ai/code/session_01BF4uWFiHTVe1KLgaXB9xA3