### PR TITLE
Add report_url and log_url tracking to test runs

### DIFF
--- a/scripts/import_test_results.py
+++ b/scripts/import_test_results.py
@@ -147,7 +147,10 @@ def parse_output_xml(xml_path: str) -> dict:
 
 
 def import_results(
-    xml_path: str, db: TestDatabase, model_name: Optional[str] = None
+    xml_path: str,
+    db: TestDatabase,
+    model_name: Optional[str] = None,
+    report_base_url: Optional[str] = None,
 ) -> int:
     """Import a single output.xml file into database.
 
@@ -218,6 +221,23 @@ def import_results(
     else:
         timestamp = datetime.now()
 
+    # Build report URLs
+    report_url: Optional[str] = None
+    log_url: Optional[str] = None
+    if report_base_url:
+        base = report_base_url.rstrip("/")
+        report_url = f"{base}/report.html"
+        log_url = f"{base}/log.html"
+    else:
+        # Auto-detect sibling report.html/log.html files
+        xml_dir = os.path.dirname(os.path.abspath(xml_path))
+        sibling_report = os.path.join(xml_dir, "report.html")
+        sibling_log = os.path.join(xml_dir, "log.html")
+        if os.path.isfile(sibling_report):
+            report_url = sibling_report
+        if os.path.isfile(sibling_log):
+            log_url = sibling_log
+
     run = TestRun(
         timestamp=timestamp,
         model_name=model_name or "unknown",
@@ -235,6 +255,8 @@ def import_results(
         skipped=data["skipped"],
         duration_seconds=data["duration"],
         rfc_version=__version__,
+        report_url=report_url,
+        log_url=log_url,
     )
 
     run_id = db.add_test_run(run)
@@ -278,6 +300,10 @@ def main():
         action="store_true",
         help="Recursively search for output.xml files in directory",
     )
+    parser.add_argument(
+        "--report-base-url",
+        help="Base URL for report.html/log.html (e.g. https://results.example.com/math)",
+    )
 
     args = parser.parse_args()
 
@@ -306,7 +332,7 @@ def main():
     imported_count = 0
     for xml_file in xml_files:
         try:
-            run_id = import_results(xml_file, db, args.model)
+            run_id = import_results(xml_file, db, args.model, args.report_base_url)
             print(f"Imported {xml_file} (run_id={run_id})")
             imported_count += 1
         except Exception as e:

--- a/src/rfc/db_listener.py
+++ b/src/rfc/db_listener.py
@@ -299,6 +299,7 @@ class DbListener:
         )
 
         hostname = self._host_info.get("hostname")
+        report_url, log_url = _build_report_urls()
 
         run = TestRun(
             timestamp=self._start_time or end_time,
@@ -318,6 +319,8 @@ class DbListener:
             duration_seconds=duration,
             rfc_version=__version__,
             hostname=hostname,
+            report_url=report_url,
+            log_url=log_url,
         )
 
         try:
@@ -407,6 +410,32 @@ class DbListener:
             error_msg = f"DbListener: FAILED to archive results: {e}"
             logger.warn(error_msg)
             logger.console(error_msg)
+
+
+def _build_report_urls() -> tuple[Optional[str], Optional[str]]:
+    """Build report_url and log_url from environment variables.
+
+    Priority:
+    1. REPORT_BASE_URL — explicit base URL (e.g. https://results.example.com/math)
+    2. CI_JOB_URL — GitLab CI artifact URL pattern
+    3. ROBOT_OUTPUT_DIR — local file path fallback
+    """
+    base = os.getenv("REPORT_BASE_URL")
+    if base:
+        base = base.rstrip("/")
+        return f"{base}/report.html", f"{base}/log.html"
+
+    ci_job_url = os.getenv("CI_JOB_URL")
+    if ci_job_url:
+        artifact_base = f"{ci_job_url}/artifacts/browse"
+        return f"{artifact_base}/report.html", f"{artifact_base}/log.html"
+
+    output_dir = os.getenv("ROBOT_OUTPUT_DIR")
+    if output_dir:
+        output_dir = output_dir.rstrip("/")
+        return f"{output_dir}/report.html", f"{output_dir}/log.html"
+
+    return None, None
 
 
 def _compute_duration(start: str, end: str) -> Optional[float]:

--- a/src/rfc/docker_keywords.py
+++ b/src/rfc/docker_keywords.py
@@ -91,15 +91,12 @@ class ConfigurableDockerKeywords:
         except RuntimeError:
             result["daemon_running"] = False
             errors.append(
-                "Docker daemon is not running. "
-                "Please start Docker and try again."
+                "Docker daemon is not running. Please start Docker and try again."
             )
             logger.warn("Docker daemon is not running or not accessible")
 
         if errors and raise_on_failure:
-            msg = "Docker setup check failed:\n" + "\n".join(
-                f"  - {e}" for e in errors
-            )
+            msg = "Docker setup check failed:\n" + "\n".join(f"  - {e}" for e in errors)
             raise RuntimeError(msg)
 
         return result

--- a/src/rfc/test_database.py
+++ b/src/rfc/test_database.py
@@ -63,6 +63,8 @@ class TestRun:
     duration_seconds: float
     rfc_version: Optional[str] = None
     hostname: Optional[str] = None
+    report_url: Optional[str] = None
+    log_url: Optional[str] = None
     id: Optional[int] = None
 
 
@@ -268,7 +270,9 @@ class _SQLiteBackend(_Backend):
         skipped INTEGER DEFAULT 0,
         duration_seconds REAL,
         rfc_version TEXT,
-        hostname TEXT
+        hostname TEXT,
+        report_url TEXT,
+        log_url TEXT
     );
 
     CREATE TABLE IF NOT EXISTS test_results (
@@ -406,6 +410,8 @@ class _SQLiteBackend(_Backend):
         "ALTER TABLE keyword_results ADD COLUMN rfc_version TEXT",
         "ALTER TABLE host_info ADD COLUMN rfc_version TEXT",
         "ALTER TABLE models ADD COLUMN rfc_version TEXT",
+        "ALTER TABLE test_runs ADD COLUMN report_url TEXT",
+        "ALTER TABLE test_runs ADD COLUMN log_url TEXT",
     ]
 
     def __init__(self, db_path: str):
@@ -427,8 +433,10 @@ class _SQLiteBackend(_Backend):
                 (timestamp, model_name, model_release_date, model_parameters,
                  test_suite, git_commit, git_branch, pipeline_url,
                  runner_id, runner_tags, total_tests, passed, failed, skipped,
-                 duration_seconds, rfc_version, hostname)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 duration_seconds, rfc_version, hostname,
+                 report_url, log_url)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                        ?, ?)
                 """,
                 (
                     run.timestamp.isoformat(),
@@ -448,6 +456,8 @@ class _SQLiteBackend(_Backend):
                     run.duration_seconds,
                     run.rfc_version,
                     run.hostname,
+                    run.report_url,
+                    run.log_url,
                 ),
             )
             run_id = cursor.lastrowid
