### PR TITLE
Remove pipeline URL and runner metadata collection

### DIFF
--- a/ai/DEV.md
+++ b/ai/DEV.md
@@ -116,11 +116,10 @@ These are set automatically by GitLab CI or GitHub Actions:
 | `CI`, `GITLAB_CI`, `GITHUB_ACTIONS` | CI runner | Platform detection |
 | `CI_COMMIT_SHA`, `GITHUB_SHA` | CI runner | Commit hash |
 | `CI_COMMIT_REF_NAME`, `GITHUB_REF_NAME` | CI runner | Branch name |
-| `CI_PIPELINE_URL`, `CI_PIPELINE_ID` | GitLab | Pipeline tracking |
+| `CI_PIPELINE_ID` | GitLab | Pipeline tracking |
 | `CI_JOB_URL`, `CI_JOB_ID`, `CI_JOB_NAME` | GitLab | Job tracking |
 | `CI_MERGE_REQUEST_IID` | GitLab | MR identification |
 | `CI_API_V4_URL`, `CI_PROJECT_ID` | GitLab | API access |
-| `CI_RUNNER_ID`, `CI_RUNNER_DESCRIPTION`, `CI_RUNNER_TAGS` | GitLab | Runner metadata |
 | `ROBOT_OUTPUT_DIR` | Robot Framework | Output directory |
 | `GITHUB_SERVER_URL`, `GITHUB_REPOSITORY` | GitHub Actions | Repo identification |
 | `GITHUB_WORKSPACE`, `CI_PROJECT_DIR` | CI runner | Workspace path |

--- a/humans/TODO.md
+++ b/humans/TODO.md
@@ -23,7 +23,7 @@ These require human decisions, manual setup, or external work.
 
 - [ ] **Add model metadata fields to database.** Call Ollama `/api/show` per model and store: quantization level (e.g., Q4_K_M, Q8_0), parameter count, architecture (llama, mistral, etc.), context length, family, license. Requires new columns on `models` table or a new `model_metadata` table.
 - [ ] **Add tokens/sec performance tracking.** Ollama's `/api/generate` response includes `eval_count`, `eval_duration`, `prompt_eval_count`, `prompt_eval_duration`, `load_duration`. Capture these in `keyword_results` or a new `llm_performance` table. This is critical for the "fastest model" comparison.
-- [ ] **Add hardware context to test runs.** Each test run should record which node (and therefore which hardware) executed it. Currently `runner_id` and `runner_tags` capture CI runner info, but for local runs there's no hardware fingerprint.
+- [ ] **Add hardware context to test runs.** Each test run should record which node (and therefore which hardware) executed it. Currently there's no hardware fingerprint for local or CI runs.
 - [ ] **Track quantization in the database.** Parse the model tag (e.g., `llama3:8b-q4_K_M`) or use `/api/show` to get quantization details. Store in model metadata so you can compare Q4 vs Q8 vs FP16 performance.
 - [ ] **Add model size in GB.** Model size should be stored in gigabytes (disk size of the GGUF/safetensors), not just parameter count. This can be researched from web sources or pulled from `/api/show`. Enables "best model that fits in X GB VRAM" queries.
 - [ ] **Add model size categories.** Define size buckets (8B, 16B, 64B, 128B, 256B+) so Superset/Grafana can group comparisons by weight class. Models should only be compared within their size category.

--- a/scripts/generate_ci_metadata.py
+++ b/scripts/generate_ci_metadata.py
@@ -29,18 +29,10 @@ if platform == "github":
         "commit_sha": sha,
         "commit_short_sha": sha[:8] if sha else "",
         "branch": os.getenv("GITHUB_REF_NAME", ""),
-        "pipeline_url": f"{project_url}/actions/runs/{run_id}"
-        if project_url and run_id
-        else "",
         "job_url": f"{project_url}/actions/runs/{run_id}"
         if project_url and run_id
         else "",
         "job_id": os.getenv("GITHUB_RUN_NUMBER", ""),
