### PR TITLE
Extract JSON extraction logic into reusable thinking module function

### DIFF
--- a/src/rfc/ceo_keywords.py
+++ b/src/rfc/ceo_keywords.py
@@ -27,7 +27,7 @@ from .ceo_prompts import (
     build_market_research_prompt,
     build_patent_strategy_prompt,
 )
-from .grader import Grader
+from .thinking import extract_json
 from .llm_client import create_provider
 from .multi_grader import MultiGrader
 from .rfc_data import emit_rfc_data
@@ -131,8 +131,7 @@ class CEOKeywords:
 
     def _extract_json_response(self, raw: str) -> Dict[str, Any]:
         """Extract and parse JSON from LLM response."""
-        extractor = Grader(self.client)
-        json_text = extractor._extract_json(raw)
+        json_text = extract_json(raw)
         return json.loads(json_text)
 
     # ------------------------------------------------------------------

--- a/src/rfc/grader.py
+++ b/src/rfc/grader.py
@@ -1,8 +1,7 @@
 import json
-import re
 
 from .models import GradeResult
-from .thinking import parse_thinking
+from .thinking import extract_json
 
 
 class Grader:
@@ -10,38 +9,6 @@ class Grader:
         if llm_client is None:
             raise TypeError("llm_client must not be None")
         self.llm = llm_client