@@ -825,6 +835,8 @@ class _SQLAlchemyBackend(_Backend):
         "ALTER TABLE keyword_results ADD COLUMN IF NOT EXISTS rfc_version VARCHAR(50)",
         "ALTER TABLE host_info ADD COLUMN IF NOT EXISTS rfc_version VARCHAR(50)",
         "ALTER TABLE models ADD COLUMN IF NOT EXISTS rfc_version VARCHAR(50)",
+        "ALTER TABLE test_runs ADD COLUMN IF NOT EXISTS report_url TEXT",
+        "ALTER TABLE test_runs ADD COLUMN IF NOT EXISTS log_url TEXT",
     ]
 
     def __init__(self, database_url: str):
@@ -870,6 +882,8 @@ class _SQLAlchemyBackend(_Backend):
             Column("duration_seconds", Float),
             Column("rfc_version", String(50)),
             Column("hostname", String(255)),
+            Column("report_url", Text),
+            Column("log_url", Text),
         )
 
         self.test_results = Table(
@@ -1039,6 +1053,8 @@ class _SQLAlchemyBackend(_Backend):
                     duration_seconds=run.duration_seconds,
                     rfc_version=run.rfc_version,
                     hostname=run.hostname,
+                    report_url=run.report_url,
+                    log_url=run.log_url,
                 )
             )
             assert result.inserted_primary_key is not None

