### PR TITLE
Make DATABASE_URL required for TestDatabase

### DIFF
--- a/ai/AGENTS.md
+++ b/ai/AGENTS.md
@@ -416,7 +416,7 @@ The `DbListener` reads `DATABASE_URL` from the environment to decide where to st
 
 | `DATABASE_URL` | Backend | Notes |
 |----------------|---------|-------|
-| Not set | SQLite | Stores to `data/test_history.db` |
+| Not set | **Error** | `RuntimeError` — must be configured |
 | `postgresql://...` | PostgreSQL | Requires `uv sync --extra superset` |
 
 ---
@@ -490,19 +490,15 @@ During the **review stage** (MR label `opencode-review` or manual trigger), Open
 
 ## Database
 
-Test results are stored in a SQL database with dual-backend support:
-
-- **SQLite** (default) — zero-config, stores in `data/test_history.db`
-- **PostgreSQL** — for production use with Superset visualization
-
-Set `DATABASE_URL` in your environment or `.env` to switch backends:
+Test results are stored in PostgreSQL (required). `DATABASE_URL` must be set
+in the environment or `.env`:
 
 ```bash
-# PostgreSQL (for Superset)
 DATABASE_URL=postgresql://rfc:changeme@localhost:5433/rfc
-
-# SQLite (default when DATABASE_URL is unset)
 ```
+
+SQLite is only used internally by test fixtures (via `db_path=` parameter)
+and is not a supported production backend.
 
 See [../docs/TEST_DATABASE.md](../docs/TEST_DATABASE.md) for schema details, queries, and maintenance.
 

--- a/scripts/import_test_results.py
+++ b/scripts/import_test_results.py
@@ -272,7 +272,6 @@ def main():
         "--model",
         help="Model name override (default: from metadata or DEFAULT_MODEL env var)",
     )
