### PR TITLE
Shuffle model execution order to avoid alphabetical bias

### DIFF
--- a/scripts/run_local_models.py
+++ b/scripts/run_local_models.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import random
 import re
 import subprocess
 import sys
@@ -267,7 +268,11 @@ def run_model_suites(
     for node_info in nodes_with_models:
         endpoint = node_info["endpoint"]
         hostname = node_info["hostname"]
-        models = node_info.get("models", [])
+        models = list(node_info.get("models", []))
+        random.shuffle(models)
+
+        if models:
+            print(f"  Model order (shuffled): {models}")
 
         for model in models:
             for suite in suites:

--- a/tests/test_run_local_models.py
+++ b/tests/test_run_local_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -268,6 +269,65 @@ class TestRunModelSuites:
         assert env is not None, "subprocess.run must be called with env= keyword"
         assert env["DEFAULT_MODEL"] == "llama3"
         assert env["OLLAMA_ENDPOINT"] == "http://host1:11434"
+
+    @patch("scripts.run_local_models.subprocess.run")
+    def test_shuffles_model_order(self, mock_run: MagicMock) -> None:
+        """Models are shuffled before execution (not always alphabetical)."""
+        mock_run.return_value = MagicMock(returncode=0)
+        config = {
+            "test_suites": [
+                {"name": "math", "path": "robot/math/tests/", "timeout_seconds": 300},
+            ],
+            "execution": {
+                "output_dir": "results/local/{node}/{model}",
+                "extra_args": [],
+                "listeners": [],
+                "continue_on_failure": True,
+                "parallel": 1,
+            },
+        }
+        models = ["alpha", "bravo", "charlie", "delta"]
+        nodes_with_models = [
+            {
+                "endpoint": "http://host1:11434",
+                "hostname": "host1",
+                "models": list(models),
+            },
+        ]
+        # Patch random.shuffle to reverse the list (deterministic non-alphabetical order)
+        with patch("scripts.run_local_models.random.shuffle", side_effect=lambda x: x.reverse()):
+            results = run_model_suites(config, nodes_with_models)
+
+        # Models should have been run in reversed order
+        executed_models = [r.model for r in results]
+        assert executed_models == ["delta", "charlie", "bravo", "alpha"]
+
+    @patch("scripts.run_local_models.subprocess.run")
+    def test_shuffle_does_not_mutate_input(self, mock_run: MagicMock) -> None:
+        """Shuffling models must not mutate the original nodes_with_models."""
+        mock_run.return_value = MagicMock(returncode=0)
+        config = {
+            "test_suites": [
+                {"name": "math", "path": "robot/math/tests/", "timeout_seconds": 300},
+            ],
+            "execution": {
+                "output_dir": "results/local/{node}/{model}",
+                "extra_args": [],
+                "listeners": [],
+                "continue_on_failure": True,
+                "parallel": 1,
+            },
+        }
+        nodes_with_models = [
+            {
+                "endpoint": "http://host1:11434",
+                "hostname": "host1",
+                "models": ["alpha", "bravo", "charlie"],
+            },
+        ]
+        original = copy.deepcopy(nodes_with_models)
+        run_model_suites(config, nodes_with_models)
+        assert nodes_with_models == original, "Input nodes_with_models must not be mutated"
 
     @patch("scripts.run_local_models.subprocess.run")
     def test_no_models_no_runs(self, mock_run: MagicMock) -> None:


### PR DESCRIPTION
## Summary
This PR adds randomization to the model execution order in the local model test runner to avoid consistently running models in alphabetical order, which could mask order-dependent issues or biases in test results.

## Key Changes
- **Model shuffling**: Models are now shuffled before execution using `random.shuffle()` to ensure non-deterministic ordering
- **Input immutability**: The original `nodes_with_models` input is not mutated by creating a copy of the models list before shuffling
- **Logging**: Added a debug message that prints the shuffled model order for each node
- **Test coverage**: Added two comprehensive tests:
  - `test_shuffles_model_order`: Verifies that models are executed in shuffled (non-alphabetical) order
  - `test_shuffle_does_not_mutate_input`: Ensures the input data structure is not modified by the shuffling operation

## Implementation Details
- The models list is converted to a new list via `list()` before shuffling to prevent mutating the original input
- The shuffle operation happens once per node before iterating through models
- A conditional check ensures the debug message only prints when models are present

https://claude.ai/code/session_01BxUC1tkftmG1bpPH8Hc4jj