### PR TITLE
Add Tron theme CSS and apply to bootstrap dashboards

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,7 @@ services:
     volumes:
       - ./superset/superset_config.py:/app/superset_config.py:ro
       - ./superset/bootstrap_dashboards.py:/app/bootstrap_dashboards.py:ro
+      - ./superset/themes:/app/themes:ro
     networks:
       - rfc-net
     entrypoint: /bin/bash

--- a/superset/bootstrap_dashboards.py
+++ b/superset/bootstrap_dashboards.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import sys
+from pathlib import Path
 from typing import Any, Dict, List
 
 logging.basicConfig(level=logging.INFO)
@@ -1320,7 +1321,12 @@ def _get_or_create_slice(db: Any, Slice: Any, cdef: Dict[str, Any]) -> Any:
 
 
 def _get_or_create_dashboard(
-    db: Any, Dashboard: Any, title: str, slug: str, slices: list
+    db: Any,
+    Dashboard: Any,
+    title: str,
+    slug: str,
+    slices: list,
+    css: str = "",
 ) -> Any:
     """Get an existing dashboard or create a new one with charts."""
     dashboard = db.session.query(Dashboard).filter_by(dashboard_title=title).first()
@@ -1330,10 +1336,16 @@ def _get_or_create_dashboard(
             slug=slug,
             position_json=_build_position_json(slices, title),
             published=True,
+            css=css,
         )
         dashboard.slices = slices
         db.session.add(dashboard)
         log.info("Created dashboard: %s", title)
+    else:
+        # Update CSS on existing dashboards
+        if css and dashboard.css != css:
+            dashboard.css = css
+            log.info("Updated CSS for dashboard: %s", title)
     return dashboard
 
 
@@ -1489,13 +1501,23 @@ def bootstrap() -> None:
             for cdef in _host_metrics_charts(datasets)
         ]
 
-        # ── 5. Dashboards ───────────────────────────────────────────
+        # ── 5. Load theme CSS ──────────────────────────────────────
+        _tron_css_path = Path(__file__).parent / "themes" / "tron.css"
+        if _tron_css_path.exists():
+            _tron_css = _tron_css_path.read_text()
+            log.info("Loaded Tron theme CSS from %s", _tron_css_path)
+        else:
+            _tron_css = ""
+            log.warning("Tron theme CSS not found at %s", _tron_css_path)
+
+        # ── 6. Dashboards ───────────────────────────────────────────
         _get_or_create_dashboard(
             db,
             Dashboard,
             "Robot Framework Test Results",
             "rfc-results",
             test_result_slices,
+            css=_tron_css,
         )
         _get_or_create_dashboard(
             db,
@@ -1503,6 +1525,7 @@ def bootstrap() -> None:
             "Pipeline Health",
             "rfc-pipelines",
             pipeline_slices,
+            css=_tron_css,
         )
         _get_or_create_dashboard(
             db,
@@ -1510,6 +1533,7 @@ def bootstrap() -> None:
             "Model Analytics",
             "rfc-models",
             model_slices,
+            css=_tron_css,
         )
         _get_or_create_dashboard(
             db,
@@ -1517,6 +1541,7 @@ def bootstrap() -> None:
             "Ollama Performance",
             "rfc-ollama",
             ollama_slices,
+            css=_tron_css,
         )
         _get_or_create_dashboard(
             db,
@@ -1524,6 +1549,7 @@ def bootstrap() -> None:
             "Host Metrics",
             "rfc-hosts",
             host_slices,
+            css=_tron_css,
         )
 
         db.session.commit()

