### PR TITLE
Support performance fingerprints for databases without hostname column

### DIFF
--- a/src/rfc/analytics.py
+++ b/src/rfc/analytics.py
@@ -108,6 +108,14 @@ CREATE TABLE IF NOT EXISTS analytics_performance_fingerprints (
 """
 
 
+def _has_column(
+    conn: sqlite3.Connection, table: str, column: str
+) -> bool:
+    """Check whether *table* has a column named *column*."""
+    cursor = conn.execute(f"PRAGMA table_info({table})")  # noqa: S608
+    return any(row[1] == column for row in cursor.fetchall())
+
+
 def _ensure_schema(conn: sqlite3.Connection) -> None:
     """Create analytics tables if they don't exist."""
     conn.executescript(ANALYTICS_SCHEMA)
@@ -507,14 +515,28 @@ def compute_performance_fingerprints(conn: sqlite3.Connection) -> int:
     _ensure_schema(conn)
     now = datetime.now().isoformat()
 
+    has_hostname = _has_column(conn, "test_runs", "hostname")
+
     # Get all test/model/host combos with durations
-    combos = conn.execute(
-        """SELECT tr.test_name, r.model_name, r.hostname
-           FROM test_results tr
-           JOIN test_runs r ON tr.run_id = r.id
-           GROUP BY tr.test_name, r.model_name, r.hostname
-           HAVING COUNT(*) >= 2"""
-    ).fetchall()
+    if has_hostname:
+        combos = conn.execute(
+            """SELECT tr.test_name, r.model_name, r.hostname
+               FROM test_results tr
+               JOIN test_runs r ON tr.run_id = r.id
+               GROUP BY tr.test_name, r.model_name, r.hostname
+               HAVING COUNT(*) >= 2"""
+        ).fetchall()
+    else:
+        combos = [
+            (row[0], row[1], None)
+            for row in conn.execute(
+                """SELECT tr.test_name, r.model_name
+                   FROM test_results tr
+                   JOIN test_runs r ON tr.run_id = r.id
+                   GROUP BY tr.test_name, r.model_name
+                   HAVING COUNT(*) >= 2"""
+            ).fetchall()
+        ]
 
     if not combos:
         return 0
@@ -522,14 +544,23 @@ def compute_performance_fingerprints(conn: sqlite3.Connection) -> int:
     count = 0
     for test_name, model_name, hostname in combos:
         # Get per-run durations for this test
-        durations = conn.execute(
-            """SELECT r.duration_seconds / NULLIF(r.total_tests, 0)
-               FROM test_results tr
-               JOIN test_runs r ON tr.run_id = r.id
-               WHERE tr.test_name = ? AND r.model_name = ?
-               AND (r.hostname = ? OR (r.hostname IS NULL AND ? IS NULL))""",
-            (test_name, model_name, hostname, hostname),
-        ).fetchall()
+        if has_hostname:
+            durations = conn.execute(
+                """SELECT r.duration_seconds / NULLIF(r.total_tests, 0)
+                   FROM test_results tr
+                   JOIN test_runs r ON tr.run_id = r.id
+                   WHERE tr.test_name = ? AND r.model_name = ?
+                   AND (r.hostname = ? OR (r.hostname IS NULL AND ? IS NULL))""",
+                (test_name, model_name, hostname, hostname),
+            ).fetchall()
+        else:
+            durations = conn.execute(
+                """SELECT r.duration_seconds / NULLIF(r.total_tests, 0)
+                   FROM test_results tr
+                   JOIN test_runs r ON tr.run_id = r.id
+                   WHERE tr.test_name = ? AND r.model_name = ?""",
+                (test_name, model_name),
+            ).fetchall()
 
         dur_values = [d[0] for d in durations if d[0] is not None]
         if not dur_values:

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -321,6 +321,48 @@ class TestComputePerformanceFingerprints:
         assert count == 0
 
 
+    def test_no_hostname_column(self, db_conn: sqlite3.Connection) -> None:
+        """Fingerprints work when test_runs lacks a hostname column."""
+        # Create a schema without hostname
+        db_conn.executescript("""
+            DROP TABLE IF EXISTS test_runs;
+            CREATE TABLE test_runs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp DATETIME NOT NULL,
+                model_name TEXT NOT NULL,
+                test_suite TEXT NOT NULL,
+                total_tests INTEGER DEFAULT 0,
+                passed INTEGER DEFAULT 0,
+                failed INTEGER DEFAULT 0,
+                skipped INTEGER DEFAULT 0,
+                duration_seconds REAL,
+                git_commit TEXT,
+                git_branch TEXT,
+                pipeline_url TEXT,
+                runner_id TEXT,
+                runner_tags TEXT,
+                rfc_version TEXT
+            );
+        """)
+        now = datetime.now()
+        for day in range(3):
+            ts = now - timedelta(days=2 - day)
+            cursor = db_conn.execute(
+                """INSERT INTO test_runs
+                   (timestamp, model_name, test_suite, total_tests,
+                    passed, failed, duration_seconds)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (ts.isoformat(), "llama3", "math", 2, 2, 0, 10.0),
+            )
+            run_id = cursor.lastrowid
+            _insert_result(db_conn, run_id, "test_0", "PASS")
+            _insert_result(db_conn, run_id, "test_1", "PASS")
+        db_conn.commit()
+
+        count = compute_performance_fingerprints(db_conn)
+        assert count >= 1
+
+
 class TestRefreshAll:
     def test_runs_all_computations(
         self, populated_db: sqlite3.Connection


### PR DESCRIPTION
## Summary
This PR adds backward compatibility for analytics databases that lack the `hostname` column in the `test_runs` table. The `compute_performance_fingerprints` function now gracefully handles both schema versions by detecting the column's presence and adjusting its queries accordingly.

## Key Changes
- Added `_has_column()` helper function to check for column existence in a table using `PRAGMA table_info`
- Modified `compute_performance_fingerprints()` to conditionally execute different SQL queries based on whether the `hostname` column exists:
  - When `hostname` exists: Groups and filters by test name, model name, and hostname (original behavior)
  - When `hostname` is absent: Groups and filters by test name and model name only
- Added test case `test_no_hostname_column()` to verify fingerprint computation works correctly on schemas without the hostname column

## Implementation Details
- The column detection is performed once at the start of `compute_performance_fingerprints()` to avoid repeated checks
- SQL queries are duplicated for each code path to maintain clarity and avoid complex conditional logic within query strings
- The `hostname` parameter is set to `None` when the column doesn't exist, ensuring consistent tuple structure across both code paths

https://claude.ai/code/session_01RVda5b6MAyoKnG9Gemp33n