### PR TITLE
Increase default timeout to 5400s (90 min) for LLM operations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,13 +35,13 @@ LLM_PROVIDER=ollama
 # Ollama endpoint for LLM tests
 OLLAMA_ENDPOINT=http://localhost:11434
 DEFAULT_MODEL=phi4:14b
-# Timeout in seconds for Ollama generate requests (increase for large models)
-OLLAMA_TIMEOUT=300
+# Timeout in seconds for Ollama generate requests (90 min default for large models)
+OLLAMA_TIMEOUT=5400
 
 # OpenAI / OpenAI-compatible API settings (used when LLM_PROVIDER=openai)
 OPENAI_API_KEY=
 OPENAI_BASE_URL=https://api.openai.com/v1
-OPENAI_TIMEOUT=120
+OPENAI_TIMEOUT=5400
 
 # Comma-separated list of Ollama node hostnames for monitoring.
 # With host networking (default Docker setup), localhost and LAN names

--- a/ai/DEV.md
+++ b/ai/DEV.md
@@ -48,7 +48,7 @@ The `.env` file is loaded automatically by:
 | `DATABASE_HOST` | Hostname for DB (CI builds `DATABASE_URL` from this) | `localhost` | .gitlab-ci.yml |
 | `DEFAULT_MODEL` | LLM model for tests | `gpt-oss:20b` (CI: `qwen3.5:27b`) | ollama.py, keywords, listeners, scripts |
 | `OLLAMA_ENDPOINT` | Ollama API URL | `http://localhost:11434` | ollama.py, pre_run_modifier, listeners, ci/test.sh |
-| `OLLAMA_TIMEOUT` | Request timeout in seconds | `120` (code), `300` (.env.example) | ollama.py, keywords, safety_keywords, Robot resources |
+| `OLLAMA_TIMEOUT` | Request timeout in seconds | `5400` (90 min) | ollama.py, keywords, safety_keywords, Robot resources |
 
 ### Node Discovery
 

--- a/robot/resources/llm_setup.resource
+++ b/robot/resources/llm_setup.resource
@@ -8,14 +8,14 @@ Documentation     Shared LLM availability verification for test suite setups.
 Library           rfc.keywords.LLMKeywords    WITH NAME    LLM
 
 *** Variables ***
-${LLM_VERIFY_TIMEOUT}    %{OLLAMA_TIMEOUT=120}
+${LLM_VERIFY_TIMEOUT}    %{OLLAMA_TIMEOUT=5400}
 
 *** Keywords ***
 Verify LLM Available
     [Documentation]    Verify the LLM endpoint is reachable and the model responds.
     ...    Fails the suite with a fatal error if the LLM is not available,
     ...    preventing all tests in the suite from running.
-    ...    Timeout is read from OLLAMA_TIMEOUT env var (default: 120s).
+    ...    Timeout is read from OLLAMA_TIMEOUT env var (default: 5400s / 90 min).
     LLM.Wait For LLM    timeout=${LLM_VERIFY_TIMEOUT}
     ${response}=    LLM.Ask LLM    Say hello in one word.
     Should Not Be Empty    ${response}    LLM returned empty response — model may not be loaded

--- a/src/rfc/ceo_keywords.py
+++ b/src/rfc/ceo_keywords.py
@@ -32,7 +32,7 @@ from .llm_client import create_provider
 from .multi_grader import MultiGrader
 from .web_cache import SearchResult, WebSearchCache
 
-_DEFAULT_TIMEOUT = 120
+_DEFAULT_TIMEOUT = 5400
 
 
 class CEOKeywords:

--- a/src/rfc/keywords.py
+++ b/src/rfc/keywords.py
@@ -8,7 +8,7 @@ from .llm_client import create_provider
 from .ollama import OllamaClient
 from .grader import Grader
 
-_DEFAULT_TIMEOUT = 120
+_DEFAULT_TIMEOUT = 5400
 
 
 class LLMKeywords:
@@ -68,7 +68,7 @@ class LLMKeywords:
         return result.score, result.reason
 
     @keyword("Wait For LLM")
