### PR TITLE
Clarify DATABASE_URL fallback behavior in documentation

### DIFF
--- a/ai/AGENTS.md
+++ b/ai/AGENTS.md
@@ -421,7 +421,7 @@ The `DbListener` reads `DATABASE_URL` from the environment to decide where to st
 
 | `DATABASE_URL` | Backend | Notes |
 |----------------|---------|-------|
-| Not set | **Error** | `RuntimeError` — must be configured |
+| Not set | `.env` fallback | Read from `.env`; `RuntimeError` if still missing |
 | `postgresql://...` | PostgreSQL | Requires `uv sync --extra superset` |
 
 ---

--- a/ai/DEV.md
+++ b/ai/DEV.md
@@ -44,7 +44,7 @@ The `.env` file is loaded automatically by:
 
 | Variable | Purpose | Default | Used By |
 |----------|---------|---------|---------|
-| `DATABASE_URL` | PostgreSQL connection string | SQLite fallback | db_listener, test_database, dry_run_listener |
+| `DATABASE_URL` | PostgreSQL connection string | `.env` fallback | db_listener, test_database, dry_run_listener |
 | `DATABASE_HOST` | Hostname for DB (CI builds `DATABASE_URL` from this) | `localhost` | .gitlab-ci.yml |
 | `DEFAULT_MODEL` | LLM model for tests | `gpt-oss:20b` (CI: `qwen3.5:27b`) | ollama.py, keywords, listeners, scripts |
 | `OLLAMA_ENDPOINT` | Ollama API URL | `http://localhost:11434` | ollama.py, pre_run_modifier, listeners, ci/test.sh |


### PR DESCRIPTION
## Summary
Updated documentation to clarify that `DATABASE_URL` falls back to reading from the `.env` file when not explicitly set as an environment variable, rather than implying a SQLite fallback.

## Changes
- **AGENTS.md**: Updated the `DbListener` configuration table to document that when `DATABASE_URL` is not set, the system attempts to read it from `.env` file before raising a `RuntimeError`
- **DEV.md**: Corrected the default value description for `DATABASE_URL` from "SQLite fallback" to "`.env` fallback" to accurately reflect the actual fallback behavior

## Details
These documentation updates clarify the actual runtime behavior where the application checks the `.env` file for `DATABASE_URL` configuration before failing, making it clearer for developers setting up their environment.

https://claude.ai/code/session_01X8kaCEKPKmCaDGbiVuTvvg