### PR TITLE
Implement lazy client initialization in CEOKeywords

### DIFF
--- a/src/rfc/ceo_keywords.py
+++ b/src/rfc/ceo_keywords.py
@@ -47,11 +47,26 @@ class CEOKeywords:
     ) -> None:
         if timeout is None:
             timeout = int(os.getenv("OLLAMA_TIMEOUT", str(_DEFAULT_TIMEOUT)))
-        self.client = create_provider(
-            provider="openai", timeout=int(timeout), max_retries=int(max_retries)
-        )
+        self._timeout = int(timeout)
+        self._max_retries = int(max_retries)
+        self._client: Optional[Any] = None
         self.web_cache = WebSearchCache()
         self._multi_grader: Optional[MultiGrader] = None
+
+    @property
+    def client(self) -> Any:
+        """Lazily create the LLM provider on first access.
+
+        This allows Robot Framework ``--dryrun`` to instantiate the library
+        and discover keywords without requiring API keys.
+        """
+        if self._client is None:
+            self._client = create_provider(
+                provider="openai",
+                timeout=self._timeout,
+                max_retries=self._max_retries,
+            )
+        return self._client
 
     def _get_multi_grader(self) -> MultiGrader:
         """Lazily initialize the multi-grader with configured models."""

--- a/tests/test_ceo_keywords.py
+++ b/tests/test_ceo_keywords.py
@@ -1,0 +1,32 @@
+"""Tests for CEOKeywords lazy client initialization.
+
+CEOKeywords must not require API keys at instantiation time so that
+Robot Framework ``--dryrun`` can discover keywords without env vars.
+"""
+
+from unittest.mock import patch
+
+from rfc.ceo_keywords import CEOKeywords
+
+
+class TestCEOKeywordsLazyInit:
+    """CEOKeywords should defer provider creation until first use."""
+
+    def test_instantiation_without_api_key(self) -> None:
+        """CEOKeywords() must succeed even without OPENAI_API_KEY set."""
+        with patch.dict("os.environ", {}, clear=False):
+            # Remove the key if it exists
+            import os
+
+            os.environ.pop("OPENAI_API_KEY", None)
+            # This should NOT raise ValueError
+            kw = CEOKeywords()
+            assert kw is not None
+
+    def test_client_created_on_first_access(self) -> None:
+        """The LLM client should be created lazily when first accessed."""
+        with patch("rfc.ceo_keywords.create_provider") as mock_create:
+            mock_create.return_value = object()  # dummy provider
+            CEOKeywords()
+            # create_provider should NOT have been called during __init__
+            mock_create.assert_not_called()


### PR DESCRIPTION
## Summary
Modified `CEOKeywords` to defer LLM provider creation until first use, enabling Robot Framework `--dryrun` to discover keywords without requiring API keys to be set.

## Key Changes
- Converted `client` from an instance variable initialized in `__init__` to a lazy-loading property
- Store timeout and max_retries as instance variables (`_timeout`, `_max_retries`) for later use
- Initialize `_client` as `None` and create the provider on first property access
- Added comprehensive tests verifying that instantiation succeeds without `OPENAI_API_KEY` and that provider creation is deferred until first access

## Implementation Details
- The `client` property now checks if `_client` is `None` and creates the provider using the stored configuration parameters only when accessed
- This pattern allows Robot Framework's `--dryrun` mode to instantiate the library and discover available keywords without environment variables being present
- All existing functionality is preserved since the client is created transparently on first use

https://claude.ai/code/session_018SnDsvcmoCQsVY2K7drify