-    def wait_for_llm(self, timeout: int = 120, poll_interval: int = 2) -> bool:
+    def wait_for_llm(self, timeout: int = 5400, poll_interval: int = 2) -> bool:
         """Wait until the LLM is available and not busy.
 
         For Ollama providers, polls the /api/ps endpoint to detect when
@@ -76,7 +76,7 @@ class LLMKeywords:
         returns True immediately (no queue detection available).
 
         Args:
-            timeout: Maximum seconds to wait (default 120).
+            timeout: Maximum seconds to wait (default 5400 / 90 min).
             poll_interval: Seconds between polling attempts (default 2).
 
         Returns:

--- a/src/rfc/ollama.py
+++ b/src/rfc/ollama.py
@@ -42,7 +42,7 @@ class OllamaClient:
     integration point for all Ollama interactions.
     """
 
-    _DEFAULT_TIMEOUT = 120
+    _DEFAULT_TIMEOUT = 5400
 
     def __init__(
         self,
@@ -236,15 +236,18 @@ class OllamaClient:
         except Exception:
             return False
 
-    def wait_until_ready(self, timeout: int = 120, poll_interval: int = 2) -> bool:
+    def wait_until_ready(self, timeout: int = 5400, poll_interval: int = 2) -> bool:
         """Wait until Ollama is available and not busy processing another request.
 
         Polls the /api/ps endpoint to detect when the LLM is idle.
         This prevents timeout errors caused by sending a request while
         Ollama is still processing a previous one.
 
+        Logs a warning after 1 minute, then every 5 minutes, so long
+        waits are visible without flooding the log.
+
         Args:
-            timeout: Maximum seconds to wait.
+            timeout: Maximum seconds to wait (default 5400 / 90 min).
             poll_interval: Seconds between checks.
 
         Returns:
@@ -259,7 +262,17 @@ class OllamaClient:
             raise ValueError(f"poll_interval must be >= 1, got {poll_interval}")
 
         start = time.time()
+        next_warn_at = 60  # first warning after 1 minute
+        warn_interval = 300  # then every 5 minutes
         while time.time() - start < timeout:
+            elapsed = int(time.time() - start)
+            if elapsed >= next_warn_at:
+                logger.warn(
+                    f"Still waiting for Ollama after {elapsed}s — "
+                    f"timeout in {timeout - elapsed}s"
+                )
+                next_warn_at += warn_interval
+
             if not self.is_available():
                 logger.info("Ollama endpoint not available yet, waiting...")
                 time.sleep(poll_interval)

--- a/src/rfc/openai_client.py
+++ b/src/rfc/openai_client.py
@@ -15,7 +15,7 @@ class OpenAIClient:
     (Together, Groq, Fireworks, etc.) by setting base_url.
     """
 
-    _DEFAULT_TIMEOUT = 120
+    _DEFAULT_TIMEOUT = 5400
 
     def __init__(
         self,

--- a/src/rfc/safety_keywords.py
+++ b/src/rfc/safety_keywords.py
@@ -7,7 +7,7 @@ from typing import Dict, Any, List, Optional
 from .llm_client import create_provider
 from .safety_grader import SafetyGrader
 
-_DEFAULT_TIMEOUT = 120
+_DEFAULT_TIMEOUT = 5400
 
 
 class SafetyKeywords:

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -13,7 +13,7 @@ class TestLLMKeywordsInit:
     @patch("rfc.keywords.Grader")
     def test_default_init(self, MockGrader, mock_create):
         LLMKeywords()
-        mock_create.assert_called_once_with(timeout=120, max_retries=2)
+        mock_create.assert_called_once_with(timeout=5400, max_retries=2)
         MockGrader.assert_called_once_with(mock_create.return_value)
 
     @patch("rfc.keywords.create_provider")

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -17,7 +17,7 @@ class TestOllamaClientInit:
         assert client.model == os.getenv("DEFAULT_MODEL", "phi4:14b")
         assert client.temperature == 0.0
         assert client.max_tokens == 256
-        assert client.timeout == 120
+        assert client.timeout == 5400
         assert client.max_retries == 2
 
     @patch.dict(os.environ, {"OLLAMA_ENDPOINT": "http://gpu1:11434"})
@@ -356,6 +356,62 @@ class TestWaitUntilReady:
     def test_invalid_poll_interval(self):
         with pytest.raises(ValueError, match="poll_interval must be >= 1"):
             OllamaClient().wait_until_ready(poll_interval=0)
+
+    @patch("rfc.ollama.logger")
+    @patch("rfc.ollama.time.sleep")
+    @patch("rfc.ollama.time.time")
+    @patch("rfc.ollama.requests.get")
+    def test_warns_after_one_minute(self, mock_get, mock_time, mock_sleep, mock_logger):
+        """Warning is logged after 60s of waiting, then every 5 minutes."""
+        # Simulate: endpoint available but busy, time advancing past 60s
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+
+        # First few calls: busy (models running), then idle (empty)
+        busy_resp = MagicMock()
+        busy_resp.status_code = 200
+        busy_resp.raise_for_status = MagicMock()
+        busy_resp.json.return_value = {"models": [{"name": "phi4:14b"}]}
+
+        idle_resp = MagicMock()
+        idle_resp.status_code = 200
+        idle_resp.raise_for_status = MagicMock()
+        idle_resp.json.return_value = {"models": []}
+
+        # is_available (tags) and running_models (ps) alternate per loop
+        # Each loop: GET /api/tags (available check), GET /api/ps (running check)
+        mock_get.side_effect = [
+            mock_resp,  # is_available → 200
+            busy_resp,  # running_models → busy
+            mock_resp,  # is_available → 200
+            busy_resp,  # running_models → busy
+            mock_resp,  # is_available → 200
+            idle_resp,  # running_models → idle → done
+        ]
+
+        # Time progression: 0, 30, 61, 61, 65, 65, 70, 70
+        # (each loop checks time twice: once for while condition, once for elapsed)
+        mock_time.side_effect = [
+            0,    # start
+            0, 0,    # loop 1: while check, elapsed check
+            30, 30,  # loop 2: while check, elapsed check
+            61, 61,  # loop 3: while check, elapsed check — triggers warning
+        ]
+
+        client = OllamaClient()
+        result = client.wait_until_ready(timeout=5400, poll_interval=2)
+
+        assert result is True
+        # Verify warn was called with the "Still waiting" message
+        warn_calls = [
+            str(c) for c in mock_logger.warn.call_args_list
+            if "Still waiting for Ollama" in str(c)
+        ]
+        assert len(warn_calls) >= 1, (
+            f"Expected at least one 'Still waiting' warning, got: "
+            f"{mock_logger.warn.call_args_list}"
+        )
 
 
 class TestGenerateMetrics:

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -18,7 +18,7 @@ class TestOpenAIClientInit:
         assert client.model == os.getenv("DEFAULT_MODEL", "gpt-4o-mini")
         assert client.temperature == 0.0
         assert client.max_tokens == 256
-        assert client.timeout == 120
+        assert client.timeout == 5400
         assert client.max_retries == 2
 
     @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test", "OPENAI_TIMEOUT": "300"})

--- a/tests/test_safety_keywords.py
+++ b/tests/test_safety_keywords.py
@@ -11,7 +11,7 @@ class TestSafetyKeywordsInit:
     @patch("rfc.safety_keywords.SafetyGrader")
     def test_default_init(self, MockGrader, mock_create):
         kw = SafetyKeywords()
-        mock_create.assert_called_once_with(timeout=120, max_retries=2)
+        mock_create.assert_called_once_with(timeout=5400, max_retries=2)
         assert kw.safety_threshold == 0.95
         assert kw.test_results == []
 


### PR DESCRIPTION
## Summary
Increases the default timeout for LLM operations from 120 seconds to 5400 seconds (90 minutes) across all LLM clients and keywords to accommodate large model inference and prevent premature timeouts.

## Key Changes
- **OllamaClient**: Updated `_DEFAULT_TIMEOUT` from 120 to 5400 seconds and adjusted `wait_until_ready()` default timeout parameter
- **OpenAIClient**: Updated `_DEFAULT_TIMEOUT` from 120 to 5400 seconds
- **Keywords modules**: Updated default timeouts in `LLMKeywords`, `CEOKeywords`, and `SafetyKeywords` classes
- **Robot Framework resources**: Updated `LLM_VERIFY_TIMEOUT` variable default from 120 to 5400 seconds
- **Environment configuration**: Updated `.env.example` to reflect new 5400s default with clarifying comments about 90-minute timeout for large models
- **Documentation**: Updated `DEV.md` to document the new timeout value

## Implementation Details
- Added warning logging to `wait_until_ready()` that triggers after 60 seconds of waiting, then every 5 minutes thereafter, to provide visibility into long waits without log flooding
- Updated docstrings to clarify the new 90-minute default timeout
- All test assertions updated to expect the new 5400-second default
- Added comprehensive test case `test_warns_after_one_minute()` to verify warning behavior during extended waits

https://claude.ai/code/session_01ERTYZEEGwNsQ5tWHiW1ttt