### PR TITLE
Add support for OpenAI token detail metrics (reasoning, cache, prediction)

### DIFF
--- a/src/rfc/db_listener.py
+++ b/src/rfc/db_listener.py
@@ -234,6 +234,14 @@ class DbListener(ListenerV3):
                 "load_duration_ns": metrics.get("load_duration_ns"),
                 "total_duration_ns": metrics.get("total_duration_ns"),
                 "tokens_per_second": metrics.get("eval_rate"),
+                "reasoning_tokens": metrics.get("reasoning_tokens"),
+                "cached_tokens": metrics.get("cached_tokens"),
+                "accepted_prediction_tokens": metrics.get(
+                    "accepted_prediction_tokens"
+                ),
+                "rejected_prediction_tokens": metrics.get(
+                    "rejected_prediction_tokens"
+                ),
             }
         )
         self._current_test_data = {}
@@ -336,6 +344,14 @@ class DbListener(ListenerV3):
                     tag_verify=_nvl(tc.get("tag_verify"), ""),
                     thinking_text=_nvl(tc.get("thinking_text"), ""),
                     thinking_tokens=_nvl(tc.get("thinking_tokens"), 0),
+                    reasoning_tokens=_nvl(tc.get("reasoning_tokens"), 0),
+                    cached_tokens=_nvl(tc.get("cached_tokens"), 0),
+                    accepted_prediction_tokens=_nvl(
+                        tc.get("accepted_prediction_tokens"), 0
+                    ),
+                    rejected_prediction_tokens=_nvl(
+                        tc.get("rejected_prediction_tokens"), 0
+                    ),
                     num_ctx=_nvl(tc.get("num_ctx"), 0),
                     num_predict=_nvl(tc.get("num_predict"), 0),
                     eval_count=_nvl(tc.get("eval_count"), 0),
@@ -460,6 +476,11 @@ def _extract_llm_metrics(metrics_json: Optional[str]) -> Dict[str, Any]:
         "eval_rate": data.get("eval_rate"),
         "num_ctx": data.get("num_ctx"),
         "num_predict": data.get("num_predict"),
+        # OpenAI token detail fields
+        "reasoning_tokens": data.get("reasoning_tokens"),
+        "cached_tokens": data.get("cached_tokens"),
+        "accepted_prediction_tokens": data.get("accepted_prediction_tokens"),
+        "rejected_prediction_tokens": data.get("rejected_prediction_tokens"),
     }
 
 

--- a/src/rfc/openai_client.py
+++ b/src/rfc/openai_client.py
@@ -145,11 +145,31 @@ class OpenAIClient:
 
 
 def _extract_metrics(data: Dict[str, Any], model: str) -> Dict[str, Any]:
-    """Extract usage metrics from an OpenAI chat completions response."""
+    """Extract usage metrics from an OpenAI chat completions response.
+
+    Maps prompt_tokens/completion_tokens to Ollama-equivalent names
+    (prompt_eval_count/eval_count) for database compatibility. Also
+    extracts nested detail fields: reasoning_tokens, cached_tokens,
+    accepted_prediction_tokens, rejected_prediction_tokens.
+    """
     usage = data.get("usage", {})
+    prompt_details = usage.get("prompt_tokens_details") or {}
+    completion_details = usage.get("completion_tokens_details") or {}
     return {
         "model_name": model,
         "prompt_tokens": usage.get("prompt_tokens"),
         "completion_tokens": usage.get("completion_tokens"),
         "total_tokens": usage.get("total_tokens"),
+        # Map to Ollama-equivalent names for DB compatibility
+        "prompt_eval_count": usage.get("prompt_tokens"),
+        "eval_count": usage.get("completion_tokens"),
+        # Detailed breakdowns
+        "reasoning_tokens": completion_details.get("reasoning_tokens"),
+        "cached_tokens": prompt_details.get("cached_tokens"),
+        "accepted_prediction_tokens": completion_details.get(
+            "accepted_prediction_tokens"
+        ),
+        "rejected_prediction_tokens": completion_details.get(
+            "rejected_prediction_tokens"
+        ),
     }

