### PR TITLE
Add output_xml_url and output_xml_gz columns to test_runs table

### DIFF
--- a/src/rfc/test_database.py
+++ b/src/rfc/test_database.py
@@ -289,6 +289,9 @@ class _SQLAlchemyBackend(_Backend):
         "DROP TABLE IF EXISTS analytics_model_comparison CASCADE",
         "DROP TABLE IF EXISTS analytics_regression_alerts CASCADE",
         "DROP TABLE IF EXISTS analytics_performance_fingerprints CASCADE",
+        # Add columns that may be missing from pre-existing test_runs tables.
+        "ALTER TABLE test_runs ADD COLUMN IF NOT EXISTS output_xml_url TEXT",
+        "ALTER TABLE test_runs ADD COLUMN IF NOT EXISTS output_xml_gz BYTEA",
     ]
 
     def __init__(self, database_url: str):

--- a/tests/test_test_database.py
+++ b/tests/test_test_database.py
@@ -289,6 +289,32 @@ class TestSQLAlchemyMigrations:
         assert len(executed_sql) == remaining
 
 
+class TestOutputXmlColumnMigrations:
+    """Verify migrations add output_xml_url and output_xml_gz columns."""
+
+    def test_migrations_include_output_xml_url_alter(self) -> None:
+        """Ensure ALTER TABLE for output_xml_url is in PG migrations."""
+        alter_sqls = [
+            s
+            for s in _SQLAlchemyBackend._PG_MIGRATIONS
+            if "output_xml_url" in s and "ALTER" in s.upper()
+        ]
+        assert len(alter_sqls) == 1, (
+            "Expected exactly one ALTER TABLE migration for output_xml_url"
+        )
+
+    def test_migrations_include_output_xml_gz_alter(self) -> None:
+        """Ensure ALTER TABLE for output_xml_gz is in PG migrations."""
+        alter_sqls = [
+            s
+            for s in _SQLAlchemyBackend._PG_MIGRATIONS
+            if "output_xml_gz" in s and "ALTER" in s.upper()
+        ]
+        assert len(alter_sqls) == 1, (
+            "Expected exactly one ALTER TABLE migration for output_xml_gz"
+        )
+
+
 class TestTableRowCount:
     def test_get_table_row_count(self, tmp_path: object) -> None:
         db = TestDatabase(db_path=str(tmp_path / "test.db"))  # type: ignore[operator]


### PR DESCRIPTION
## Summary
This PR adds two new columns to the `test_runs` table via database migrations: `output_xml_url` (TEXT) and `output_xml_gz` (BYTEA). These columns are added conditionally to support pre-existing test_runs tables that may be missing these fields.

## Changes
- **Database Migration**: Added two ALTER TABLE statements to `_SQLAlchemyBackend._PG_MIGRATIONS` that conditionally add the new columns to the `test_runs` table if they don't already exist
  - `output_xml_url TEXT` - for storing XML output URLs
  - `output_xml_gz BYTEA` - for storing gzip-compressed XML output

- **Test Coverage**: Added `TestOutputXmlColumnMigrations` test class with two test methods to verify the migrations are properly included:
  - `test_migrations_include_output_xml_url_alter()` - ensures exactly one ALTER TABLE migration exists for `output_xml_url`
  - `test_migrations_include_output_xml_gz_alter()` - ensures exactly one ALTER TABLE migration exists for `output_xml_gz`

## Implementation Details
- Uses `IF NOT EXISTS` clause to safely handle both new and existing databases
- Migrations are added to the PostgreSQL-specific migration list
- Tests validate that migrations are present and properly formatted rather than testing actual migration execution

https://claude.ai/code/session_01JufDbx1tTCfd45DrHE4rX9