-    parser.add_argument("--db", help="Database path (default: data/test_history.db)")
     parser.add_argument(
         "--recursive",
         "-r",
@@ -282,11 +281,8 @@ def main():
 
     args = parser.parse_args()
 
-    # Initialize database (respects DATABASE_URL env var for PostgreSQL)
-    if args.db:
-        db = TestDatabase(db_path=args.db)
-    else:
-        db = TestDatabase()
+    # Initialize database (requires DATABASE_URL env var)
+    db = TestDatabase()
 
     # Find output.xml files
     xml_files: list[str] = []

--- a/src/rfc/db_listener.py
+++ b/src/rfc/db_listener.py
@@ -147,7 +147,7 @@ class DbListener:
         if url and url.startswith("sqlite:///"):
             path = url.replace("sqlite:///", "")
             return f"SQLite: {path}"
-        return "SQLite: data/test_history.db (default)"
+        return "NOT CONFIGURED (DATABASE_URL is not set)"
 
     def start_suite(self, name: str, attributes: Dict[str, Any]) -> None:
         self._suite_depth += 1

--- a/src/rfc/test_database.py
+++ b/src/rfc/test_database.py
@@ -15,7 +15,6 @@ import os
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -1397,11 +1396,12 @@ class _SQLAlchemyBackend(_Backend):
 class TestDatabase:
     """Manager for test results database.
 
-    Supports SQLite (default) and PostgreSQL backends.
+    Supports PostgreSQL (via DATABASE_URL) and SQLite (via explicit db_path).
     Backend selection:
       - Set DATABASE_URL env var to a PostgreSQL connection string
-      - Pass database_url to constructor
-      - Falls back to SQLite at data/test_history.db
+      - Pass database_url= to constructor
+      - Pass db_path= for SQLite (test fixtures only)
+    Raises RuntimeError if no database is configured.
     """
 
     def __init__(
@@ -1415,9 +1415,14 @@ class TestDatabase:
             db_path: Path to SQLite database file.  When provided
                      explicitly this **always** creates a SQLite backend,
                      even if DATABASE_URL is set in the environment.
+                     Intended for test fixtures only.
             database_url: SQLAlchemy database URL.  Takes precedence over
                           the DATABASE_URL env var but **not** over an
                           explicit *db_path*.
+
+        Raises:
+            RuntimeError: If no database is configured (no *db_path*,
+                no *database_url*, and DATABASE_URL env var is unset).
         """
         self._backend: _Backend
 
@@ -1430,7 +1435,18 @@ class TestDatabase:
 
         url = database_url or os.getenv("DATABASE_URL")
 
-        if url and not url.startswith("sqlite"):
+        if not url:
+            raise RuntimeError(
+                "DATABASE_URL is not set. Configure it in .env or pass "
+                "database_url= to TestDatabase(). "
+                "See docs/TEST_DATABASE.md for details."
+            )
+
+        if url.startswith("sqlite"):
+            sqlite_path = url.replace("sqlite:///", "")
+            self._backend = _SQLiteBackend(sqlite_path)
+            self.db_path = sqlite_path
+        else:
             if not HAS_SQLALCHEMY:
                 raise ImportError(
                     "sqlalchemy and psycopg2-binary are required for "
@@ -1439,26 +1455,6 @@ class TestDatabase:
                 )
             self._backend = _SQLAlchemyBackend(url)
             self.db_path = url
-        else:
-            # SQLite path
-            sqlite_path: Optional[str] = None
-            if url and url.startswith("sqlite"):
-                # Extract path from sqlite:///path URL
-                sqlite_path = url.replace("sqlite:///", "")
-            if sqlite_path is None:
-                project_root = self._find_project_root()
-                sqlite_path = os.path.join(project_root, "data", "test_history.db")
-            self._backend = _SQLiteBackend(sqlite_path)
-            self.db_path = sqlite_path
-
-    @staticmethod
-    def _find_project_root() -> str:
-        current = Path.cwd()
-        while current != current.parent:
-            if (current / ".git").exists():
-                return str(current)
-            current = current.parent
-        return str(Path.cwd())
 
     def add_test_run(self, run: TestRun) -> int:
         return self._backend.add_test_run(run)

--- a/tasks.py
+++ b/tasks.py
@@ -60,12 +60,16 @@ def _uv_run(*args: str, check: bool = True) -> int:
 
 
 def _ensure_env() -> None:
-    """Copy ``.env.example`` → ``.env`` if ``.env`` doesn't exist."""
+    """Copy ``.env.example`` → ``.env`` if missing, then load into environ."""
     env_file = ROOT / ".env"
     example = ROOT / ".env.example"
     if not env_file.exists() and example.exists():
         shutil.copy2(str(example), str(env_file))
         print("  Created .env from .env.example — edit it if needed.")
+    if env_file.exists():
+        from dotenv import load_dotenv  # type: ignore[import-not-found]
+
+        load_dotenv(env_file, override=False)
 
 
 # ── Targets ──────────────────────────────────────────────────────────
@@ -84,16 +88,19 @@ def robot() -> None:
 
 def robot_math() -> None:
     """Run math tests (Robot Framework)."""
+    _ensure_env()
     _uv_run("robot", "-d", "results/math", *LISTENERS, "robot/math/tests/")
 
 
 def robot_safety() -> None:
     """Run safety tests (Robot Framework)."""
+    _ensure_env()
     _uv_run("robot", "-d", "results/safety", *LISTENERS, "robot/safety/")
 
 
 def robot_dryrun() -> None:
     """Validate all Robot tests (dry run, no execution)."""
+    _ensure_env()
     _uv_run(
         "robot",
         "--dryrun",

--- a/tests/test_db_listener.py
+++ b/tests/test_db_listener.py
@@ -635,13 +635,12 @@ class TestDbListenerGetDb:
 class TestDbListenerDatabaseDescription:
     """Tests for _describe_database_destination helper."""
 
-    def test_default_sqlite_when_no_url(self):
+    def test_not_configured_when_no_url(self):
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("DATABASE_URL", None)
             listener = DbListener()
             desc = listener._describe_database_destination()
-            assert "SQLite" in desc
-            assert "test_history.db" in desc
+            assert "NOT CONFIGURED" in desc
 
     def test_explicit_sqlite_url(self):
         listener = DbListener(database_url="sqlite:///path/to/my.db")

--- a/tests/test_test_database.py
+++ b/tests/test_test_database.py
@@ -4,6 +4,8 @@ import sqlite3
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from rfc.test_database import (
     HostInfo,
     KeywordResult,
@@ -134,7 +136,7 @@ class TestSQLiteBackend:
 
 
 class TestTestDatabase:
-    def test_default_sqlite_backend(self, tmp_path):
+    def test_explicit_db_path_uses_sqlite(self, tmp_path):
         db = TestDatabase(db_path=str(tmp_path / "test.db"))
         assert db is not None
 
@@ -142,6 +144,12 @@ class TestTestDatabase:
         db = TestDatabase(db_path=str(tmp_path / "test.db"))
         run_id = db.add_test_run(_make_run())
         assert run_id > 0
+
+    def test_no_database_url_raises_error(self, monkeypatch):
+        """TestDatabase() with no args and no DATABASE_URL must raise."""
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        with pytest.raises(RuntimeError, match="DATABASE_URL is not set"):
+            TestDatabase()
 
 
 class TestTestRunDataclass:


### PR DESCRIPTION
## Summary
This PR makes `DATABASE_URL` a required configuration for the `TestDatabase` class, removing the implicit fallback to a default SQLite database at `data/test_history.db`. PostgreSQL is now the only supported production backend, while SQLite is restricted to test fixtures via the explicit `db_path=` parameter.

## Key Changes

- **TestDatabase initialization**: Now raises `RuntimeError` if no database is configured (no `db_path`, no `database_url` parameter, and `DATABASE_URL` env var unset)
- **Removed implicit SQLite fallback**: Deleted `_find_project_root()` method and the logic that automatically created `data/test_history.db` when no database URL was provided
- **Simplified backend selection logic**: Restructured `__init__` to explicitly handle SQLite URLs vs PostgreSQL, with clear error messaging
- **Updated documentation**: 
  - Modified docstrings to clarify that PostgreSQL is required and SQLite is test-fixture-only
  - Updated `AGENTS.md` to reflect that `DATABASE_URL` is mandatory
  - Updated `db_listener.py` to report "NOT CONFIGURED" instead of defaulting to SQLite
- **Enhanced test coverage**: Added `test_no_database_url_raises_error()` to verify the new error behavior
- **Improved task automation**: Updated `tasks.py` to call `_ensure_env()` before Robot Framework tests and added `.env` loading via `dotenv`
- **Simplified import script**: Removed `--db` CLI argument from `import_test_results.py` since SQLite is no longer a supported backend option

## Implementation Details

The new initialization flow:
1. Check for `db_path` parameter → use SQLite backend
2. Check for `database_url` parameter or `DATABASE_URL` env var
3. If no URL found → raise `RuntimeError` with helpful message
4. If URL is SQLite → use SQLite backend
5. If URL is PostgreSQL → use SQLAlchemy backend (requires sqlalchemy/psycopg2)

This enforces explicit configuration and prevents silent failures from missing environment variables.

https://claude.ai/code/session_01BHH8svdCrfsw2nePefevau