--- a/src/rfc/test_database.py
+++ b/src/rfc/test_database.py
@@ -91,6 +91,10 @@ class TestResult:
     tag_verify: str = ""
     thinking_text: str = ""
     thinking_tokens: int = 0
+    reasoning_tokens: int = 0
+    cached_tokens: int = 0
+    accepted_prediction_tokens: int = 0
+    rejected_prediction_tokens: int = 0
     num_ctx: int = 0
     num_predict: int = 0
     eval_count: int = 0
@@ -189,6 +193,10 @@ class _SQLiteBackend(_Backend):
         tag_verify TEXT,
         thinking_text TEXT,
         thinking_tokens INTEGER,
+        reasoning_tokens INTEGER,
+        cached_tokens INTEGER,
+        accepted_prediction_tokens INTEGER,
+        rejected_prediction_tokens INTEGER,
         num_ctx INTEGER,
         num_predict INTEGER,
         eval_count INTEGER,
@@ -238,6 +246,10 @@ class _SQLiteBackend(_Backend):
         tr.tag_verify,
         tr.thinking_text,
         tr.thinking_tokens,
+        tr.reasoning_tokens,
+        tr.cached_tokens,
+        tr.accepted_prediction_tokens,
+        tr.rejected_prediction_tokens,
         tr.num_ctx,
         tr.num_predict,
         tr.eval_count,
@@ -285,6 +297,10 @@ class _SQLiteBackend(_Backend):
         "ALTER TABLE test_results ADD COLUMN load_duration_ns INTEGER",
         "ALTER TABLE test_results ADD COLUMN total_duration_ns INTEGER",
         "ALTER TABLE test_results ADD COLUMN tokens_per_second REAL",
+        "ALTER TABLE test_results ADD COLUMN reasoning_tokens INTEGER",
+        "ALTER TABLE test_results ADD COLUMN cached_tokens INTEGER",
+        "ALTER TABLE test_results ADD COLUMN accepted_prediction_tokens INTEGER",
+        "ALTER TABLE test_results ADD COLUMN rejected_prediction_tokens INTEGER",
     ]
 
     def __init__(self, db_path: str):