--- a/superset/themes/tron.css
+++ b/superset/themes/tron.css
@@ -1,0 +1,326 @@
+/*
+ * Tron Theme for Apache Superset Dashboards
+ *
+ * Dark background with neon cyan accents inspired by the Tron aesthetic.
+ * Applied via the Dashboard.css field during bootstrap.
+ */
+
+/* ── Global / Body ───────────────────────────────────────────────────── */
+
+body {
+  background-color: #0c0c1d !important;
+  color: #e0e0e0 !important;
+}
+
+/* ── Dashboard background ────────────────────────────────────────────── */
+
+.dashboard {
+  background-color: #0c0c1d !important;
+}
+
+.dashboard-content {
+  background-color: #0c0c1d !important;
+}
+
+.grid-container {
+  background-color: #0c0c1d !important;
+}
+
+.gridComponent {
+  background-color: #0c0c1d !important;
+}
+
+/* ── Dashboard header ────────────────────────────────────────────────── */
+
+.dashboard-header {
+  background-color: #0a0a1a !important;
+  border-bottom: 1px solid #00fff9 !important;
+  box-shadow: 0 2px 12px rgba(0, 255, 249, 0.15) !important;
+}
+
+.header-title,
+.dashboard-title {
+  color: #00fff9 !important;
+  text-shadow: 0 0 8px rgba(0, 255, 249, 0.6) !important;
+  font-weight: 600 !important;
+}
+
+.editable-title input,
+.editable-title span {
+  color: #00fff9 !important;
+}
+
+/* ── Chart cards / containers ────────────────────────────────────────── */
+
+.chart-container,
+.slice_container,
+.dashboard-chart {
+  background-color: #12122a !important;
+  border: 1px solid rgba(0, 255, 249, 0.25) !important;
+  border-radius: 4px !important;
+  box-shadow: 0 0 10px rgba(0, 255, 249, 0.08),
+              inset 0 0 20px rgba(0, 255, 249, 0.03) !important;
+}
+
+.chart-container:hover,
+.slice_container:hover {
+  border-color: rgba(0, 255, 249, 0.5) !important;
+  box-shadow: 0 0 18px rgba(0, 255, 249, 0.15),
+              inset 0 0 20px rgba(0, 255, 249, 0.05) !important;
+}
+
+.dashboard-component-chart-holder {
+  background-color: #12122a !important;
+}
+
+/* ── Chart headers / titles ──────────────────────────────────────────── */
+
+.chart-header,
+.header-title .editable-title,
+.slice_container .header {
+  background-color: #0e0e24 !important;
+  color: #00fff9 !important;
+  border-bottom: 1px solid rgba(0, 255, 249, 0.15) !important;
+}
+
+.chart-header span,
+.slice-header .header-title span {
+  color: #b0e0e0 !important;
+}
+
+/* ── Row backgrounds ─────────────────────────────────────────────────── */
+
+.grid-row,
+.dragdroppable-row {
+  background-color: transparent !important;
+}
+
+/* ── Tabs & navigation ───────────────────────────────────────────────── */
+
+.ant-tabs {
+  color: #e0e0e0 !important;
+}
+
+.ant-tabs-tab {
+  color: #7a7a9e !important;
+}
+
+.ant-tabs-tab-active,
+.ant-tabs-tab.ant-tabs-tab-active .ant-tabs-tab-btn {
+  color: #00fff9 !important;
+}
+
+.ant-tabs-ink-bar {
+  background-color: #00fff9 !important;
+  box-shadow: 0 0 6px rgba(0, 255, 249, 0.5) !important;
+}
+
+.ant-tabs-nav {
+  background-color: #0a0a1a !important;
+}
+
+/* ── Filter bar ──────────────────────────────────────────────────────── */
+
+.filter-bar,
+.dashboard-filters-panel {
+  background-color: #0e0e24 !important;
+  border-right: 1px solid rgba(0, 255, 249, 0.2) !important;
+}
+
+.filter-bar .filter-item-wrapper {
+  border-bottom: 1px solid rgba(0, 255, 249, 0.1) !important;
+}
+
+/* ── Form controls & inputs ──────────────────────────────────────────── */
+
+.ant-select,
+.ant-input,
+.ant-picker {
+  background-color: #1a1a35 !important;
+  border-color: rgba(0, 255, 249, 0.3) !important;
+  color: #e0e0e0 !important;
+}
+
+.ant-select-selector {
+  background-color: #1a1a35 !important;
+  border-color: rgba(0, 255, 249, 0.3) !important;
+  color: #e0e0e0 !important;
+}
+
+.ant-select-dropdown {
+  background-color: #12122a !important;
+  border: 1px solid rgba(0, 255, 249, 0.2) !important;
+}
+
+.ant-select-item {
+  color: #e0e0e0 !important;
+}
+
+.ant-select-item-option-active,
+.ant-select-item-option-selected {
+  background-color: rgba(0, 255, 249, 0.1) !important;
+}
+
+/* ── Buttons ─────────────────────────────────────────────────────────── */
+
+.ant-btn-primary {
+  background-color: rgba(0, 255, 249, 0.15) !important;
+  border-color: #00fff9 !important;
+  color: #00fff9 !important;
+}
+
+.ant-btn-primary:hover {
+  background-color: rgba(0, 255, 249, 0.25) !important;
+  box-shadow: 0 0 8px rgba(0, 255, 249, 0.3) !important;
+}
+
+.ant-btn-default {
+  background-color: #1a1a35 !important;
+  border-color: rgba(0, 255, 249, 0.2) !important;
+  color: #b0e0e0 !important;
+}
+
+/* ── Table charts ────────────────────────────────────────────────────── */
+
+.superset-legacy-chart table,
+table.table {
+  color: #e0e0e0 !important;
+}
+
+.superset-legacy-chart th,
+table.table th {
+  background-color: #0e0e24 !important;
+  color: #00fff9 !important;
+  border-bottom: 2px solid rgba(0, 255, 249, 0.3) !important;
+}
+
+.superset-legacy-chart td,
+table.table td {
+  background-color: #12122a !important;
+  border-bottom: 1px solid rgba(0, 255, 249, 0.08) !important;
+}
+
+.superset-legacy-chart tr:hover td,
+table.table tbody tr:hover td {
+  background-color: rgba(0, 255, 249, 0.06) !important;
+}
+
+/* Pivot table and data table overrides */
+.dt-is-filter {
+  background-color: rgba(0, 255, 249, 0.1) !important;
+}
+
+/* ── ECharts overrides ───────────────────────────────────────────────── */
+
+/* Tooltip */
+.echarts-tooltip {
+  background-color: #0e0e24 !important;
+  border: 1px solid rgba(0, 255, 249, 0.4) !important;
+  color: #e0e0e0 !important;
+  box-shadow: 0 0 12px rgba(0, 255, 249, 0.15) !important;
+}
+
+/* ── Big Number charts ───────────────────────────────────────────────── */
+
+.superset-legacy-chart-big-number .header-line,
+.big-number .header-line {
+  color: #00fff9 !important;
+  text-shadow: 0 0 6px rgba(0, 255, 249, 0.4) !important;
+}
+
+.superset-legacy-chart-big-number .subheader-line,
+.big-number .subheader-line {
+  color: #7a9e9e !important;
+}
+
+/* ── Modals & popups ─────────────────────────────────────────────────── */
+
+.ant-modal-content {
+  background-color: #12122a !important;
+  border: 1px solid rgba(0, 255, 249, 0.2) !important;
+  color: #e0e0e0 !important;
+}
+
+.ant-modal-header {
+  background-color: #0e0e24 !important;
+  border-bottom: 1px solid rgba(0, 255, 249, 0.15) !important;
+}
+
+.ant-modal-title {
+  color: #00fff9 !important;
+}
+
+/* ── Scrollbars ──────────────────────────────────────────────────────── */
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: #0c0c1d;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(0, 255, 249, 0.2);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(0, 255, 249, 0.4);
+}
+
+/* ── Loading indicators ──────────────────────────────────────────────── */
+
+.loading-indicator {
+  border-color: rgba(0, 255, 249, 0.3) !important;
+  border-top-color: #00fff9 !important;
+}
+
+/* ── Miscellaneous ───────────────────────────────────────────────────── */
+
+.ant-card {
+  background-color: #12122a !important;
+  border-color: rgba(0, 255, 249, 0.15) !important;
+  color: #e0e0e0 !important;
+}
+
+.ant-divider {
+  border-color: rgba(0, 255, 249, 0.12) !important;
+}
+
+/* Alert and info boxes */
+.ant-alert {
+  background-color: #1a1a35 !important;
+  border-color: rgba(0, 255, 249, 0.2) !important;
+  color: #e0e0e0 !important;
+}
+
+/* Links */
+a {
+  color: #00d4ce !important;
+}
+
+a:hover {
+  color: #00fff9 !important;
+  text-shadow: 0 0 4px rgba(0, 255, 249, 0.3) !important;
+}
+
+/* Breadcrumbs */
+.ant-breadcrumb,
+.ant-breadcrumb a {
+  color: #7a9e9e !important;
+}
+
+/* ── Markdown components ─────────────────────────────────────────────── */
+
+.dashboard-markdown .markdown-container {
+  background-color: #12122a !important;
+  color: #e0e0e0 !important;
+}
+
+.dashboard-markdown h1,
+.dashboard-markdown h2,
+.dashboard-markdown h3 {
+  color: #00fff9 !important;
+}


