### PR TITLE
Clarify feature branch creation from claude-code-staging

### DIFF
--- a/ai/AGENTS.md
+++ b/ai/AGENTS.md
@@ -123,7 +123,7 @@ Read `ai/CLAUDE.md` for grading tiers and test rules.
 - `chore:` - Maintenance
 
 **Pull Request Workflow:**
-1. Create feature branch from `claude-code-staging`
+1. Create feature branch from `claude-code-staging` (the integration branch for all Claude Code work — not `main`)
 2. Implement changes following all rules above
 3. Push branch to remote: `git push origin feature-name`
 4. Create PR/MR with descriptive title and body

--- a/ai/SKILLS.md
+++ b/ai/SKILLS.md
@@ -30,7 +30,7 @@ This document outlines the capabilities and skills of the AI agent working on ro
 - Tagging and releases
 
 **Pull Request Workflow:**
-- Create feature branches from main
+- Create feature branches from `claude-code-staging` (the integration branch for all Claude Code work)
 - Push branches to remote: `git push origin feature-name`
 - Create PRs/MRs with descriptive titles and bodies
 - Monitor PRs for feedback and respond promptly
@@ -108,7 +108,7 @@ This document outlines the capabilities and skills of the AI agent working on ro
 1. Read ai/AGENTS.md and ai/SKILLS.md
 2. Understand project structure and conventions
 3. Check for existing issues or PRs
-4. Create feature branch: `git checkout -b feature/description`
+4. Create feature branch from `claude-code-staging`: `git checkout -b feature/description claude-code-staging`
 
 ### During Development
 


### PR DESCRIPTION
## Summary
Updated documentation to clarify that feature branches should be created from `claude-code-staging` (the integration branch for Claude Code work) rather than `main`, and provided explicit git commands to ensure correct branch creation.

## Key Changes
- Updated SKILLS.md to clarify that feature branches are created from `claude-code-staging`, not `main`
- Updated the feature branch creation command in SKILLS.md to explicitly specify the source branch: `git checkout -b feature/description claude-code-staging`
- Updated AGENTS.md to emphasize that `claude-code-staging` is the integration branch for all Claude Code work and explicitly note it is not `main`
- Ensured consistency across both documentation files regarding the branching workflow

## Notable Details
These changes prevent confusion about the correct base branch for feature development and ensure all Claude Code work flows through the `claude-code-staging` integration branch before reaching `main`.

https://claude.ai/code/session_012pRCpmGLi5ncrCbzfCTa5D