@@ -346,12 +362,15 @@ class _SQLiteBackend(_Backend):
                 (run_id, test_name, test_status, score, tags, question,
                  expected_answer, actual_answer, grading_reason,
                  rfc_version, tag_severity, tag_tier, tag_verify,
-                 thinking_text, thinking_tokens, num_ctx, num_predict,
+                 thinking_text, thinking_tokens,
+                 reasoning_tokens, cached_tokens,
+                 accepted_prediction_tokens, rejected_prediction_tokens,
+                 num_ctx, num_predict,
                  eval_count, eval_duration_ns, prompt_eval_count,
                  prompt_eval_duration_ns, load_duration_ns,
                  total_duration_ns, tokens_per_second)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 [
                     (
@@ -370,6 +389,10 @@ class _SQLiteBackend(_Backend):
                         r.tag_verify,
                         r.thinking_text,
                         r.thinking_tokens,
+                        r.reasoning_tokens,
+                        r.cached_tokens,
+                        r.accepted_prediction_tokens,
+                        r.rejected_prediction_tokens,
                         r.num_ctx,
                         r.num_predict,
                         r.eval_count,
@@ -507,6 +530,11 @@ class _SQLAlchemyBackend(_Backend):
         "ALTER TABLE test_results ADD COLUMN IF NOT EXISTS load_duration_ns BIGINT",
         "ALTER TABLE test_results ADD COLUMN IF NOT EXISTS total_duration_ns BIGINT",
         "ALTER TABLE test_results ADD COLUMN IF NOT EXISTS tokens_per_second REAL",
+        # OpenAI token detail columns.
+        "ALTER TABLE test_results ADD COLUMN IF NOT EXISTS reasoning_tokens INTEGER",
+        "ALTER TABLE test_results ADD COLUMN IF NOT EXISTS cached_tokens INTEGER",
+        "ALTER TABLE test_results ADD COLUMN IF NOT EXISTS accepted_prediction_tokens INTEGER",
+        "ALTER TABLE test_results ADD COLUMN IF NOT EXISTS rejected_prediction_tokens INTEGER",
         # Models table.
         """CREATE TABLE IF NOT EXISTS models (
             name TEXT PRIMARY KEY,
@@ -632,6 +660,10 @@ class _SQLAlchemyBackend(_Backend):
             Column("tag_verify", String(50)),
             Column("thinking_text", Text),
             Column("thinking_tokens", Integer),
+            Column("reasoning_tokens", Integer),
+            Column("cached_tokens", Integer),
+            Column("accepted_prediction_tokens", Integer),
+            Column("rejected_prediction_tokens", Integer),
             Column("num_ctx", Integer),
             Column("num_predict", Integer),
             Column("eval_count", Integer),
@@ -717,6 +749,10 @@ class _SQLAlchemyBackend(_Backend):
                         "tag_verify": r.tag_verify,
                         "thinking_text": r.thinking_text,
                         "thinking_tokens": r.thinking_tokens,
+                        "reasoning_tokens": r.reasoning_tokens,
+                        "cached_tokens": r.cached_tokens,
+                        "accepted_prediction_tokens": r.accepted_prediction_tokens,
+                        "rejected_prediction_tokens": r.rejected_prediction_tokens,
                         "num_ctx": r.num_ctx,
                         "num_predict": r.num_predict,
                         "eval_count": r.eval_count,

--- a/tests/test_db_listener.py
+++ b/tests/test_db_listener.py
@@ -742,6 +742,38 @@ class TestExtractLlmMetrics:
         assert result["eval_count"] == 10
         assert result.get("eval_duration_ns") is None
 
+    def test_openai_metrics_passthrough(self) -> None:
+        """OpenAI token detail fields pass through to metrics dict."""
+        import json
+
+        data = json.dumps(
+            {
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "reasoning_tokens": 30,
+                "cached_tokens": 20,
+                "accepted_prediction_tokens": 10,
+                "rejected_prediction_tokens": 5,
+                "prompt_eval_count": 100,
+                "eval_count": 50,
+            }
+        )
+        result = _extract_llm_metrics(data)
+        assert result["reasoning_tokens"] == 30
+        assert result["cached_tokens"] == 20
+        assert result["accepted_prediction_tokens"] == 10
+        assert result["rejected_prediction_tokens"] == 5
+        assert result["prompt_eval_count"] == 100
+        assert result["eval_count"] == 50
+
+    def test_openai_metrics_missing_returns_none(self) -> None:
+        """Missing OpenAI detail fields return None."""
+        result = _extract_llm_metrics('{"eval_count": 10}')
+        assert result.get("reasoning_tokens") is None
+        assert result.get("cached_tokens") is None
+        assert result.get("accepted_prediction_tokens") is None
+        assert result.get("rejected_prediction_tokens") is None
+
 
 class TestDbListenerThinkingCapture:
     """Tests for thinking and metrics data capture in the listener."""

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -273,6 +273,38 @@ class TestMetrics:
 
     @patch("rfc.openai_client.logger")
     @patch("rfc.openai_client.requests.post")
+    def test_stores_reasoning_tokens_in_last_metrics(self, mock_post, mock_logger):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"content": "hello"}}],
+            "usage": {
+                "prompt_tokens": 50,
+                "completion_tokens": 80,
+                "total_tokens": 130,
+                "completion_tokens_details": {
+                    "reasoning_tokens": 60,
+                    "accepted_prediction_tokens": 0,
+                    "rejected_prediction_tokens": 0,
+                },
+                "prompt_tokens_details": {
+                    "cached_tokens": 20,
+                },
+            },
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_post.return_value = mock_resp
+
+        client = OpenAIClient(api_key="sk-test")
+        client.generate("test")
+
+        assert client.last_metrics is not None
+        assert client.last_metrics["reasoning_tokens"] == 60
+        assert client.last_metrics["cached_tokens"] == 20
+        assert client.last_metrics["prompt_eval_count"] == 50
+        assert client.last_metrics["eval_count"] == 80
+
+    @patch("rfc.openai_client.logger")
+    @patch("rfc.openai_client.requests.post")
     def test_last_metrics_includes_model_name(self, mock_post, mock_logger):
         mock_resp = MagicMock()
         mock_resp.json.return_value = {
@@ -308,6 +340,92 @@ class TestExtractMetrics:
         metrics = _extract_metrics({}, "gpt-4o")
         assert metrics["model_name"] == "gpt-4o"
         assert metrics["prompt_tokens"] is None
+
+    def test_extracts_reasoning_tokens(self):
+        data = {
+            "usage": {
+                "prompt_tokens": 50,
+                "completion_tokens": 80,
+                "total_tokens": 130,
+                "completion_tokens_details": {
+                    "reasoning_tokens": 60,
+                },
+            }
+        }
+        metrics = _extract_metrics(data, "o3")
+        assert metrics["reasoning_tokens"] == 60
+
+    def test_extracts_cached_tokens(self):
+        data = {
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 20,
+                "total_tokens": 120,
+                "prompt_tokens_details": {
+                    "cached_tokens": 80,
+                },
+            }
+        }
+        metrics = _extract_metrics(data, "gpt-4o")
+        assert metrics["cached_tokens"] == 80
+
+    def test_extracts_prediction_tokens(self):
+        data = {
+            "usage": {
+                "prompt_tokens": 50,
+                "completion_tokens": 40,
+                "total_tokens": 90,
+                "completion_tokens_details": {
+                    "reasoning_tokens": 0,
+                    "accepted_prediction_tokens": 15,
+                    "rejected_prediction_tokens": 5,
+                },
+            }
+        }
+        metrics = _extract_metrics(data, "gpt-4o")
+        assert metrics["accepted_prediction_tokens"] == 15
+        assert metrics["rejected_prediction_tokens"] == 5
+
+    def test_maps_to_ollama_equivalents(self):
+        data = {
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 20,
+                "total_tokens": 30,
+            }
+        }
+        metrics = _extract_metrics(data, "gpt-4o")
+        assert metrics["prompt_eval_count"] == 10
+        assert metrics["eval_count"] == 20
+
+    def test_missing_details_defaults_to_none(self):
+        data = {
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            }
+        }
+        metrics = _extract_metrics(data, "gpt-4o")
+        assert metrics["reasoning_tokens"] is None
+        assert metrics["cached_tokens"] is None
+        assert metrics["accepted_prediction_tokens"] is None
+        assert metrics["rejected_prediction_tokens"] is None
+
+    def test_null_details_defaults_to_none(self):
+        """When details objects are explicitly null in JSON."""
+        data = {
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+                "prompt_tokens_details": None,
+                "completion_tokens_details": None,
+            }
+        }
+        metrics = _extract_metrics(data, "gpt-4o")
+        assert metrics["reasoning_tokens"] is None
+        assert metrics["cached_tokens"] is None
 
 
 class TestProtocolCompliance:

--- a/tests/test_test_database.py
+++ b/tests/test_test_database.py
@@ -581,6 +581,81 @@ class TestModelsTable:
         assert db.get_table_row_count("models") == 2
 
 
+class TestTokenMetricColumns:
+    """Verify OpenAI token detail columns (reasoning, cache, prediction)."""
+
+    def test_token_detail_columns_stored(self, tmp_path: object) -> None:
+        db = TestDatabase(db_path=str(tmp_path / "test.db"))  # type: ignore[operator]
+        run_id = db.add_test_run(_make_run())
+        db.add_test_results(
+            [
+                TestResult(
+                    run_id=run_id,
+                    test_name="Token Detail Test",
+                    test_status="PASS",
+                    reasoning_tokens=60,
+                    cached_tokens=20,
+                    accepted_prediction_tokens=15,
+                    rejected_prediction_tokens=5,
+                ),
+            ]
+        )
+        with sqlite3.connect(str(tmp_path / "test.db")) as conn:  # type: ignore[operator]
+            conn.row_factory = sqlite3.Row
+            row = conn.execute("SELECT * FROM test_results").fetchone()
+            assert row["reasoning_tokens"] == 60
+            assert row["cached_tokens"] == 20
+            assert row["accepted_prediction_tokens"] == 15
+            assert row["rejected_prediction_tokens"] == 5
+
+    def test_token_detail_columns_default_zero(self, tmp_path: object) -> None:
+        db = TestDatabase(db_path=str(tmp_path / "test.db"))  # type: ignore[operator]
+        run_id = db.add_test_run(_make_run())
+        db.add_test_results(
+            [
+                TestResult(
+                    run_id=run_id,
+                    test_name="Defaults",
+                    test_status="PASS",
+                ),
+            ]
+        )
+        with sqlite3.connect(str(tmp_path / "test.db")) as conn:  # type: ignore[operator]
+            conn.row_factory = sqlite3.Row
+            row = conn.execute("SELECT * FROM test_results").fetchone()
+            assert row["reasoning_tokens"] == 0
+            assert row["cached_tokens"] == 0
+            assert row["accepted_prediction_tokens"] == 0
+            assert row["rejected_prediction_tokens"] == 0
+
+    def test_token_detail_in_view(self, tmp_path: object) -> None:
+        db = TestDatabase(db_path=str(tmp_path / "test.db"))  # type: ignore[operator]
+        run_id = db.add_test_run(_make_run())
+        db.add_test_results(
+            [
+                TestResult(
+                    run_id=run_id,
+                    test_name="View Test",
+                    test_status="PASS",
+                    reasoning_tokens=30,
+                    cached_tokens=10,
+                ),
+            ]
+        )
+        with sqlite3.connect(str(tmp_path / "test.db")) as conn:  # type: ignore[operator]
+            conn.row_factory = sqlite3.Row
+            row = conn.execute("SELECT * FROM test_results_full").fetchone()
+            assert row["reasoning_tokens"] == 30
+            assert row["cached_tokens"] == 10
+
+    def test_dataclass_defaults(self) -> None:
+        r = TestResult(run_id=1, test_name="T", test_status="PASS")
+        assert r.reasoning_tokens == 0
+        assert r.cached_tokens == 0
+        assert r.accepted_prediction_tokens == 0
+        assert r.rejected_prediction_tokens == 0
+
+
 class TestViewIncludesNewColumns:
     """Verify test_results_full view includes new columns."""
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for capturing and storing OpenAI's advanced token metrics, including reasoning tokens, cached tokens, and prediction tokens. These metrics are now extracted from OpenAI API responses, mapped to database-compatible field names, and persisted in the test results database.

## Key Changes

- **OpenAI Client (`openai_client.py`)**
  - Enhanced `_extract_metrics()` to extract nested token detail fields from OpenAI API responses:
    - `reasoning_tokens` from `completion_tokens_details`
    - `cached_tokens` from `prompt_tokens_details`
    - `accepted_prediction_tokens` and `rejected_prediction_tokens` from `completion_tokens_details`
  - Added mapping of OpenAI's `prompt_tokens`/`completion_tokens` to Ollama-equivalent names (`prompt_eval_count`/`eval_count`) for database compatibility

- **Database Schema (`test_database.py`)**
  - Added four new integer columns to `TestResult` dataclass with default value of 0:
    - `reasoning_tokens`
    - `cached_tokens`
    - `accepted_prediction_tokens`
    - `rejected_prediction_tokens`
  - Updated both SQLite and SQLAlchemy backends to include these columns in table creation and migrations
  - Updated the `test_results_full` view to include the new columns

- **Database Listener (`db_listener.py`)**
  - Modified `end_test()` to extract and store token detail metrics from the metrics dictionary
  - Modified `end_suite()` to pass token detail metrics when creating `TestResult` objects
  - Enhanced `_extract_llm_metrics()` to pass through OpenAI token detail fields from JSON metrics

- **Tests**
  - Added comprehensive test coverage for metric extraction in `test_openai_client.py`
  - Added database storage and retrieval tests in `test_test_database.py`
  - Added metrics passthrough tests in `test_db_listener.py`

## Implementation Details

The implementation maintains backward compatibility by defaulting all new token detail fields to 0 in the dataclass and database. The metrics extraction gracefully handles missing detail objects by treating them as empty dictionaries, ensuring None values are returned when fields are absent. This allows the system to work with both legacy OpenAI responses and newer responses that include detailed token breakdowns.

https://claude.ai/code/session_01EERjEnPYgSFec8qGZAoDSL