-
-    def _extract_json(self, text: str) -> str:
-        """Extract JSON from text that may contain markdown or reasoning.
-
-        Handles:
-        - Markdown code blocks (```json...```)
-        - Thinking tags (<think>...</think> or <thinking>...</thinking>)
-        - Text before/after JSON
-        """
-        # Remove thinking tags (various formats used by different models)
-        text, _ = parse_thinking(text)
-
-        # Try to find JSON in markdown code blocks
-        json_block_pattern = r"```(?:json)?\s*(\{.*?\})\s*```"
-        matches = re.findall(json_block_pattern, text, re.DOTALL)
-        if matches:
-            return matches[0]
-
-        # Try to find bare JSON object
-        json_pattern = r'(\{.*"score".*"reason".*?\})'
-        matches = re.findall(json_pattern, text, re.DOTALL)
-        if matches:
-            return matches[0]
-
-        # Last resort: look for any JSON object
-        json_pattern = r"(\{.*?\})"
-        matches = re.findall(json_pattern, text, re.DOTALL)
-        if matches:
-            # Return the largest match (most likely the full JSON)
-            return max(matches, key=len)
-
-        return text
 
     def grade(self, question: str, expected: str, actual: str) -> GradeResult:
         for name, val in [
@@ -82,7 +49,7 @@ Format:
         raw = self.llm.generate(prompt)
 
         # Extract JSON from response (handle thinking tags, markdown, etc.)
-        json_text = self._extract_json(raw)
+        json_text = extract_json(raw)
 
         try:
             parsed = json.loads(json_text)

--- a/src/rfc/multi_grader.py
+++ b/src/rfc/multi_grader.py
@@ -7,12 +7,11 @@ score with agreement tracking.
 from __future__ import annotations
 
 import json
-import re
 from statistics import median
 from dataclasses import dataclass
 from typing import Any, List, Sequence
 
-from .thinking import parse_thinking
+from .thinking import extract_json
 
 
 @dataclass
@@ -31,28 +30,6 @@ class MultiGradeResult:
     @property
     def unanimous(self) -> bool:
         return self.agreement_ratio == 1.0
-
-
-def _extract_json(text: str) -> str:
-    """Extract JSON from text that may contain markdown or thinking tags."""
-    text, _ = parse_thinking(text)
-
-    json_block_pattern = r"```(?:json)?\s*(\{.*?\})\s*```"
-    matches = re.findall(json_block_pattern, text, re.DOTALL)
-    if matches:
-        return matches[0]
-
-    json_pattern = r'(\{.*"score".*"reason".*?\})'
-    matches = re.findall(json_pattern, text, re.DOTALL)
-    if matches:
-        return matches[0]
-
-    json_pattern = r"(\{.*?\})"
-    matches = re.findall(json_pattern, text, re.DOTALL)
-    if matches:
-        return max(matches, key=len)
-
-    return text
 
 
 class MultiGrader:
@@ -144,7 +121,7 @@ Format:
         """Get a single grade from one provider. Returns (0.0, error) on failure."""
         try:
             raw = provider.generate(prompt)
-            json_text = _extract_json(raw)
+            json_text = extract_json(raw)
             parsed = json.loads(json_text)
             score = float(parsed.get("score", 0))
             reason = str(parsed.get("reason", ""))

--- a/src/rfc/thinking.py
+++ b/src/rfc/thinking.py
@@ -40,6 +40,39 @@ def parse_thinking(text: str) -> tuple[str, Optional[str]]:
     return clean, thinking
 
 
+def extract_json(text: str) -> str:
+    """Extract JSON from text that may contain markdown or thinking tags.
+
+    Handles:
+    - Markdown code blocks (``\\`\\`\\`json...\\`\\`\\```)
+    - Thinking tags (``<think>`` / ``<thinking>``)
+    - Text before/after JSON
+
+    Returns the extracted JSON string, or the original text if no JSON is found.
+    """
+    text, _ = parse_thinking(text)
+
+    # Try to find JSON in markdown code blocks
+    json_block_pattern = r"```(?:json)?\s*(\{.*?\})\s*```"
+    matches = re.findall(json_block_pattern, text, re.DOTALL)
+    if matches:
+        return matches[0]
+
+    # Try to find bare JSON with score/reason fields
+    json_pattern = r'(\{.*"score".*"reason".*?\})'
+    matches = re.findall(json_pattern, text, re.DOTALL)
+    if matches:
+        return matches[0]
+
+    # Last resort: any JSON object, pick the largest match
+    json_pattern = r"(\{.*?\})"
+    matches = re.findall(json_pattern, text, re.DOTALL)
+    if matches:
+        return max(matches, key=len)
+
+    return text
+
+
 def estimate_token_count(text: Optional[str]) -> int:
     """Estimate token count using whitespace splitting.
 

--- a/tests/test_multi_grader.py
+++ b/tests/test_multi_grader.py
@@ -215,11 +215,11 @@ class TestMultiGrader:
         assert result.reasons[0] == "Invalid score value: 1.2"
 
     def test_bare_json_extract_fallback(self) -> None:
-        """_extract_json falls back to max-length bare JSON match (line 52)."""
-        from rfc.multi_grader import _extract_json
+        """extract_json falls back to max-length bare JSON match."""
+        from rfc.thinking import extract_json
 
         # No markdown block, no "score".*"reason" pattern — just a bare JSON object
         text = 'I think the answer is {"reason": "good", "score": 1}'
-        result = _extract_json(text)
+        result = extract_json(text)
         assert '"reason"' in result
         assert '"score"' in result

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -1,6 +1,6 @@
 """Tests for rfc.thinking — thinking token parser."""
 
-from rfc.thinking import estimate_token_count, parse_thinking
+from rfc.thinking import estimate_token_count, extract_json, parse_thinking
 
 
 class TestParseThinking:
@@ -69,6 +69,42 @@ class TestParseThinking:
         clean, thinking = parse_thinking(text)
         assert clean == "Result."
         assert thinking == "What about {json} and [arrays]?"
+
+
+class TestExtractJson:
+    def test_plain_json(self) -> None:
+        text = '{"score": 1, "reason": "correct"}'
+        assert extract_json(text) == text
+
+    def test_json_in_markdown_block(self) -> None:
+        text = '```json\n{"score": 1, "reason": "ok"}\n```'
+        assert extract_json(text) == '{"score": 1, "reason": "ok"}'
+
+    def test_json_in_markdown_block_no_lang(self) -> None:
+        text = '```\n{"score": 0.5, "reason": "partial"}\n```'
+        assert extract_json(text) == '{"score": 0.5, "reason": "partial"}'
+
+    def test_thinking_tags_stripped(self) -> None:
+        text = '<think>hmm let me think</think>\n{"score": 1, "reason": "ok"}'
+        result = extract_json(text)
+        assert '"score"' in result
+        assert "<think>" not in result
+
+    def test_text_before_json(self) -> None:
+        text = 'I think the answer is {"score": 0.8, "reason": "mostly right"}'
+        result = extract_json(text)
+        assert '"score"' in result
+        assert '"reason"' in result
+
+    def test_bare_json_fallback_picks_largest(self) -> None:
+        text = 'prefix {"a": 1} and {"reason": "good", "score": 1, "extra": true} end'
+        result = extract_json(text)
+        assert '"reason"' in result
+        assert '"score"' in result
+
+    def test_no_json_returns_text(self) -> None:
+        text = "no json here at all"
+        assert extract_json(text) == text
 
 
 class TestEstimateTokenCount:


### PR DESCRIPTION
## Summary
Refactored JSON extraction logic from the `Grader` class into a standalone `extract_json()` function in the `thinking` module, eliminating code duplication across multiple files.

## Key Changes
- **New function**: Added `extract_json()` to `src/rfc/thinking.py` that handles extraction of JSON from text containing markdown code blocks, thinking tags, and surrounding text
- **Removed duplication**: Deleted `_extract_json()` method from `Grader` class in `src/rfc/grader.py`
- **Removed duplication**: Deleted `_extract_json()` function from `src/rfc/multi_grader.py`
- **Updated imports**: Changed `src/rfc/ceo_keywords.py` to import `extract_json` directly from `thinking` module instead of using `Grader._extract_json()`
- **Updated references**: Updated `Grader.grade()` and `MultiGrader._grade_single()` to use the new `extract_json()` function
- **Added tests**: Comprehensive test suite in `tests/test_thinking.py` covering various JSON extraction scenarios (plain JSON, markdown blocks, thinking tags, fallback behavior)

## Implementation Details
The `extract_json()` function uses a multi-strategy approach:
1. First removes thinking tags using existing `parse_thinking()` function
2. Attempts to extract JSON from markdown code blocks (with optional `json` language specifier)
3. Falls back to finding JSON objects with `"score"` and `"reason"` fields
4. As a last resort, extracts any JSON object and returns the largest match
5. Returns original text if no JSON is found

This consolidation improves maintainability by having a single source of truth for JSON extraction logic across the codebase.

https://claude.ai/code/session_01Cn46DTBXs5YUAbQQyKsLsP