-    }
-    runner_data = {
-        "id": os.getenv("RUNNER_NAME", ""),
-        "description": os.getenv("RUNNER_OS", ""),
-        "tags": "",
     }
 else:
     ci_data = {
@@ -48,21 +40,14 @@ else:
         "commit_sha": os.getenv("CI_COMMIT_SHA", ""),
         "commit_short_sha": os.getenv("CI_COMMIT_SHORT_SHA", ""),
         "branch": os.getenv("CI_COMMIT_REF_NAME", ""),
-        "pipeline_url": os.getenv("CI_PIPELINE_URL", ""),
         "job_url": os.getenv("CI_JOB_URL", ""),
         "job_id": os.getenv("CI_JOB_ID", ""),
-    }
-    runner_data = {
-        "id": os.getenv("CI_RUNNER_ID", ""),
-        "description": os.getenv("CI_RUNNER_DESCRIPTION", ""),
-        "tags": os.getenv("CI_RUNNER_TAGS", ""),
     }
 
 data = {
     "version": __version__,
     "ci_platform": platform or "unknown",
     "ci": ci_data,
-    "runner": runner_data,
     "ollama": {
         "endpoint": os.getenv("OLLAMA_ENDPOINT", "http://localhost:11434"),
         "default_model": os.getenv("DEFAULT_MODEL", "phi4:14b"),

--- a/src/rfc/git_metadata.py
+++ b/src/rfc/git_metadata.py
@@ -35,7 +35,6 @@ def _collect_gitlab_metadata() -> Dict[str, str]:
         "Commit_SHA": os.getenv("CI_COMMIT_SHA", ""),
         "Commit_Short_SHA": os.getenv("CI_COMMIT_SHORT_SHA", ""),
         "Branch": os.getenv("CI_COMMIT_REF_NAME", ""),
-        "Pipeline_URL": os.getenv("CI_PIPELINE_URL", ""),
         "Pipeline_ID": os.getenv("CI_PIPELINE_ID", ""),
         # Job information
         "Job_URL": os.getenv("CI_JOB_URL", ""),
@@ -52,10 +51,6 @@ def _collect_gitlab_metadata() -> Dict[str, str]:
         # Repository
         "Repository_URL": os.getenv("CI_REPOSITORY_URL", ""),
         "Triggered_By": os.getenv("CI_PIPELINE_SOURCE", ""),
-        # Runner information
-        "Runner_ID": os.getenv("CI_RUNNER_ID", ""),
-        "Runner_Description": os.getenv("CI_RUNNER_DESCRIPTION", ""),
-        "Runner_Tags": os.getenv("CI_RUNNER_TAGS", ""),
         # Environment
         "Test_Environment": os.getenv("CI_ENVIRONMENT_NAME", ""),
         "User": os.getenv("GITLAB_USER_LOGIN", ""),
@@ -77,9 +72,6 @@ def _collect_github_metadata() -> Dict[str, str]:
         "Commit_SHA": sha,
         "Commit_Short_SHA": sha[:8] if sha else "",
         "Branch": os.getenv("GITHUB_REF_NAME", ""),
-        "Pipeline_URL": f"{project_url}/actions/runs/{run_id}"
-        if project_url and run_id
-        else "",
         "Pipeline_ID": run_id,
         # Job information
         "Job_URL": f"{project_url}/actions/runs/{run_id}"
@@ -92,10 +84,6 @@ def _collect_github_metadata() -> Dict[str, str]:
         # Repository
         "Repository_URL": f"{project_url}.git" if project_url else "",
         "Triggered_By": os.getenv("GITHUB_EVENT_NAME", ""),
-        # Runner information
-        "Runner_ID": os.getenv("RUNNER_NAME", ""),
-        "Runner_Description": os.getenv("RUNNER_OS", ""),
-        "Runner_Tags": "",
         # Environment
         "Test_Environment": os.getenv("GITHUB_ENVIRONMENT", ""),
         "User": os.getenv("GITHUB_ACTOR", ""),

--- a/src/rfc/git_metadata_listener.py
+++ b/src/rfc/git_metadata_listener.py
@@ -74,13 +74,6 @@ class GitMetaData(ListenerV3):
                 project_url, commit_sha, commit_short
             )
 
-        # Format Pipeline_URL as a clickable link
-        pipeline_url = self.ci_info.get("Pipeline_URL", "")
-        pipeline_id = self.ci_info.get("Pipeline_ID", "")
-        if pipeline_url:
-            label = f"Pipeline #{pipeline_id}" if pipeline_id else "Pipeline"
-            metadata["Pipeline_URL"] = f"[{label}|{pipeline_url}]"
-
         # Format Job_URL as a clickable link
         job_url = self.ci_info.get("Job_URL", "")
         job_name = self.ci_info.get("Job_Name", "")

--- a/tests/test_generate_ci_metadata.py
+++ b/tests/test_generate_ci_metadata.py
@@ -48,8 +48,6 @@ class TestGitHubPlatform:
             GITHUB_RUN_ID="12345",
             GITHUB_REF_NAME="main",
             GITHUB_RUN_NUMBER="42",
-            RUNNER_NAME="ubuntu-latest",
-            RUNNER_OS="Linux",
             OLLAMA_ENDPOINT="http://my-ollama:11434",
             DEFAULT_MODEL="mistral",
         )
