### PR TITLE
Rename diagnose-superset target to superset-diagnose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ export
         code-quality-lint code-quality-format code-quality-typecheck \
         code-quality-check code-quality-coverage code-quality-audit \
         docker-up docker-down docker-restart docker-logs bootstrap \
-        cache-flush superset-export superset-import diagnose-superset \
+        cache-flush superset-export superset-import superset-diagnose \
         ci-generate ci-report ci-deploy \
         opencode-pipeline-review opencode-local-review opencode-audit-markdown \
         build-check docker-build-app docker-test-app version
@@ -152,7 +152,7 @@ superset-export: ## Export Superset dashboards to backups/ directory
 		"./backups/superset_export_$${TIMESTAMP}.zip" && \
 	echo "Exported to backups/superset_export_$${TIMESTAMP}.zip"
 
-diagnose-superset: ## Diagnose Superset database connectivity and data pipeline
+superset-diagnose: ## Diagnose Superset database connectivity and data pipeline
 	uv run python scripts/diagnose_superset_db.py
 
 superset-import: ## Import Superset dashboards from ZIP: make superset-import FILE=backups/export.zip


### PR DESCRIPTION
## Summary
Standardized the Makefile target naming convention by renaming the `diagnose-superset` target to `superset-diagnose` to maintain consistency with other Superset-related targets.

## Changes
- Renamed Makefile target from `diagnose-superset` to `superset-diagnose`
- Updated the target in the `.PHONY` declaration to reflect the new name
- Updated the target definition and its help text

## Details
This change improves naming consistency across the Makefile. Other Superset-related targets follow the `superset-*` naming pattern (e.g., `superset-export`, `superset-import`), and this rename brings the diagnostics target in line with that convention.

https://claude.ai/code/session_01AtXW3prccHms6dWU3cyFf8