### PR TITLE
Remove parameter_count and release_date metadata fields

### DIFF
--- a/docs/GRAFANA_SUPERSET_SETUP.md
+++ b/docs/GRAFANA_SUPERSET_SETUP.md
@@ -910,8 +910,6 @@ db.export_to_json("full_export.json")
 | `name` | VARCHAR(255) PK | Model identifier |
 | `full_name` | VARCHAR(255) | Human-readable name |
 | `organization` | VARCHAR(255) | Model creator |
-| `release_date` | VARCHAR(255) | Model release date |
-| `parameters` | VARCHAR(255) | Parameter count |
 | `last_tested` | TIMESTAMP | Last test timestamp |
 
 #### `keyword_results` — Keyword execution timing

--- a/docs/TEST_DATABASE.md
+++ b/docs/TEST_DATABASE.md
@@ -127,7 +127,6 @@ LLM model metadata:
 | `architecture` | TEXT | e.g., llama, mistral, gemma |
 | `context_length` | INTEGER | Max context window |
 | `family` | TEXT | Model family |
-| `parameter_count` | TEXT | e.g., 8B, 27B |
 
 ### Future Schema Additions
 

--- a/robot/ci/fetch_model_metadata.robot
+++ b/robot/ci/fetch_model_metadata.robot
@@ -29,30 +29,10 @@ Research Ollama Model
     ${description}=    Get Text    .description >> visible=false
     ${tags}=    Get Elements    .tag
 
-    # Try to extract release date from page
-    ${release_date}=    Set Variable    Unknown
-    TRY
-        ${date_element}=    Get Element    time[datetime]
-        ${release_date}=    Get Attribute    ${date_element}    datetime
-    EXCEPT
-        Log    Could not extract release date for ${model_name}
-    END
-
-    # Try to extract model sizes/parameters
-    ${parameters}=    Set Variable    Unknown
-    TRY
-        ${params_text}=    Get Text    .parameters
-        ${parameters}=    Set Variable    ${params_text}
-    EXCEPT
-        Log    Could not extract parameters for ${model_name}
-    END
-
     ${model_info}=    Create Dictionary
     ...    name=${model_name}
     ...    title=${title}
     ...    description=${description}
-    ...    release_date=${release_date}
-    ...    parameters=${parameters}
     ...    url=${url}
     ...    researched_at=${CURRENT_DATE}
 

--- a/robot/ci/models.yaml
+++ b/robot/ci/models.yaml
@@ -12,8 +12,7 @@ models:
     full_name: "Meta Llama 3"
     organization: "Meta AI"
     description: "Meta's open source LLM model"
-    release_date: "2024-04-18"
-    parameters: "8B"
+
     ollama_library_url: "https://ollama.com/library/llama3"
     hugging_face_url: "https://huggingface.co/meta-llama/Meta-Llama-3-8B"
     capabilities:
@@ -33,8 +32,7 @@ models:
     full_name: "Mistral 7B"
     organization: "Mistral AI"
     description: "High-performance open source LLM"
-    release_date: "2023-09-27"
-    parameters: "7B"
+
     ollama_library_url: "https://ollama.com/library/mistral"
     hugging_face_url: "https://huggingface.co/mistralai/Mistral-7B-v0.1"
     capabilities:
@@ -53,8 +51,7 @@ models:
     full_name: "Code Llama"
     organization: "Meta AI"
     description: "Code-focused variant of Llama 2"
-    release_date: "2023-08-24"
-    parameters: "7B"
+
     ollama_library_url: "https://ollama.com/library/codellama"
     hugging_face_url: "https://huggingface.co/codellama/CodeLlama-7b-hf"
     capabilities:
@@ -72,8 +69,7 @@ models:
     full_name: "Meta Llama 3.1"
     organization: "Meta AI"
     description: "Updated version of Llama 3"
-    release_date: "2024-07-23"
-    parameters: "8B"
+
     ollama_library_url: "https://ollama.com/library/llama3.1"
     hugging_face_url: "https://huggingface.co/meta-llama/Meta-Llama-3.1-8B"
     capabilities:

--- a/src/rfc/pre_run_modifier.py
+++ b/src/rfc/pre_run_modifier.py
@@ -173,10 +173,6 @@ class ModelAwarePreRunModifier:
             suite.metadata["Model_Name"] = model_info.get(
                 "full_name", self.default_model
             )
-            suite.metadata["Model_Release_Date"] = model_info.get(
-                "release_date", "Unknown"
-            )
-            suite.metadata["Model_Parameters"] = model_info.get("parameters", "Unknown")
             suite.metadata["Model_Organization"] = model_info.get(
                 "organization", "Unknown"
             )

