### PR TITLE
Extract retry logic into reusable retry_on_transient helper

### DIFF
--- a/src/rfc/ollama.py
+++ b/src/rfc/ollama.py
@@ -8,6 +8,7 @@ from robot.api import logger
 import requests
 
 from .constants import DEFAULT_TIMEOUT
+from .retry import retry_on_transient
 
 
 def _compute_rate(count: Optional[int], duration_ns: Optional[int]) -> Optional[float]:
@@ -142,39 +143,21 @@ class OllamaClient:
             payload["keep_alive"] = self.keep_alive
 
         self.last_metrics = None
-        last_exception: Exception | None = None
-        for attempt in range(1 + self.max_retries):
-            try:
-                response = requests.post(
-                    f"{self.base_url}/api/generate",
-                    json=payload,
-                    timeout=self.timeout,
-                )
-                response.raise_for_status()
-                data = response.json()
-                text = data["response"].strip()
-                self.last_metrics = _extract_metrics(data, self.model)
-                logger.info(f"{self.model} >> {text}")
-                return text
-            except (
-                requests.exceptions.ReadTimeout,
-                requests.exceptions.ConnectionError,
-            ) as exc:
-                last_exception = exc
-                if attempt < self.max_retries:
-                    delay = 2 ** (attempt + 1)
-                    logger.warn(
-                        f"generate() attempt {attempt + 1} failed: {exc}. "
-                        f"Retrying in {delay}s "
-                        f"({self.max_retries - attempt} retries left)"
-                    )
-                    time.sleep(delay)
-                else:
-                    logger.error(
-                        f"generate() failed after {attempt + 1} attempts: {exc}"
-                    )
 