### PR DESCRIPTION
## Summary
This PR introduces a new "Tron" theme for Apache Superset dashboards with a dark background and neon cyan accents, and applies it to all bootstrap dashboards during initialization.

## Key Changes
- **New Tron Theme CSS** (`superset/themes/tron.css`): Added a comprehensive 326-line stylesheet featuring:
  - Dark background (#0c0c1d) with neon cyan (#00fff9) accent colors
  - Styled components including dashboard headers, chart containers, tabs, filters, form controls, tables, and modals
  - Hover effects and glow shadows for interactive elements
  - Custom scrollbar styling
  - Support for various chart types (ECharts, Big Number, tables, etc.)

- **Bootstrap Dashboard Updates** (`superset/bootstrap_dashboards.py`):
  - Added `css` parameter to `_get_or_create_dashboard()` function to support custom CSS
  - Implemented CSS loading from `superset/themes/tron.css` during bootstrap
  - Applied Tron theme CSS to all five bootstrap dashboards (Robot Framework Test Results, Pipeline Health, Model Analytics, Ollama Performance, Host Metrics)
  - Added logic to update CSS on existing dashboards if it differs from the loaded theme

- **Docker Compose Configuration** (`docker-compose.yml`):
  - Added volume mount for `superset/themes` directory to make theme files accessible to the container

## Implementation Details
- Theme CSS is loaded once during bootstrap and applied to all dashboards via the Dashboard.css field
- The implementation gracefully handles missing theme files with appropriate logging
- Existing dashboards are updated with the new CSS if they don't already have it
- All styling uses `!important` flags to ensure theme application across Superset's component hierarchy

https://claude.ai/code/session_01MZbgYafipDBLZD5AKLK811