@@ -67,9 +65,6 @@ class TestGitHubPlatform:
         assert data["ci"]["commit_short_sha"] == "abc12345"
         assert data["ci"]["branch"] == "main"
         assert data["ci"]["job_id"] == "42"
-        assert "actions/runs/12345" in data["ci"]["pipeline_url"]
-        assert data["runner"]["id"] == "ubuntu-latest"
-        assert data["runner"]["description"] == "Linux"
         assert data["ollama"]["endpoint"] == "http://my-ollama:11434"
         assert data["ollama"]["default_model"] == "mistral"
         assert "version" in data
@@ -91,7 +86,7 @@ class TestGitHubPlatform:
         assert data["ci_platform"] == "github"
         assert data["ci"]["project_url"] == ""
         assert data["ci"]["commit_short_sha"] == ""
-        assert data["ci"]["pipeline_url"] == ""
+        assert data["ci"]["job_url"] == ""
 
 
 class TestGitLabPlatform:
@@ -102,12 +97,8 @@ class TestGitLabPlatform:
             CI_COMMIT_SHA="deadbeefcafe1234",
             CI_COMMIT_SHORT_SHA="deadbeef",
             CI_COMMIT_REF_NAME="develop",
-            CI_PIPELINE_URL="https://gitlab.example.com/group/project/pipelines/999",
             CI_JOB_URL="https://gitlab.example.com/group/project/-/jobs/1234",
             CI_JOB_ID="1234",
-            CI_RUNNER_ID="77",
-            CI_RUNNER_DESCRIPTION="shared-runner",
-            CI_RUNNER_TAGS="docker,linux",
         )
         result = _run_script(tmp_path, env)
         assert result.returncode == 0, result.stderr
@@ -121,9 +112,7 @@ class TestGitLabPlatform:
         assert data["ci"]["commit_short_sha"] == "deadbeef"
         assert data["ci"]["branch"] == "develop"
         assert data["ci"]["job_id"] == "1234"
-        assert data["runner"]["id"] == "77"
-        assert data["runner"]["description"] == "shared-runner"
-        assert data["runner"]["tags"] == "docker,linux"
+        assert "runner" not in data
 
 
 class TestNoPlatform:

--- a/tests/test_git_metadata.py
+++ b/tests/test_git_metadata.py
@@ -77,7 +77,6 @@ class TestCollectGitMetadata:
         assert result["Branch"] == "feature-branch"
         assert result["CI_Platform"] == "github"
         assert result["Project_URL"] == "https://github.com/org/repo"
