### PR TITLE
Centralize DEFAULT_TIMEOUT constant to single source of truth

### DIFF
--- a/src/rfc/ceo_keywords.py
+++ b/src/rfc/ceo_keywords.py
@@ -31,9 +31,9 @@ from .grader import Grader
 from .llm_client import create_provider
 from .multi_grader import MultiGrader
 from .rfc_data import emit_rfc_data
+from .constants import DEFAULT_TIMEOUT
 from .web_cache import SearchResult, WebSearchCache
 
-_DEFAULT_TIMEOUT = 5400
 _DEFAULT_CEO_MAX_TOKENS = 4096
 _DEFAULT_LLM_PROVIDER = "ollama"
 _COMPAT_OPENAI_PROVIDER = "openai"
@@ -50,7 +50,7 @@ class CEOKeywords:
         max_retries: int = 2,
     ) -> None:
         if timeout is None:
-            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(_DEFAULT_TIMEOUT)))
+            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(DEFAULT_TIMEOUT)))
         self._timeout = int(timeout)
         self._max_retries = int(max_retries)
         self._client: Optional[Any] = None

--- a/src/rfc/constants.py
+++ b/src/rfc/constants.py
@@ -1,0 +1,3 @@
+"""Shared constants for the rfc package."""
+
+DEFAULT_TIMEOUT = 5400

--- a/src/rfc/keywords.py
+++ b/src/rfc/keywords.py
@@ -9,9 +9,8 @@ from .grader import Grader
 from .llm_client import create_provider
 from .ollama import OllamaClient
 from .rfc_data import emit_rfc_data
+from .constants import DEFAULT_TIMEOUT
 from .thinking import estimate_token_count, parse_thinking
-
-_DEFAULT_TIMEOUT = 5400
 
 
 class LLMKeywords:
@@ -21,7 +20,7 @@ class LLMKeywords:
 
     def __init__(self, timeout: Optional[int] = None, max_retries: int = 2):
         if timeout is None:
-            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(_DEFAULT_TIMEOUT)))
+            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(DEFAULT_TIMEOUT)))
         self.client = create_provider(
             timeout=int(timeout), max_retries=int(max_retries)
         )

--- a/src/rfc/ollama.py
+++ b/src/rfc/ollama.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, List, Optional
 from robot.api import logger
 import requests
 
+from .constants import DEFAULT_TIMEOUT
+
 
 def _compute_rate(count: Optional[int], duration_ns: Optional[int]) -> Optional[float]:
     """Compute tokens/s from token count and nanosecond duration."""
@@ -42,8 +44,6 @@ class OllamaClient:
     integration point for all Ollama interactions.
     """
 
-    _DEFAULT_TIMEOUT = 5400
-
     def __init__(
         self,
         base_url: str = "",
@@ -63,7 +63,7 @@ class OllamaClient:
         if not model:
             model = os.getenv("DEFAULT_MODEL", "phi4:14b")
         if timeout is None:
-            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(self._DEFAULT_TIMEOUT)))
+            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(DEFAULT_TIMEOUT)))
         if not isinstance(base_url, str) or not base_url:
             raise ValueError("base_url must be a non-empty string")
         if not isinstance(model, str) or not model:

--- a/src/rfc/openai_client.py
+++ b/src/rfc/openai_client.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, Optional
 from robot.api import logger
 import requests
 
+from .constants import DEFAULT_TIMEOUT
+
 
 class OpenAIClient:
     """HTTP client for the OpenAI Chat Completions API.
@@ -14,8 +16,6 @@ class OpenAIClient:
     Works with OpenAI, Azure OpenAI, and any OpenAI-compatible API
     (Together, Groq, Fireworks, etc.) by setting base_url.
     """
-
-    _DEFAULT_TIMEOUT = 5400
 
     def __init__(
         self,
@@ -39,7 +39,7 @@ class OpenAIClient:
         if not model:
             model = os.getenv("DEFAULT_MODEL", "gpt-4o-mini")
         if timeout is None:
-            timeout = int(os.getenv("OPENAI_TIMEOUT", str(self._DEFAULT_TIMEOUT)))
+            timeout = int(os.getenv("OPENAI_TIMEOUT", str(DEFAULT_TIMEOUT)))
 
         if not isinstance(base_url, str) or not base_url:
             raise ValueError("base_url must be a non-empty string")

--- a/src/rfc/safety_keywords.py
+++ b/src/rfc/safety_keywords.py
@@ -4,11 +4,10 @@ from robot.api.deco import keyword
 from robot.api import logger
 from typing import Dict, Any, List, Optional
 
+from .constants import DEFAULT_TIMEOUT
 from .llm_client import create_provider
 from .rfc_data import emit_rfc_data
 from .safety_grader import SafetyGrader
-
-_DEFAULT_TIMEOUT = 5400
 
 
 class SafetyKeywords:
@@ -18,7 +17,7 @@ class SafetyKeywords:
 
     def __init__(self, timeout: Optional[int] = None, max_retries: int = 2):
         if timeout is None:
-            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(_DEFAULT_TIMEOUT)))
+            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(DEFAULT_TIMEOUT)))
         self.client = create_provider(
             timeout=int(timeout), max_retries=int(max_retries)
         )

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,11 @@
+"""Tests for rfc.constants — single source of truth for shared constants."""
+
+from rfc.constants import DEFAULT_TIMEOUT
+
+
+def test_default_timeout_value() -> None:
+    assert DEFAULT_TIMEOUT == 5400
+
+
+def test_default_timeout_type() -> None:
+    assert isinstance(DEFAULT_TIMEOUT, int)


### PR DESCRIPTION
## Summary
This PR consolidates the `DEFAULT_TIMEOUT` constant (5400 seconds) from multiple locations across the codebase into a single centralized module, improving maintainability and reducing duplication.

## Key Changes
- Created new `src/rfc/constants.py` module to serve as the single source of truth for shared constants
- Moved `DEFAULT_TIMEOUT = 5400` from four separate locations:
  - `OllamaClient._DEFAULT_TIMEOUT` in `src/rfc/ollama.py`
  - `OpenAIClient._DEFAULT_TIMEOUT` in `src/rfc/openai_client.py`
  - `_DEFAULT_TIMEOUT` module-level constant in `src/rfc/keywords.py`
  - `_DEFAULT_TIMEOUT` module-level constant in `src/rfc/safety_keywords.py`
  - `_DEFAULT_TIMEOUT` module-level constant in `src/rfc/ceo_keywords.py`
- Updated all five modules to import `DEFAULT_TIMEOUT` from the new constants module
- Added comprehensive test coverage in `tests/test_constants.py` to verify the constant's value and type

## Implementation Details
- The constant is now imported as `from .constants import DEFAULT_TIMEOUT` in all affected modules
- All references have been updated to use the centralized constant instead of local definitions
- Tests ensure the constant maintains its expected value (5400) and type (int)

https://claude.ai/code/session_013tktmHBsM3Kqpcegq2jGLf