### PR TITLE
Follow-up: add fractional grading regressions and clarify multi-grader consensus

### DIFF
--- a/src/rfc/ceo_keywords.py
+++ b/src/rfc/ceo_keywords.py
@@ -352,7 +352,7 @@ class CEOKeywords:
         output: Dict[str, Any],
         rubric: str = "",
     ) -> Dict[str, Any]:
-        """Grade stage output using multi-LLM majority vote.
+        """Grade stage output using multi-LLM median consensus.
 
         Args:
             stage_name: The pipeline stage name.
@@ -362,7 +362,7 @@ class CEOKeywords:
         Returns:
             Dict with scores, majority_score, agreement_ratio, reasons.
         """
-        logger.info(f"Grading {stage_name} output with multi-LLM vote")
+        logger.info(f"Grading {stage_name} output with multi-LLM consensus")
 
         grader = self._get_multi_grader()
         result = grader.grade(

--- a/src/rfc/multi_grader.py
+++ b/src/rfc/multi_grader.py
@@ -1,7 +1,7 @@
 """Multi-LLM consensus grader for tier:3 verification.
 
-Uses 3+ LLM providers to evaluate a response, returning a consensus
-score with agreement tracking.
+Uses 3+ LLM providers to evaluate a response, returning a fractional
+consensus score with agreement tracking.
 """
 
 from __future__ import annotations
@@ -56,10 +56,11 @@ def _extract_json(text: str) -> str:
 
 
 class MultiGrader:
-    """Grades LLM output using consensus across multiple providers.
+    """Grades LLM output using median consensus across multiple providers.
 
     Requires at least 3 providers. Each provider independently evaluates
-    the output, and the median score becomes the aggregate result.
+    the output, and the median score becomes the aggregate result so
+    fractional values remain intact instead of being bucketed to pass/fail.
     """
 
     def __init__(self, providers: Sequence[Any]) -> None:

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -90,3 +90,4 @@ class TestGrader:
         assert "score must be a number between 0.0 and 1.0" in prompt
         assert "use partial credit" in prompt
         assert '"score": 0.0 to 1.0' in prompt
+        assert "score must be 0 or 1" not in prompt

--- a/tests/test_multi_grader.py
+++ b/tests/test_multi_grader.py
@@ -1,4 +1,4 @@
-"""Unit tests for multi-LLM majority-vote grader."""
+"""Unit tests for multi-LLM consensus grader."""
 
 from __future__ import annotations
 
@@ -190,6 +190,30 @@ class TestMultiGrader:
         assert abs(result.agreement_ratio - 0.9) < 0.01
         assert result.passed
 
+    def test_fractional_consensus_does_not_collapse_low_scores_to_zero(self) -> None:
+        providers = [
+            _mock_provider('{"score": 0.4, "reason": "partial"}'),
+            _mock_provider('{"score": 0.4, "reason": "partial"}'),
+            _mock_provider('{"score": 0.4, "reason": "partial"}'),
+        ]
+        grader = MultiGrader(providers=providers)
+        result = grader.grade(question="q", expected="e", actual="a", rubric="r")
+        assert result.scores == [0.4, 0.4, 0.4]
+        assert result.majority_score == 0.4
+        assert result.agreement_ratio == 1.0
+        assert not result.passed
+
+    def test_fractional_consensus_uses_median_instead_of_binary_vote(self) -> None:
+        providers = [
+            _mock_provider('{"score": 0.9, "reason": "strong"}'),
+            _mock_provider('{"score": 0.6, "reason": "solid"}'),
+            _mock_provider('{"score": 0.6, "reason": "solid"}'),
+        ]
+        grader = MultiGrader(providers=providers)
+        result = grader.grade(question="q", expected="e", actual="a", rubric="r")
+        assert result.majority_score == 0.6
+        assert result.passed
+
     def test_prompt_requests_fractional_scores(self) -> None:
         providers = [
             _mock_provider('{"score": 0.5, "reason": "ok"}'),
@@ -202,6 +226,7 @@ class TestMultiGrader:
         assert "score must be a number between 0.0 and 1.0" in prompt
         assert "use partial credit" in prompt
         assert '"score": 0.0 to 1.0' in prompt
+        assert "score must be 0 or 1" not in prompt
 
     def test_invalid_fractional_score_reports_original_value(self) -> None:
         providers = [


### PR DESCRIPTION
### Motivation
- Ensure the LLM-facing grader instructions require fractional scores so the new 0.0–1.0 scoring model is actually reachable and the old binary wording (`score must be 0 or 1`) cannot be reintroduced.
- Prevent the multi-LLM aggregation path from collapsing fractional inputs into binary outcomes by making the intended median/consensus behavior explicit and covered by tests.
- Align exposed keywords/logging to describe fractional median consensus so external callers (e.g. Robot keywords) reflect the intended behavior.

### Description
- Updated wording/docstrings in `src/rfc/multi_grader.py` to describe median consensus and that fractional values are preserved. 
- Clarified `src/rfc/ceo_keywords.py` `grade_stage_output` docstring and logging from “majority vote” to “median consensus”.
- Added regression assertions to `tests/test_grader.py` to require the grader prompt to ask for fractional scores and to assert the old `"score must be 0 or 1"` phrasing is not present. 
- Added tests to `tests/test_multi_grader.py` that assert fractional inputs are preserved (`[0.4, 0.4, 0.4]` remains `0.4`) and that median consensus is used for cases like `[0.9, 0.6, 0.6]` (median `0.6`).

### Testing
- Ran `pytest tests/test_grader.py tests/test_multi_grader.py` without `PYTHONPATH` which failed to import `rfc` due to environment configuration (expected in this environment). 
- Ran `PYTHONPATH=src pytest tests/test_grader.py tests/test_multi_grader.py` and observed `30 passed` for the targeted test set, indicating the new regressions and existing assertions succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0de651d8832a97f9825a286d7823)