-        assert "12345" in result["Pipeline_URL"]
 
     def test_empty_values_filtered(self):
         with patch.dict(
@@ -93,15 +92,12 @@ class TestCollectGitMetadata:
             os.environ,
             {
                 "GITLAB_CI": "true",
-                "CI_PIPELINE_URL": "https://gitlab.com/pipeline/1",
                 "CI_JOB_URL": "https://gitlab.com/job/1",
-                "CI_RUNNER_ID": "42",
             },
             clear=True,
         ):
             result = collect_ci_metadata()
-        assert result["Pipeline_URL"] == "https://gitlab.com/pipeline/1"
-        assert result["Runner_ID"] == "42"
+        assert result["Job_URL"] == "https://gitlab.com/job/1"
 
     @patch("rfc.git_metadata.subprocess.run")
     def test_no_ci_platform_uses_local_metadata(self, mock_run):

--- a/tests/test_import_test_results.py
+++ b/tests/test_import_test_results.py
@@ -29,9 +29,6 @@ MINIMAL_OUTPUT_XML = """\
       <item name="Model">llama3</item>
       <item name="Commit_SHA">abc123</item>
       <item name="Branch">main</item>
-      <item name="Pipeline_URL">https://gl.test/p/500</item>
-      <item name="Runner_ID">runner-1</item>
-      <item name="Runner_Tags">ollama,gpu</item>
       <item name="Timestamp">2025-06-15T10:00:00</item>
     </metadata>
     <test name="IQ 100 Basic Addition" id="s1-t1">
@@ -316,7 +313,6 @@ class TestParseOutputXml:
             assert data["metadata"]["Model"] == "llama3"
             assert data["metadata"]["Commit_SHA"] == "abc123"
             assert data["metadata"]["Branch"] == "main"
-            assert data["metadata"]["Pipeline_URL"] == "https://gl.test/p/500"
         finally:
             os.unlink(path)
 
@@ -573,9 +569,6 @@ class TestImportResults:
         {
             "CI_COMMIT_SHA": "env-sha",
             "CI_COMMIT_REF_NAME": "env-branch",
-            "CI_PIPELINE_URL": "https://gl.test/env-pipeline",
-            "CI_RUNNER_ID": "env-runner",
-            "CI_RUNNER_TAGS": "env-tags",
         },
         clear=False,
     )


### PR DESCRIPTION
## Summary
This PR removes the collection and tracking of pipeline URLs and runner metadata (runner ID, description, and tags) from CI metadata gathering and test result reporting across the codebase.

## Key Changes

- **CI Metadata Generation** (`scripts/generate_ci_metadata.py`):
  - Removed `pipeline_url` field from both GitHub Actions and GitLab CI data structures
  - Removed entire `runner_data` dictionary containing runner ID, description, and tags for both platforms

- **Git Metadata Collection** (`src/rfc/git_metadata.py`):
  - Removed `Pipeline_URL` field from both GitHub and GitLab metadata collection
  - Removed runner information fields: `Runner_ID`, `Runner_Description`, and `Runner_Tags`

- **Git Metadata Listener** (`src/rfc/git_metadata_listener.py`):
  - Removed pipeline URL formatting logic that created clickable links for pipeline references

- **Test Result Import** (`tests/test_import_test_results.py`):
  - Removed pipeline URL and runner metadata assertions from test fixtures and validation

- **Documentation** (`ai/DEV.md`, `humans/TODO.md`):
  - Updated environment variable documentation to remove references to `CI_PIPELINE_URL`, `CI_RUNNER_ID`, `CI_RUNNER_DESCRIPTION`, and `CI_RUNNER_TAGS`
  - Updated TODO item to reflect that hardware context tracking is not currently implemented

- **Tests** (`tests/test_generate_ci_metadata.py`, `tests/test_git_metadata.py`):
  - Updated test cases to remove assertions for pipeline URLs and runner metadata
  - Removed test environment variables related to runners

## Implementation Details

The changes maintain job-level tracking (`job_url`, `job_id`) while removing pipeline-level and runner-level metadata. This simplifies the metadata structure and reduces the amount of CI-specific information being collected and stored in test results.

https://claude.ai/code/session_0175DgMjdmpTYdLjh5FrFGzj