### PR TITLE
Enhance cache-flush target to refresh RF Metrics dashboards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,10 +153,12 @@ docker-logs: ## Tail service logs
 bootstrap: ## First-time Superset setup (run after 'make docker-up')
 	$(COMPOSE) run --rm superset-init
 
-cache-flush: ## Flush Superset/Redis cache (forces dashboards to re-query PostgreSQL)
+cache-flush: ## Flush caches and refresh all dashboards (Superset + RF Metrics)
 	@echo "Flushing Redis cache..."
 	$(COMPOSE) exec redis redis-cli FLUSHALL
-	@echo "Cache flushed — reload Superset dashboards to see fresh data."
+	@echo "Triggering RF Metrics dashboard regeneration..."
+	$(COMPOSE) restart metrics
+	@echo "Done — Superset will re-query on next load; RF Metrics are regenerating now."
 
 superset-sanitize: ## Truncate all RFC data tables (preserves dashboards/charts)
 	uv run python scripts/sanitize_superset_db.py


### PR DESCRIPTION
## Summary
Updated the `cache-flush` make target to coordinate cache clearing across both Superset and RF Metrics services, ensuring comprehensive dashboard refresh.

## Key Changes
- Updated help text to clarify that the target now flushes caches for both Superset and RF Metrics
- Added `metrics` service restart to trigger RF Metrics dashboard regeneration after Redis cache flush
- Enhanced console output to communicate the dual-service refresh process and expected behavior

## Implementation Details
The target now performs a two-step refresh:
1. Flushes the Redis cache (affecting Superset)
2. Restarts the `metrics` service to trigger RF Metrics dashboard regeneration

This ensures that both dashboard systems refresh their data on the next load, providing a complete cache invalidation workflow.

https://claude.ai/code/session_01ChZGP3xVufJYaTfzR9AuSy