### PR TITLE
Add post-run database verification to local model test runner

### DIFF
--- a/scripts/run_local_models.py
+++ b/scripts/run_local_models.py
@@ -38,6 +38,7 @@ import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -372,6 +373,131 @@ def _print_summary(results: list[RunResult]) -> None:
     print()
 
 
+# ---------------------------------------------------------------------------
+# ANSI helpers (mirroring diagnose_superset_db.py)
+# ---------------------------------------------------------------------------
+
+_GREEN = "\033[92m"
+_RED = "\033[91m"
+_YELLOW = "\033[93m"
+_BOLD = "\033[1m"
+_RESET = "\033[0m"
+
+
+def _db_ok(msg: str) -> None:
+    print(f"  {_GREEN}OK{_RESET}  {msg}")
+
+
+def _db_fail(msg: str) -> None:
+    print(f"  {_RED}FAIL{_RESET}  {msg}")
+
+
+def _db_warn(msg: str) -> None:
+    print(f"  {_YELLOW}WARN{_RESET}  {msg}")
+
+
+def _db_heading(msg: str) -> None:
+    print(f"\n{_BOLD}── {msg} ──{_RESET}")
+
+
+# ---------------------------------------------------------------------------
+# Post-run database verification
+# ---------------------------------------------------------------------------
+
+
+def verify_db_results(
+    results: list[RunResult],
+    *,
+    dry_run: bool = False,
+) -> bool:
+    """Check that test runs were recorded in the database.
+
+    Returns True if verification passed or was skipped, False on failure.
+    """
+    if dry_run:
+        return True
+
+    if not results:
+        return True
+
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        _db_heading("Database Verification")
+        _db_warn(
+            "DATABASE_URL not set — skipping DB verification.\n"
+            "        → Results may have been written to local SQLite instead.\n"
+            "        → Set DATABASE_URL in .env for PostgreSQL archival."
+        )
+        return True
+
+    _db_heading("Database Verification")
+    expected_count = len(results)
+
+    try:
+        from rfc.test_database import TestDatabase
+
+        db = TestDatabase(database_url=database_url)
+    except Exception as e:
+        _db_fail(
+            f"Cannot connect to database: {e}\n"
+            "        → Check DATABASE_URL and database connectivity.\n"
+            "        → Run: make superset-diagnose"
+        )
+        return False
+
+    try:
+        recent_runs = db.get_recent_runs(limit=expected_count * 2)
+    except Exception as e:
+        _db_fail(f"Failed to query recent runs: {e}")
+        return False
+
+    # Count runs within the last 30 minutes.
+    cutoff = datetime.now(tz=timezone.utc) - timedelta(minutes=30)
+    recent_count = 0
+    for run in recent_runs:
+        ts = run.get("timestamp", "")
+        if isinstance(ts, str):
+            try:
+                run_time = datetime.fromisoformat(ts)
+                if run_time.tzinfo is None:
+                    run_time = run_time.replace(tzinfo=timezone.utc)
+            except ValueError:
+                continue
+        elif isinstance(ts, datetime):
+            run_time = ts
+            if run_time.tzinfo is None:
+                run_time = run_time.replace(tzinfo=timezone.utc)
+        else:
+            continue
+
+        if run_time >= cutoff:
+            recent_count += 1
+
+    if recent_count >= expected_count:
+        _db_ok(
+            f"Found {recent_count} recent test run(s) in database "
+            f"(expected {expected_count})"
+        )
+        return True
+    elif recent_count > 0:
+        _db_warn(
+            f"Found {recent_count} of {expected_count} expected test run(s) "
+            f"in database (partial archival).\n"
+            "        → Some runs may not have been archived.\n"
+            "        → Check Robot output for 'DbListener: FAILED to archive results'."
+        )
+        return True
+    else:
+        _db_fail(
+            f"Found 0 of {expected_count} expected test run(s) in database.\n"
+            "        → Data pipeline failure: no results were archived.\n"
+            "        → Check DATABASE_URL is correct.\n"
+            "        → Check Robot output for DbListener errors.\n"
+            "        → Run: make superset-diagnose"
+        )
+        return False
+
+
 def run_iteration_loop(
     config: dict[str, Any],
     *,
@@ -443,6 +569,12 @@ def run_iteration_loop(
 
             results = run_model_suites(config, nodes_with_models, dry_run=dry_run)
             _print_summary(results)
+
+            # Verify data landed in the database.
+            if not dry_run:
+                db_ok = verify_db_results(results)
+                if not db_ok:
+                    had_failure = True
 
             pass_had_failure = any(r.returncode != 0 for r in results)
             if pass_had_failure:

--- a/tests/test_run_local_models.py
+++ b/tests/test_run_local_models.py
@@ -9,12 +9,14 @@ from unittest.mock import MagicMock, patch
 import yaml
 
 from scripts.run_local_models import (
+    RunResult,
     _build_robot_command,
     _sanitize_name,
     discover_local_models,
     load_local_config,
     run_iteration_loop,
     run_model_suites,
+    verify_db_results,
 )
 
 
@@ -550,3 +552,78 @@ class TestRunIterationLoop:
         """Each iteration re-discovers nodes/models (nodes may change)."""
         run_iteration_loop(_ITER_CONFIG, iterations=3)
         assert mock_discover.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# verify_db_results
+# ---------------------------------------------------------------------------
+
+_SAMPLE_RESULTS = [
+    RunResult(node="host1", model="llama3", suite="math", returncode=0, output_dir="r/h/m"),
+    RunResult(node="host1", model="mistral", suite="math", returncode=0, output_dir="r/h/m2"),
+]
+
+
+def _recent_timestamp() -> str:
+    """Return an ISO timestamp from a few minutes ago."""
+    from datetime import datetime, timedelta, timezone
+
+    return (datetime.now(tz=timezone.utc) - timedelta(minutes=2)).isoformat()
+
+
+class TestVerifyDbResults:
+    """Tests for verify_db_results() — post-run DB confirmation."""
+
+    def test_skips_on_dry_run(self) -> None:
+        """Dry-run mode should skip DB check entirely and return True."""
+        assert verify_db_results(_SAMPLE_RESULTS, dry_run=True) is True
+
+    def test_skips_when_no_results(self) -> None:
+        """No results means nothing to verify."""
+        assert verify_db_results([], dry_run=False) is True
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_skips_when_no_database_url(self) -> None:
+        """Without DATABASE_URL, skip gracefully and return True."""
+        # Ensure DATABASE_URL is not set
+        import os
+
+        os.environ.pop("DATABASE_URL", None)
+        assert verify_db_results(_SAMPLE_RESULTS) is True
+
+    @patch("rfc.test_database.TestDatabase")
+    @patch.dict("os.environ", {"DATABASE_URL": "postgresql://rfc:pass@db:5433/rfc"})
+    def test_passes_when_recent_runs_found(self, mock_db_cls: MagicMock) -> None:
+        """Returns True when DB has recent runs matching expected count."""
+        mock_db = mock_db_cls.return_value
+        mock_db.get_recent_runs.return_value = [
+            {"id": 1, "timestamp": _recent_timestamp(), "model_name": "llama3"},
+            {"id": 2, "timestamp": _recent_timestamp(), "model_name": "mistral"},
+        ]
+        assert verify_db_results(_SAMPLE_RESULTS) is True
+
+    @patch("rfc.test_database.TestDatabase")
+    @patch.dict("os.environ", {"DATABASE_URL": "postgresql://rfc:pass@db:5433/rfc"})
+    def test_fails_when_no_recent_runs(self, mock_db_cls: MagicMock) -> None:
+        """Returns False (hard failure) when DB has zero recent runs."""
+        mock_db = mock_db_cls.return_value
+        mock_db.get_recent_runs.return_value = []
+        assert verify_db_results(_SAMPLE_RESULTS) is False
+
+    @patch("rfc.test_database.TestDatabase")
+    @patch.dict("os.environ", {"DATABASE_URL": "postgresql://rfc:pass@db:5433/rfc"})
+    def test_warns_on_partial_archival(self, mock_db_cls: MagicMock) -> None:
+        """Partial archival (some rows, not all) returns True with warning."""
+        mock_db = mock_db_cls.return_value
+        mock_db.get_recent_runs.return_value = [
+            {"id": 1, "timestamp": _recent_timestamp(), "model_name": "llama3"},
+        ]
+        # 2 results expected but only 1 in DB — still True (partial is not hard fail)
+        assert verify_db_results(_SAMPLE_RESULTS) is True
+
+    @patch("rfc.test_database.TestDatabase")
+    @patch.dict("os.environ", {"DATABASE_URL": "postgresql://rfc:pass@db:5433/rfc"})
+    def test_handles_db_connection_error(self, mock_db_cls: MagicMock) -> None:
+        """DB connection failure returns False (hard failure)."""
+        mock_db_cls.side_effect = Exception("Connection refused")
+        assert verify_db_results(_SAMPLE_RESULTS) is False


### PR DESCRIPTION
## Summary
This PR adds database verification functionality to the local model test runner to confirm that test results are properly archived after execution. It includes colored console output helpers, a verification function that checks for recent test runs in the database, and comprehensive test coverage.

## Key Changes
- **ANSI color helpers**: Added `_db_ok()`, `_db_fail()`, `_db_warn()`, and `_db_heading()` functions to provide consistent colored output (mirroring `diagnose_superset_db.py`)
- **Database verification function**: Implemented `verify_db_results()` that:
  - Skips verification in dry-run mode or when no results exist
  - Gracefully handles missing `DATABASE_URL` environment variable
  - Connects to the database and queries recent test runs
  - Counts runs from the last 30 minutes and compares against expected count
  - Returns `True` for success/warnings, `False` only for hard failures (no runs found or connection error)
  - Handles both string (ISO format) and datetime timestamp formats
- **Integration into test loop**: Added call to `verify_db_results()` in `run_iteration_loop()` after test execution to report archival status
- **Comprehensive test suite**: Added 7 test cases covering:
  - Dry-run skipping
  - Empty results handling
  - Missing DATABASE_URL graceful skip
  - Successful verification with recent runs
  - Hard failure when no runs found
  - Partial archival warning
  - Database connection error handling

## Notable Implementation Details
- Verification is non-blocking for partial archival (returns `True` with warning) but fails hard (`False`) only when zero runs are found or connection fails
- Timestamp handling is robust, supporting both ISO string and datetime objects with timezone normalization
- Uses a 30-minute lookback window to identify recent runs
- Provides actionable error messages with suggestions (e.g., "Run: make superset-diagnose")

https://claude.ai/code/session_01PRZhjiuhgVYDufm7aywccP