### PR TITLE
Replace git pull with make update in cron job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ discover-local-models: ## Discover Ollama nodes and list their models
 run-local-models: ## Run test suites against every model on every local node (ITERATIONS=-1 forever, 0 stop-on-error)
 	uv run python scripts/run_local_models.py $(if $(ITERATIONS),--iterations $(ITERATIONS),)
 
-cron-install: ## Install hourly cron job for git pull + run-local-models
+cron-install: ## Install hourly cron job for update + sync-models + run-local-models
 	@scripts/cron_run_local_models.sh --install
 
 cron-uninstall: ## Remove hourly cron job

--- a/scripts/cron_run_local_models.sh
+++ b/scripts/cron_run_local_models.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# Hourly cron job: pull latest code, sync models, and run test suites.
+# Hourly cron job: make update, sync models, and run test suites.
 #
 # Usage:
-#   scripts/cron_run_local_models.sh             # Run git pull + sync models + make run-local-models
+#   scripts/cron_run_local_models.sh             # Run make update + sync models + make run-local-models
 #   scripts/cron_run_local_models.sh --install    # Add hourly cron entry
 #   scripts/cron_run_local_models.sh --uninstall  # Remove cron entry
 #   scripts/cron_run_local_models.sh --sync-models # Only check/pull missing master models
@@ -127,8 +127,8 @@ mkdir -p "$(dirname "$LOGFILE")"
 
 {
     echo "=== $(date -Iseconds) ==="
-    echo "Pulling latest changes..."
-    git pull
+    echo "Updating repository..."
+    make update
     echo "Syncing master models..."
     sync_models
     echo "Running local models..."


### PR DESCRIPTION
## Summary
Updated the cron job script and Makefile documentation to use `make update` instead of `git pull` for repository updates.

## Key Changes
- Modified `scripts/cron_run_local_models.sh` to call `make update` instead of `git pull` when running the hourly cron job
- Updated script comments and usage documentation to reflect the new update mechanism
- Updated Makefile `cron-install` target description to accurately document the new workflow (update + sync-models + run-local-models)

## Details
This change standardizes the update process by using the Makefile's `update` target instead of directly calling `git pull`. This provides a more abstracted and maintainable approach to repository updates, allowing for potential future enhancements to the update process without modifying the cron script.

https://claude.ai/code/session_012smLWcEyyszY1rTFCbcQ7h