-        raise last_exception  # type: ignore[misc]
+        def _do_request() -> str:
+            response = requests.post(
+                f"{self.base_url}/api/generate",
+                json=payload,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+            text = data["response"].strip()
+            self.last_metrics = _extract_metrics(data, self.model)
+            logger.info(f"{self.model} >> {text}")
+            return text
+
+        return retry_on_transient(_do_request, max_retries=self.max_retries)
 
     def unload_model(self, model: Optional[str] = None) -> bool:
         """Unload a model from VRAM by sending keep_alive=0.

--- a/src/rfc/openai_client.py
+++ b/src/rfc/openai_client.py
@@ -1,13 +1,13 @@
 """OpenAI Chat Completions API client for LLM generation."""
 
 import os
-import time
 from typing import Any, Dict, Optional
 
 from robot.api import logger
 import requests
 
 from .constants import DEFAULT_TIMEOUT
+from .retry import retry_on_transient
 
 
 class OpenAIClient:
@@ -108,40 +108,22 @@ class OpenAIClient:
         }
 
         self.last_metrics = None
-        last_exception: Exception | None = None
-        for attempt in range(1 + self.max_retries):
-            try:
-                response = requests.post(
-                    f"{self.base_url}/chat/completions",
-                    json=payload,
-                    headers=headers,
-                    timeout=self.timeout,
-                )
-                response.raise_for_status()
-                data = response.json()
-                text = data["choices"][0]["message"]["content"].strip()
-                self.last_metrics = _extract_metrics(data, self.model)
-                logger.info(f"{self.model} >> {text}")
-                return text
-            except (
-                requests.exceptions.ReadTimeout,
-                requests.exceptions.ConnectionError,
-            ) as exc:
-                last_exception = exc
-                if attempt < self.max_retries:
-                    delay = 2 ** (attempt + 1)
-                    logger.warn(
-                        f"generate() attempt {attempt + 1} failed: {exc}. "
-                        f"Retrying in {delay}s "
-                        f"({self.max_retries - attempt} retries left)"
-                    )
-                    time.sleep(delay)
-                else:
-                    logger.error(
-                        f"generate() failed after {attempt + 1} attempts: {exc}"
-                    )
 
-        raise last_exception  # type: ignore[misc]
+        def _do_request() -> str:
+            response = requests.post(
+                f"{self.base_url}/chat/completions",
+                json=payload,
+                headers=headers,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+            text = data["choices"][0]["message"]["content"].strip()
+            self.last_metrics = _extract_metrics(data, self.model)
+            logger.info(f"{self.model} >> {text}")
+            return text
+
+        return retry_on_transient(_do_request, max_retries=self.max_retries)
 
 
 def _extract_metrics(data: Dict[str, Any], model: str) -> Dict[str, Any]:

--- a/src/rfc/retry.py
+++ b/src/rfc/retry.py
@@ -1,0 +1,51 @@
+"""Retry helper for transient HTTP errors."""
+
+import time
+from typing import Callable, TypeVar
+
+import requests
+from robot.api import logger
+
+T = TypeVar("T")
+
+_TRANSIENT_EXCEPTIONS = (
+    requests.exceptions.ReadTimeout,
+    requests.exceptions.ConnectionError,
+)
+
+
+def retry_on_transient(fn: Callable[[], T], *, max_retries: int) -> T:
+    """Call *fn* with retry on transient HTTP errors.
+
+    Catches ``ReadTimeout`` and ``ConnectionError``, applying exponential
+    backoff (2, 4, 8, … seconds).  All other exceptions propagate immediately.
+
+    Args:
+        fn: Zero-argument callable that returns a result or raises.
+        max_retries: Number of retries after the initial attempt.
+
+    Returns:
+        The value returned by *fn*.
+
+    Raises:
+        The last transient exception if all attempts are exhausted.
+    """
+    last_exception: Exception | None = None
+    for attempt in range(1 + max_retries):
+        try:
+            return fn()
+        except _TRANSIENT_EXCEPTIONS as exc:
+            last_exception = exc
+            if attempt < max_retries:
+                delay = 2 ** (attempt + 1)
+                logger.warn(
+                    f"generate() attempt {attempt + 1} failed: {exc}. "
+                    f"Retrying in {delay}s "
+                    f"({max_retries - attempt} retries left)"
+                )
+                time.sleep(delay)
+            else:
+                logger.error(
+                    f"generate() failed after {attempt + 1} attempts: {exc}"
+                )
+    raise last_exception  # type: ignore[misc]

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -133,8 +133,8 @@ class TestGenerate:
 
 
 class TestGenerateRetry:
-    @patch("rfc.ollama.logger")
-    @patch("rfc.ollama.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.ollama.requests.post")
     def test_retries_on_read_timeout(self, mock_post, mock_sleep, mock_logger):
         mock_resp = MagicMock()
@@ -152,8 +152,8 @@ class TestGenerateRetry:
         assert mock_post.call_count == 2
         mock_sleep.assert_called_once_with(2)
 
-    @patch("rfc.ollama.logger")
-    @patch("rfc.ollama.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.ollama.requests.post")
     def test_retries_on_connection_error(self, mock_post, mock_sleep, mock_logger):
         mock_resp = MagicMock()
@@ -170,8 +170,8 @@ class TestGenerateRetry:
         assert result == "ok"
         assert mock_post.call_count == 2
 
-    @patch("rfc.ollama.logger")
-    @patch("rfc.ollama.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.ollama.requests.post")
     def test_exhausts_retries_then_raises(self, mock_post, mock_sleep, mock_logger):
         mock_post.side_effect = req_lib.exceptions.ReadTimeout("timed out")
@@ -182,8 +182,8 @@ class TestGenerateRetry:
         # 1 initial + 2 retries = 3 total calls
         assert mock_post.call_count == 3
 
-    @patch("rfc.ollama.logger")
-    @patch("rfc.ollama.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.ollama.requests.post")
     def test_no_retry_on_http_error(self, mock_post, mock_sleep, mock_logger):
         mock_post.side_effect = req_lib.exceptions.HTTPError("500 Server Error")
@@ -194,7 +194,7 @@ class TestGenerateRetry:
         assert mock_post.call_count == 1
         mock_sleep.assert_not_called()
 
-    @patch("rfc.ollama.logger")
+    @patch("rfc.retry.logger")
     @patch("rfc.ollama.requests.post")
     def test_no_retry_when_max_retries_zero(self, mock_post, mock_logger):
         mock_post.side_effect = req_lib.exceptions.ReadTimeout("timed out")
@@ -204,8 +204,8 @@ class TestGenerateRetry:
             client.generate("test")
         assert mock_post.call_count == 1
 
-    @patch("rfc.ollama.logger")
-    @patch("rfc.ollama.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.ollama.requests.post")
     def test_exponential_backoff_timing(self, mock_post, mock_sleep, mock_logger):
         mock_post.side_effect = req_lib.exceptions.ReadTimeout("timed out")

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -136,8 +136,8 @@ class TestGenerate:
 
 
 class TestGenerateRetry:
-    @patch("rfc.openai_client.logger")
-    @patch("rfc.openai_client.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.openai_client.requests.post")
     def test_retries_on_read_timeout(self, mock_post, mock_sleep, mock_logger):
         mock_resp = MagicMock()
@@ -158,8 +158,8 @@ class TestGenerateRetry:
         assert mock_post.call_count == 2
         mock_sleep.assert_called_once_with(2)
 
-    @patch("rfc.openai_client.logger")
-    @patch("rfc.openai_client.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.openai_client.requests.post")
     def test_retries_on_connection_error(self, mock_post, mock_sleep, mock_logger):
         mock_resp = MagicMock()
@@ -179,8 +179,8 @@ class TestGenerateRetry:
         assert result == "ok"
         assert mock_post.call_count == 2
 
-    @patch("rfc.openai_client.logger")
-    @patch("rfc.openai_client.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.openai_client.requests.post")
     def test_exhausts_retries_then_raises(self, mock_post, mock_sleep, mock_logger):
         mock_post.side_effect = req_lib.exceptions.ReadTimeout("timed out")
@@ -190,8 +190,8 @@ class TestGenerateRetry:
             client.generate("test")
         assert mock_post.call_count == 3
 
-    @patch("rfc.openai_client.logger")
-    @patch("rfc.openai_client.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.openai_client.requests.post")
     def test_no_retry_on_http_error(self, mock_post, mock_sleep, mock_logger):
         mock_post.side_effect = req_lib.exceptions.HTTPError("401 Unauthorized")
@@ -202,7 +202,7 @@ class TestGenerateRetry:
         assert mock_post.call_count == 1
         mock_sleep.assert_not_called()
 
-    @patch("rfc.openai_client.logger")
+    @patch("rfc.retry.logger")
     @patch("rfc.openai_client.requests.post")
     def test_no_retry_when_max_retries_zero(self, mock_post, mock_logger):
         mock_post.side_effect = req_lib.exceptions.ReadTimeout("timed out")
@@ -212,8 +212,8 @@ class TestGenerateRetry:
             client.generate("test")
         assert mock_post.call_count == 1
 
-    @patch("rfc.openai_client.logger")
-    @patch("rfc.openai_client.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.openai_client.requests.post")
     def test_exponential_backoff_timing(self, mock_post, mock_sleep, mock_logger):
         mock_post.side_effect = req_lib.exceptions.ReadTimeout("timed out")

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,102 @@
+"""Tests for rfc.retry.retry_on_transient."""
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+import requests as req_lib
+
+from rfc.retry import retry_on_transient
+
+
+class TestRetryOnTransient:
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
+    def test_returns_result_on_first_success(self, mock_sleep, mock_logger):
+        fn = MagicMock(return_value="ok")
+        result = retry_on_transient(fn, max_retries=2)
+        assert result == "ok"
+        fn.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
+    def test_retries_on_read_timeout(self, mock_sleep, mock_logger):
+        fn = MagicMock(
+            side_effect=[req_lib.exceptions.ReadTimeout("timed out"), "ok"]
+        )
+        result = retry_on_transient(fn, max_retries=2)
+        assert result == "ok"
+        assert fn.call_count == 2
+        mock_sleep.assert_called_once_with(2)
+
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
+    def test_retries_on_connection_error(self, mock_sleep, mock_logger):
+        fn = MagicMock(
+            side_effect=[req_lib.exceptions.ConnectionError("refused"), "ok"]
+        )
+        result = retry_on_transient(fn, max_retries=2)
+        assert result == "ok"
+        assert fn.call_count == 2
+
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
+    def test_exhausts_retries_then_raises(self, mock_sleep, mock_logger):
+        fn = MagicMock(
+            side_effect=req_lib.exceptions.ReadTimeout("timed out")
+        )
+        with pytest.raises(req_lib.exceptions.ReadTimeout):
+            retry_on_transient(fn, max_retries=2)
+        assert fn.call_count == 3  # 1 initial + 2 retries
+
+    @patch("rfc.retry.logger")
+    def test_no_retry_when_max_retries_zero(self, mock_logger):
+        fn = MagicMock(
+            side_effect=req_lib.exceptions.ReadTimeout("timed out")
+        )
+        with pytest.raises(req_lib.exceptions.ReadTimeout):
+            retry_on_transient(fn, max_retries=0)
+        fn.assert_called_once()
+
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
+    def test_exponential_backoff_timing(self, mock_sleep, mock_logger):
+        fn = MagicMock(
+            side_effect=req_lib.exceptions.ReadTimeout("timed out")
+        )
+        with pytest.raises(req_lib.exceptions.ReadTimeout):
+            retry_on_transient(fn, max_retries=2)
+        assert mock_sleep.call_args_list == [call(2), call(4)]
+
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
+    def test_non_transient_error_propagates(self, mock_sleep, mock_logger):
+        fn = MagicMock(
+            side_effect=req_lib.exceptions.HTTPError("500 Server Error")
+        )
+        with pytest.raises(req_lib.exceptions.HTTPError):
+            retry_on_transient(fn, max_retries=2)
+        fn.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
+    def test_logs_warn_on_retry_and_error_on_exhaust(
+        self, mock_sleep, mock_logger
+    ):
+        fn = MagicMock(
+            side_effect=req_lib.exceptions.ReadTimeout("timed out")
+        )
+        with pytest.raises(req_lib.exceptions.ReadTimeout):
+            retry_on_transient(fn, max_retries=1)
+
+        # First attempt fails -> warn about retry
+        mock_logger.warn.assert_called_once()
+        warn_msg = mock_logger.warn.call_args[0][0]
+        assert "attempt 1 failed" in warn_msg
+        assert "Retrying in 2s" in warn_msg
+
+        # Second attempt fails -> error (exhausted)
+        mock_logger.error.assert_called_once()
+        error_msg = mock_logger.error.call_args[0][0]
+        assert "failed after 2 attempts" in error_msg


### PR DESCRIPTION
## Summary
Refactored duplicate retry logic from `OpenAIClient` and `OllamaClient` into a new reusable `retry_on_transient()` helper function. This eliminates code duplication and centralizes the handling of transient HTTP errors (ReadTimeout and ConnectionError) with exponential backoff.

## Key Changes
- **New module**: `src/rfc/retry.py` - Implements `retry_on_transient()` function that:
  - Handles transient HTTP errors (ReadTimeout, ConnectionError) with exponential backoff (2, 4, 8, … seconds)
  - Propagates non-transient exceptions immediately
  - Provides consistent logging for retry attempts and exhaustion
  - Accepts a zero-argument callable and max_retries parameter

- **Updated `OpenAIClient.generate()`**: Replaced 30+ lines of retry logic with a call to `retry_on_transient()`, wrapping the HTTP request in a nested `_do_request()` function

- **Updated `OllamaClient.generate()`**: Applied the same refactoring pattern as OpenAIClient

- **New test suite**: `tests/test_retry.py` - Comprehensive tests for the retry helper covering:
  - Successful first attempt
  - Retry on ReadTimeout and ConnectionError
  - Retry exhaustion
  - Exponential backoff timing
  - Non-transient error propagation
  - Logging behavior

- **Updated existing tests**: Modified test patches in `test_openai_client.py` and `test_ollama.py` to target `rfc.retry` module instead of the client modules, since retry logic now lives in the shared helper

## Implementation Details
- The retry helper uses a generic TypeVar to preserve return type information
- Exponential backoff formula: `delay = 2 ** (attempt + 1)` (starting at 2 seconds)
- Logging messages maintain the original format for backward compatibility
- Both client implementations now follow the same pattern: define a `_do_request()` closure and delegate retry handling to the helper

https://claude.ai/code/session_01LjzUdDWQceb42pYq1mucTy