--- a/src/rfc/test_database.py
+++ b/src/rfc/test_database.py
@@ -114,7 +114,6 @@ class Model:
     architecture: str = ""
     context_length: int = 0
     family: str = ""
-    parameter_count: str = ""
 
 
 class _Backend(abc.ABC):
@@ -208,8 +207,7 @@ class _SQLiteBackend(_Backend):
         quantization TEXT,
         architecture TEXT,
         context_length INTEGER,
-        family TEXT,
-        parameter_count TEXT
+        family TEXT
     );
 
     CREATE INDEX IF NOT EXISTS idx_test_runs_model ON test_runs(model_name);
@@ -447,8 +445,8 @@ class _SQLiteBackend(_Backend):
                 """
                 INSERT OR REPLACE INTO models
                 (name, sha256_digest, size_gb, quantization, architecture,
-                 context_length, family, parameter_count)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                 context_length, family)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     model.name,
@@ -458,7 +456,6 @@ class _SQLiteBackend(_Backend):
                     model.architecture,
                     model.context_length,
                     model.family,
-                    model.parameter_count,
                 ),
             )
 
@@ -515,8 +512,7 @@ class _SQLAlchemyBackend(_Backend):
             quantization TEXT,
             architecture TEXT,
             context_length INTEGER,
-            family TEXT,
-            parameter_count TEXT
+            family TEXT
         )""",
         # Joined view for Superset — one flat dataset with all columns.
         """CREATE OR REPLACE VIEW test_results_full AS
@@ -654,7 +650,6 @@ class _SQLAlchemyBackend(_Backend):
             Column("architecture", Text),
             Column("context_length", Integer),
             Column("family", Text),
-            Column("parameter_count", Text),
         )
 
     def _run_migrations(self) -> None:
@@ -784,7 +779,6 @@ class _SQLAlchemyBackend(_Backend):
                     architecture=model.architecture,
                     context_length=model.context_length,
                     family=model.family,
-                    parameter_count=model.parameter_count,
                 )
             )
             if result.rowcount == 0:
@@ -797,7 +791,6 @@ class _SQLAlchemyBackend(_Backend):
                         architecture=model.architecture,
                         context_length=model.context_length,
                         family=model.family,
-                        parameter_count=model.parameter_count,
                     )
                 )
 

--- a/tests/test_pre_run_modifier.py
+++ b/tests/test_pre_run_modifier.py
@@ -171,8 +171,6 @@ class TestAddMetadata:
         mod.model_config = {
             "llama3": {
                 "full_name": "LLaMA 3",
-                "release_date": "2024-04-01",
-                "parameters": "8B",
                 "organization": "Meta",
             }
         }
@@ -182,7 +180,7 @@ class TestAddMetadata:
 
         mod._add_metadata(suite)
         assert suite.metadata["Model_Name"] == "LLaMA 3"
-        assert suite.metadata["Model_Parameters"] == "8B"
+        assert suite.metadata["Model_Organization"] == "Meta"
 
     @patch("rfc.pre_run_modifier.OllamaClient")
     def test_skips_empty_metadata(self, MockClient):

--- a/tests/test_test_database.py
+++ b/tests/test_test_database.py
@@ -548,7 +548,6 @@ class TestModelsTable:
             architecture="llama",
             context_length=8192,
             family="llama",
-            parameter_count="8B",
         )
         db.upsert_model(model)
 


### PR DESCRIPTION
## Summary
This PR removes the `parameter_count` and `release_date` metadata fields from the model tracking system across the codebase. These fields were being collected but are no longer needed for the current requirements.

## Key Changes

- **Robot Framework**: Removed extraction logic for release date and parameters from the Ollama model research script (`fetch_model_metadata.robot`)
- **Database Schema**: Removed `parameter_count` column from the `models` table in both SQLite and SQLAlchemy backends
- **Model Class**: Removed `parameter_count` field from the `Model` dataclass
- **Configuration**: Removed `release_date` and `parameters` entries from the model definitions in `models.yaml`
- **Metadata Handling**: Removed population of `Model_Release_Date` and `Model_Parameters` metadata fields in the test suite modifier
- **Documentation**: Updated schema documentation in `GRAFANA_SUPERSET_SETUP.md` and `TEST_DATABASE.md` to reflect the removed fields
- **Tests**: Updated test cases to remove assertions and test data related to the removed fields

## Implementation Details

The removal is comprehensive across all layers:
- Both database backends (SQLite and SQLAlchemy) have been updated with matching schema changes
- The upsert operations for models no longer reference these fields
- Test fixtures and assertions have been cleaned up to match the new schema

https://claude.ai/code/session_01EhgdizdGRLEBUuAiW7GgLP