--- a/superset/bootstrap_dashboards.py
+++ b/superset/bootstrap_dashboards.py
@@ -42,7 +42,9 @@ CREATE TABLE IF NOT EXISTS test_runs (
     skipped INTEGER DEFAULT 0,
     duration_seconds DOUBLE PRECISION,
     rfc_version VARCHAR(50),
-    hostname VARCHAR(255)
+    hostname VARCHAR(255),
+    report_url TEXT,
+    log_url TEXT
 );
 
 CREATE TABLE IF NOT EXISTS test_results (
@@ -192,6 +194,10 @@ _VIRTUAL_DATASETS: Dict[str, str] = {
             runs.test_suite,
             runs.git_branch,
             runs.git_commit,
+            runs.pipeline_url,
+            runs.hostname,
+            runs.report_url,
+            runs.log_url,
             runs.duration_seconds AS run_duration,
             runs.rfc_version
         FROM test_results tr
@@ -279,6 +285,35 @@ _VIRTUAL_DATASETS: Dict[str, str] = {
             CAST(om.eval_duration_ns AS DOUBLE PRECISION) / 1e9 AS eval_duration_s
         FROM ollama_metrics om
         JOIN test_runs runs ON om.run_id = runs.id
+    """,
+    "test_run_context": """
+        SELECT
+            r.id AS run_id,
+            r.timestamp,
+            r.model_name,
+            r.test_suite,
+            SUBSTRING(r.git_commit FROM 1 FOR 8) AS git_commit_short,
+            r.git_commit,
+            r.git_branch,
+            r.pipeline_url,
+            r.report_url,
+            r.log_url,
+            r.hostname,
+            r.runner_id,
+            r.runner_tags,
+            r.total_tests,
+            r.passed,
+            r.failed,
+            r.skipped,
+            r.duration_seconds,
+            r.rfc_version,
+            h.os_name,
+            h.cpu_arch,
+            h.cpu_count,
+            h.total_ram_gb,
+            h.gpu_info
+        FROM test_runs r
+        LEFT JOIN host_info h ON r.hostname = h.hostname
     """,
 }
 
@@ -394,6 +429,9 @@ def _test_results_charts(datasets: Dict[str, Any]) -> List[Dict[str, Any]]:
                     "skipped",
                     "duration_seconds",
                     "git_branch",
+                    "git_commit",
+                    "hostname",
+                    "report_url",
                 ],
                 "order_desc": True,
                 "row_limit": 50,
@@ -513,9 +551,40 @@ def _test_results_charts(datasets: Dict[str, Any]) -> List[Dict[str, Any]]:
                     "score",
                     "actual_answer",
                     "grading_reason",
+                    "git_branch",
+                    "hostname",
+                    "report_url",
                 ],
                 "order_desc": True,
                 "row_limit": 100,
+                "order_by_cols": '["timestamp"]',
+            },
+        },
+        {
+            "name": "Run Provenance",
+            "viz_type": "table",
+            "datasource": datasets["test_run_context"],
+            "params": {
+                "viz_type": "table",
+                "all_columns": [
+                    "timestamp",
+                    "model_name",
+                    "test_suite",
+                    "git_branch",
+                    "git_commit_short",
+                    "hostname",
+                    "os_name",
+                    "cpu_arch",
+                    "gpu_info",
+                    "passed",
+                    "failed",
+                    "duration_seconds",
+                    "report_url",
+                    "log_url",
+                    "pipeline_url",
+                ],
+                "order_desc": True,
+                "row_limit": 50,
                 "order_by_cols": '["timestamp"]',
             },
         },

--- a/tests/test_db_listener.py
+++ b/tests/test_db_listener.py
@@ -958,3 +958,116 @@ class TestDbListenerHostInfo:
             assert row["cpu_arch"] == "arm64"
             assert row["cpu_count"] == 10
             assert row["total_ram_gb"] == 16.0
+
+
+class TestDbListenerReportUrls:
+    """Tests for report_url and log_url capture in end_suite."""
+
+    @patch("rfc.db_listener.collect_ci_metadata", return_value={})
+    def test_report_url_from_report_base_url_env(self, _mock_ci, tmp_path):
+        """REPORT_BASE_URL env var builds report/log URLs."""
+        import sqlite3
+
+        db_path = str(tmp_path / "test.db")
+        listener = DbListener(database_url=f"sqlite:///{db_path}")
+
+        env = {"REPORT_BASE_URL": "https://results.example.com/results/math"}
+        with patch.dict(os.environ, env, clear=False):
+            listener.start_suite("Suite", {})
+            listener.end_test("T", _test_attrs())
+            listener.end_suite("Suite", _suite_attrs())
+
+        with sqlite3.connect(db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute("SELECT * FROM test_runs").fetchone()
+            assert (
+                row["report_url"]
+                == "https://results.example.com/results/math/report.html"
+            )
+            assert row["log_url"] == "https://results.example.com/results/math/log.html"
+
+    @patch("rfc.db_listener.collect_ci_metadata", return_value={})
+    def test_report_url_from_ci_job_url(self, _mock_ci, tmp_path):
+        """Falls back to CI_JOB_URL artifact pattern."""
+        import sqlite3
+
+        db_path = str(tmp_path / "test.db")
+        listener = DbListener(database_url=f"sqlite:///{db_path}")
+
+        env = {"CI_JOB_URL": "https://gitlab.example.com/project/-/jobs/123"}
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("REPORT_BASE_URL", None)
+            listener.start_suite("Suite", {})
+            listener.end_test("T", _test_attrs())
+            listener.end_suite("Suite", _suite_attrs())
+
+        with sqlite3.connect(db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute("SELECT * FROM test_runs").fetchone()
+            assert "/artifacts/browse/" in row["report_url"]
+            assert row["report_url"].endswith("report.html")
+            assert "/artifacts/browse/" in row["log_url"]
+            assert row["log_url"].endswith("log.html")
+
+    @patch("rfc.db_listener.collect_ci_metadata", return_value={})
+    def test_report_url_from_output_dir(self, _mock_ci, tmp_path):
+        """Falls back to ROBOT_OUTPUT_DIR as local file path."""
+        import sqlite3
+
+        db_path = str(tmp_path / "test.db")
+        listener = DbListener(database_url=f"sqlite:///{db_path}")
+
+        env = {"ROBOT_OUTPUT_DIR": "/tmp/results/math"}
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("REPORT_BASE_URL", None)
+            os.environ.pop("CI_JOB_URL", None)
+            listener.start_suite("Suite", {})
+            listener.end_test("T", _test_attrs())
+            listener.end_suite("Suite", _suite_attrs())
+
+        with sqlite3.connect(db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute("SELECT * FROM test_runs").fetchone()
+            assert row["report_url"] == "/tmp/results/math/report.html"
+            assert row["log_url"] == "/tmp/results/math/log.html"
+
+    @patch("rfc.db_listener.collect_ci_metadata", return_value={})
+    def test_report_url_none_when_no_env(self, _mock_ci, tmp_path):
+        """report_url and log_url are None when no env vars are set."""
+        import sqlite3
+
+        db_path = str(tmp_path / "test.db")
+        listener = DbListener(database_url=f"sqlite:///{db_path}")
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("REPORT_BASE_URL", None)
+            os.environ.pop("CI_JOB_URL", None)
+            os.environ.pop("ROBOT_OUTPUT_DIR", None)
+            listener.start_suite("Suite", {})
+            listener.end_test("T", _test_attrs())
+            listener.end_suite("Suite", _suite_attrs())
+
+        with sqlite3.connect(db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute("SELECT * FROM test_runs").fetchone()
+            assert row["report_url"] is None
+            assert row["log_url"] is None
+
+    @patch("rfc.db_listener.collect_ci_metadata", return_value={})
+    def test_report_base_url_trailing_slash_handled(self, _mock_ci, tmp_path):
+        """Trailing slash on REPORT_BASE_URL doesn't cause double slash."""
+        import sqlite3
+
+        db_path = str(tmp_path / "test.db")
+        listener = DbListener(database_url=f"sqlite:///{db_path}")
+
+        env = {"REPORT_BASE_URL": "https://results.example.com/math/"}
+        with patch.dict(os.environ, env, clear=False):
+            listener.start_suite("Suite", {})
+            listener.end_test("T", _test_attrs())
+            listener.end_suite("Suite", _suite_attrs())
+
+        with sqlite3.connect(db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute("SELECT * FROM test_runs").fetchone()
+            assert "//" not in row["report_url"].replace("https://", "")

--- a/tests/test_docker_keywords.py
+++ b/tests/test_docker_keywords.py
@@ -63,7 +63,10 @@ class TestCheckDockerSetup:
         assert result["docker_cli_path"] == ""
         assert result["daemon_running"] is False
         assert len(result["errors"]) > 0
-        assert any("not found" in e.lower() or "not installed" in e.lower() for e in result["errors"])
+        assert any(
+            "not found" in e.lower() or "not installed" in e.lower()
+            for e in result["errors"]
+        )
 
     @patch("rfc.docker_keywords.shutil.which")
     @patch("rfc.docker_keywords.ContainerManager")
@@ -77,7 +80,10 @@ class TestCheckDockerSetup:
         assert result["docker_cli"] is True
         assert result["daemon_running"] is False
         assert len(result["errors"]) > 0
-        assert any("daemon" in e.lower() or "not running" in e.lower() for e in result["errors"])
+        assert any(
+            "daemon" in e.lower() or "not running" in e.lower()
+            for e in result["errors"]
+        )
 
     @patch("rfc.docker_keywords.shutil.which")
     @patch("rfc.docker_keywords.ContainerManager")

--- a/tests/test_import_test_results.py
+++ b/tests/test_import_test_results.py
@@ -624,3 +624,74 @@ class TestImportResults:
             assert len(results) == 3
         finally:
             os.unlink(path)
+
+    def test_import_report_base_url_sets_urls(self):
+        """report_base_url parameter builds report_url and log_url."""
+        path = _write_xml(MINIMAL_OUTPUT_XML)
+        try:
+            db = MagicMock()
+            db.add_test_run.return_value = 1
+
+            import_results(path, db, report_base_url="https://results.example.com/math")
+
+            run = db.add_test_run.call_args[0][0]
+            assert run.report_url == "https://results.example.com/math/report.html"
+            assert run.log_url == "https://results.example.com/math/log.html"
+        finally:
+            os.unlink(path)
+
+    def test_import_report_base_url_trailing_slash(self):
+        """Trailing slash on report_base_url doesn't cause double slash."""
+        path = _write_xml(MINIMAL_OUTPUT_XML)
+        try:
+            db = MagicMock()
+            db.add_test_run.return_value = 1
+
+            import_results(
+                path, db, report_base_url="https://results.example.com/math/"
+            )
+
+            run = db.add_test_run.call_args[0][0]
+            assert "//" not in run.report_url.replace("https://", "")
+        finally:
+            os.unlink(path)
+
+    def test_import_detects_sibling_report_files(self):
+        """Auto-detects sibling report.html/log.html when no base URL given."""
+        path = _write_xml(MINIMAL_OUTPUT_XML)
+        try:
+            report_path = os.path.join(os.path.dirname(path), "report.html")
+            log_path = os.path.join(os.path.dirname(path), "log.html")
+            with open(report_path, "w") as f:
+                f.write("<html></html>")
+            with open(log_path, "w") as f:
+                f.write("<html></html>")
+
+            db = MagicMock()
+            db.add_test_run.return_value = 1
+
+            import_results(path, db)
+
+            run = db.add_test_run.call_args[0][0]
+            assert run.report_url == report_path
+            assert run.log_url == log_path
+        finally:
+            os.unlink(path)
+            for p in [report_path, log_path]:
+                if os.path.exists(p):
+                    os.unlink(p)
+
+    def test_import_no_report_files_urls_none(self):
+        """report_url and log_url are None when no sibling files exist."""
+        path = _write_xml(MINIMAL_OUTPUT_XML)
+        try:
+            db = MagicMock()
+            db.add_test_run.return_value = 1
+
+            import_results(path, db)
+
+            run = db.add_test_run.call_args[0][0]
+            assert run.report_url is None
+            assert run.log_url is None
+        finally:
+            os.unlink(path)

--- a/tests/test_test_database.py
+++ b/tests/test_test_database.py
@@ -98,6 +98,25 @@ class TestSQLiteBackend:
         runs = db.get_recent_runs(limit=2)
         assert len(runs) == 2
 
+    def test_report_url_and_log_url_stored(self, tmp_path):
+        db = TestDatabase(db_path=str(tmp_path / "test.db"))
+        run = _make_run(
+            report_url="https://results.example.com/math/report.html",
+            log_url="https://results.example.com/math/log.html",
+        )
+        db.add_test_run(run)
+        runs = db.get_recent_runs(limit=1)
+        assert runs[0]["report_url"] == "https://results.example.com/math/report.html"
+        assert runs[0]["log_url"] == "https://results.example.com/math/log.html"
+
+    def test_report_url_defaults_to_none(self, tmp_path):
+        db = TestDatabase(db_path=str(tmp_path / "test.db"))
+        run = _make_run()
+        db.add_test_run(run)
+        runs = db.get_recent_runs(limit=1)
+        assert runs[0]["report_url"] is None
+        assert runs[0]["log_url"] is None
+
     def test_get_model_performance(self, tmp_path):
         db = TestDatabase(db_path=str(tmp_path / "test.db"))
         db.add_test_run(_make_run(model_name="llama3", passed=8, failed=2))


### PR DESCRIPTION
## Summary
This PR adds support for capturing and storing report URLs and log URLs for test runs. These URLs point to Robot Framework's generated report.html and log.html files, enabling better traceability and access to detailed test execution results.

## Key Changes

- **Database Schema Updates**: Added `report_url` and `log_url` TEXT columns to the `test_runs` table in both SQLite and SQLAlchemy backends, with migration support for existing databases.

- **URL Detection Logic** (`src/rfc/db_listener.py`): Implemented `_build_report_urls()` function with a priority-based detection strategy:
  1. `REPORT_BASE_URL` environment variable (explicit base URL)
  2. `CI_JOB_URL` environment variable (GitLab CI artifact pattern)
  3. `ROBOT_OUTPUT_DIR` environment variable (local file path)
  4. Falls back to `None` if no environment variables are set

- **Import Script Enhancement** (`scripts/import_test_results.py`): Added `--report-base-url` command-line argument and auto-detection of sibling `report.html`/`log.html` files when importing test results from XML.

- **Dashboard Integration** (`superset/bootstrap_dashboards.py`): 
  - Added `report_url` and `log_url` to the test results table view
  - Created new "Run Provenance" dashboard chart displaying test run context including URLs, git info, and host details
  - Updated existing charts to include additional columns for better visibility

- **Test Coverage**: Added comprehensive test suites covering:
  - URL building from various environment variables
  - Trailing slash handling in base URLs
  - Fallback behavior when no URLs are available
  - Auto-detection of sibling report files during import
  - Database storage and retrieval of URLs

## Implementation Details

- URL building handles trailing slashes gracefully to prevent double slashes in constructed URLs
- The detection strategy allows flexibility across different CI/CD systems and local development environments
- All changes are backward compatible; existing test runs will have `NULL` values for the new columns
- The new dashboard chart provides visibility into test run provenance including environment details and direct links to reports

https://claude.ai/code/session_017bokyr4Yq7uxQeSiMsHAg8