### PR TITLE
Add robot_review script to check Robot Framework test tag compliance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,28 @@ After a working solution is committed and tests pass:
    to submit, not while still mid-implementation. Do not block the user with
    questions while other agents need attention.
 
+### PR review workflow (mandatory)
+
+After pushing the PR, check for review feedback using the `gh` CLI. Codex
+reviews can be slow — wait patiently and poll periodically.
+
+```bash
+# List comments on a PR (replace 123 with PR number)
+gh pr view 123 --comments
+gh api repos/tkarcheski/robotframework-chat/pulls/123/comments
+gh api repos/tkarcheski/robotframework-chat/pulls/123/reviews
+
+# Check PR status and review state
+gh pr checks 123
+gh pr status
+```
+
+1. **After pushing**, run `gh pr view <number> --comments` to check for review
+   feedback. Codex reviews are slow — wait and re-check if no comments yet.
+2. **Address all review comments** before requesting re-review. Make fixes in
+   new commits (do not amend or squash until the reviewer approves).
+3. **Re-push** and re-check for additional feedback until the PR is approved.
+
 ---
 
 ## Architecture guardrails

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ export
 
 .PHONY: help install update \
         robot robot-math robot-accounting robot-docker robot-safety robot-superset robot-dryrun \
+        robot-review \
         robot-bash robot-c robot-rust robot-computer-skills \
         robot robot-math robot-accounting robot-docker robot-safety robot-superset robot-dryrun \
         send-results \
@@ -84,6 +85,9 @@ robot-superset: ## Test PostgreSQL connection and push host info to database
 
 robot-dryrun: ## Validate all Robot tests (dry run, no execution)
 	$(ROBOT) --dryrun --exclude browser -d results/dryrun $(DRYRUN_LISTENER) robot/
+
+robot-review: ## Check tag compliance in output.xml (run after robot-dryrun)
+	uv run python scripts/robot_review.py
 
 send-results: ## Send results to remote server via rsync (set RESULTS_SERVER_* env vars)
 	bash ci/send_results.sh

--- a/scripts/robot_review.py
+++ b/scripts/robot_review.py
@@ -21,6 +21,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from robot.api import ExecutionResult  # type: ignore[import-not-found]
+from robot.errors import DataError  # type: ignore[import-not-found]
 from robot.result.model import TestCase, TestSuite  # type: ignore[import-not-found]
 
 VALID_TIERS: set[int] = {0, 1, 2, 3, 4, 5, 6}
@@ -53,8 +54,10 @@ def check_test(test_name: str, suite_name: str, tags: list[str]) -> Violation | 
     """
     issues: list[str] = []
 
-    tier_tags = [t for t in tags if t.startswith("tier:")]
-    verify_tags = [t for t in tags if t.startswith("verify:")]
+    # Robot Framework tags are case-insensitive; normalize before matching.
+    normalized = [t.lower() for t in tags]
+    tier_tags = [t for t in normalized if t.startswith("tier:")]
+    verify_tags = [t for t in normalized if t.startswith("verify:")]
 
     # Duplicate detection
     if len(tier_tags) > 1:
@@ -199,7 +202,7 @@ def main() -> int:
     for path in args.paths:
         try:
             results.append(review_output_xml(path))
-        except FileNotFoundError as exc:
+        except (FileNotFoundError, DataError) as exc:
             print(f"ERROR: {exc}", file=sys.stderr)
             return 2
 

--- a/scripts/robot_review.py
+++ b/scripts/robot_review.py
@@ -1,0 +1,213 @@
+"""Check Robot Framework test tag compliance in output.xml files.
+
+Every test must have exactly one ``tier:*`` (0-6) and one ``verify:*``
+(robot|python|llm|llms) tag.  Parses output.xml via the Robot Framework
+API and reports violations with a non-zero exit code for CI gating.
+
+Usage:
+    uv run python scripts/robot_review.py [output.xml ...]
+    uv run python scripts/robot_review.py results/dryrun/output.xml
+    uv run python scripts/robot_review.py --quiet results/*/output.xml
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Allow imports from src/
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from robot.api import ExecutionResult  # type: ignore[import-not-found]
+from robot.result.model import TestCase, TestSuite  # type: ignore[import-not-found]
+
+VALID_TIERS: set[int] = {0, 1, 2, 3, 4, 5, 6}
+VALID_VERIFY: set[str] = {"robot", "python", "llm", "llms"}
+
+
+@dataclass
+class Violation:
+    """A single test that violates tag compliance rules."""
+
+    test_name: str
+    suite_name: str
+    issues: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ReviewResult:
+    """Aggregated compliance result for one output.xml file."""
+
+    total_tests: int
+    compliant: int
+    violations: list[Violation]
+    file_path: str
+
+
+def check_test(test_name: str, suite_name: str, tags: list[str]) -> Violation | None:
+    """Check a single test's tags for compliance.
+
+    Returns a Violation if non-compliant, or None if the test passes.
+    """
+    issues: list[str] = []
+
+    tier_tags = [t for t in tags if t.startswith("tier:")]
+    verify_tags = [t for t in tags if t.startswith("verify:")]
+
+    # Duplicate detection
+    if len(tier_tags) > 1:
+        issues.append(f"multiple tier:* tags ({', '.join(tier_tags)})")
+    if len(verify_tags) > 1:
+        issues.append(f"multiple verify:* tags ({', '.join(verify_tags)})")
+
+    # Tier validation
+    if len(tier_tags) == 0:
+        issues.append("missing tier:* tag")
+    elif len(tier_tags) == 1:
+        raw = tier_tags[0].split(":", 1)[1]
+        try:
+            tier_val = int(raw)
+            if tier_val not in VALID_TIERS:
+                issues.append(f"invalid tier value: {tier_val} (expected 0-6)")
+        except ValueError:
+            issues.append(f"non-numeric tier value: {raw}")
+
+    # Verify validation
+    if len(verify_tags) == 0:
+        issues.append("missing verify:* tag")
+    elif len(verify_tags) == 1:
+        verify_val = verify_tags[0].split(":", 1)[1]
+        if verify_val not in VALID_VERIFY:
+            issues.append(
+                f"invalid verify value: {verify_val} "
+                f"(expected {', '.join(sorted(VALID_VERIFY))})"
+            )
+
+    if issues:
+        return Violation(test_name=test_name, suite_name=suite_name, issues=issues)
+    return None
+
+
+def _collect_tests(
+    suite: TestSuite,
+) -> list[tuple[str, str, list[str]]]:
+    """Recursively collect (test_name, suite_name, tags) from a suite tree."""
+    tests: list[tuple[str, str, list[str]]] = []
+    for test in suite.tests:
+        assert isinstance(test, TestCase)
+        tests.append((test.name, suite.name, list(test.tags)))
+    for child in suite.suites:
+        tests.extend(_collect_tests(child))
+    return tests
+
+
+def review_output_xml(path: str) -> ReviewResult:
+    """Parse an output.xml file and check all tests for tag compliance.
+
+    Raises:
+        FileNotFoundError: If the path does not exist.
+    """
+    if not Path(path).exists():
+        raise FileNotFoundError(f"output.xml not found: {path}")
+
+    result = ExecutionResult(path)
+    all_tests = _collect_tests(result.suite)
+
+    violations: list[Violation] = []
+    for test_name, suite_name, tags in all_tests:
+        v = check_test(test_name, suite_name, tags)
+        if v is not None:
+            violations.append(v)
+
+    compliant = len(all_tests) - len(violations)
+    return ReviewResult(
+        total_tests=len(all_tests),
+        compliant=compliant,
+        violations=violations,
+        file_path=path,
+    )
+
+
+def print_report(results: list[ReviewResult], *, quiet: bool = False) -> None:
+    """Print a compliance report to stdout."""
+    total_all = sum(r.total_tests for r in results)
+    compliant_all = sum(r.compliant for r in results)
+    violations_all = sum(len(r.violations) for r in results)
+
+    print("\nTag Compliance Report")
+    print("=" * 60)
+
+    for r in results:
+        if len(results) > 1:
+            print(f"\nFile: {r.file_path}")
+            print("-" * 60)
+
+        pct = (r.compliant / r.total_tests * 100) if r.total_tests else 0
+        print(f"  Total tests:  {r.total_tests}")
+        print(f"  Compliant:    {r.compliant} ({pct:.1f}%)")
+        print(f"  Violations:   {len(r.violations)}")
+
+        if not quiet and r.violations:
+            print()
+            for v in r.violations:
+                print(f"  FAIL  {v.test_name}")
+                print(f"        Suite: {v.suite_name}")
+                for issue in v.issues:
+                    print(f"        - {issue}")
+                print()
+
+    if len(results) > 1:
+        print("=" * 60)
+        total_pct = (compliant_all / total_all * 100) if total_all else 0
+        print(f"  TOTAL: {compliant_all}/{total_all} compliant ({total_pct:.1f}%)")
+
+    print("=" * 60)
+    if violations_all == 0:
+        print("  PASS: All tests have valid tier:* and verify:* tags.")
+    else:
+        print(f"  FAIL: {violations_all} test(s) with tag violations.")
+    print()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Check Robot Framework test tag compliance in output.xml files.",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=["results/dryrun/output.xml"],
+        help="output.xml file path(s) to check (default: results/dryrun/output.xml)",
+    )
+    parser.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="Only print summary, not individual violations",
+    )
+    return parser
+
+
+def main() -> int:
+    """Entry point. Returns 0 if compliant, 1 if violations, 2 if file error."""
+    args = build_parser().parse_args()
+
+    results: list[ReviewResult] = []
+    for path in args.paths:
+        try:
+            results.append(review_output_xml(path))
+        except FileNotFoundError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+
+    print_report(results, quiet=args.quiet)
+
+    total_violations = sum(len(r.violations) for r in results)
+    return 1 if total_violations > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks.py
+++ b/tasks.py
@@ -127,6 +127,11 @@ def robot_dryrun() -> None:
     )
 
 
+def robot_review() -> None:
+    """Check tag compliance in output.xml (run after robot-dryrun)."""
+    _uv_run("python", "scripts/robot_review.py")
+
+
 def run_local_models() -> None:
     """Run test suites against every model on every local node."""
     _ensure_env()
@@ -223,6 +228,7 @@ TARGETS: dict[str, object] = {
     "robot-accounting": robot_accounting,
     "robot-safety": robot_safety,
     "robot-dryrun": robot_dryrun,
+    "robot-review": robot_review,
     "run-local-models": run_local_models,
     "robot-autopilot": robot_autopilot,
     "import-results": import_results,

--- a/tests/test_robot_review.py
+++ b/tests/test_robot_review.py
@@ -12,10 +12,12 @@ import sys
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
+from robot.errors import DataError  # noqa: E402
 from robot_review import (  # noqa: E402
     ReviewResult,
     Violation,
     check_test,
+    main,
     print_report,
     review_output_xml,
 )
@@ -45,6 +47,19 @@ class TestCheckTestCompliant:
     @pytest.mark.parametrize("verify", ["robot", "python", "llm", "llms"])
     def test_all_valid_verify(self, verify: str) -> None:
         result = check_test("T", "S", ["tier:0", f"verify:{verify}"])
+        assert result is None
+
+    def test_mixed_case_tags(self) -> None:
+        """Robot Framework tags are case-insensitive; mixed case must pass."""
+        result = check_test("T", "S", ["TIER:2", "VERIFY:LLM"])
+        assert result is None
+
+    def test_title_case_tags(self) -> None:
+        result = check_test("T", "S", ["Tier:0", "Verify:Robot"])
+        assert result is None
+
+    def test_mixed_case_verify_value(self) -> None:
+        result = check_test("T", "S", ["tier:1", "Verify:Python"])
         assert result is None
 
 
@@ -174,6 +189,18 @@ class TestReviewOutputXml:
         with pytest.raises(FileNotFoundError):
             review_output_xml("/nonexistent/output.xml")
 
+    def test_malformed_xml(self, tmp_path: Path) -> None:
+        """Malformed XML should raise DataError, caught as exit code 2."""
+        bad_file = tmp_path / "output.xml"
+        bad_file.write_text("<<<not valid xml>>>")
+        with pytest.raises(DataError):
+            review_output_xml(str(bad_file))
+
+    def test_directory_instead_of_file(self, tmp_path: Path) -> None:
+        """Passing a directory should raise DataError, not a traceback."""
+        with pytest.raises(DataError):
+            review_output_xml(str(tmp_path))
+
     def test_file_path_stored(self, tmp_path: Path) -> None:
         xml_file = tmp_path / "output.xml"
         xml_file.write_text(_COMPLIANT_XML)
@@ -230,3 +257,26 @@ class TestPrintReport:
         captured = capsys.readouterr().out
         assert "Bad Test" in captured
         assert "Worse Test" in captured
+
+
+# ── main() exit code tests ────────────────────────────────────────────
+
+
+class TestMainExitCode:
+    """Verify main() returns correct exit codes for error cases."""
+
+    def test_malformed_xml_returns_2(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Malformed XML should exit 2 (file error), not crash with a traceback."""
+        bad_file = tmp_path / "output.xml"
+        bad_file.write_text("<<<not valid xml>>>")
+        monkeypatch.setattr("sys.argv", ["robot_review", str(bad_file)])
+        assert main() == 2
+
+    def test_directory_returns_2(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Passing a directory should exit 2 (file error), not crash."""
+        monkeypatch.setattr("sys.argv", ["robot_review", str(tmp_path)])
+        assert main() == 2

--- a/tests/test_robot_review.py
+++ b/tests/test_robot_review.py
@@ -1,0 +1,232 @@
+"""Tests for scripts/robot_review.py — Robot Framework tag compliance checker."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# The script uses sys.path manipulation; replicate it for test imports.
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from robot_review import (  # noqa: E402
+    ReviewResult,
+    Violation,
+    check_test,
+    print_report,
+    review_output_xml,
+)
+
+
+# ── check_test() unit tests ─────────────────────────────────────────
+
+
+class TestCheckTestCompliant:
+    """Tests where tags are fully compliant — no violation returned."""
+
+    def test_tier0_verify_robot(self) -> None:
+        result = check_test("My Test", "Suite", ["tier:0", "verify:robot"])
+        assert result is None
+
+    def test_extra_tags_ignored(self) -> None:
+        result = check_test(
+            "My Test", "Suite", ["tier:2", "verify:llm", "IQ:100", "math"]
+        )
+        assert result is None
+
+    @pytest.mark.parametrize("tier", [0, 1, 2, 3, 4, 5, 6])
+    def test_all_valid_tiers(self, tier: int) -> None:
+        result = check_test("T", "S", [f"tier:{tier}", "verify:robot"])
+        assert result is None
+
+    @pytest.mark.parametrize("verify", ["robot", "python", "llm", "llms"])
+    def test_all_valid_verify(self, verify: str) -> None:
+        result = check_test("T", "S", ["tier:0", f"verify:{verify}"])
+        assert result is None
+
+
+class TestCheckTestViolations:
+    """Tests where tags are non-compliant — Violation returned."""
+
+    def test_missing_tier(self) -> None:
+        v = check_test("T", "S", ["verify:robot"])
+        assert v is not None
+        assert any("tier" in issue.lower() for issue in v.issues)
+
+    def test_missing_verify(self) -> None:
+        v = check_test("T", "S", ["tier:1"])
+        assert v is not None
+        assert any("verify" in issue.lower() for issue in v.issues)
+
+    def test_missing_both(self) -> None:
+        v = check_test("T", "S", [])
+        assert v is not None
+        assert len(v.issues) == 2
+
+    def test_invalid_tier_value(self) -> None:
+        v = check_test("T", "S", ["tier:9", "verify:robot"])
+        assert v is not None
+        assert any("9" in issue for issue in v.issues)
+
+    def test_invalid_verify_value(self) -> None:
+        v = check_test("T", "S", ["tier:0", "verify:magic"])
+        assert v is not None
+        assert any("magic" in issue for issue in v.issues)
+
+    def test_duplicate_tier(self) -> None:
+        v = check_test("T", "S", ["tier:0", "tier:1", "verify:robot"])
+        assert v is not None
+        assert any(
+            "duplicate" in issue.lower() or "multiple" in issue.lower()
+            for issue in v.issues
+        )
+
+    def test_duplicate_verify(self) -> None:
+        v = check_test("T", "S", ["tier:0", "verify:robot", "verify:llm"])
+        assert v is not None
+        assert any(
+            "duplicate" in issue.lower() or "multiple" in issue.lower()
+            for issue in v.issues
+        )
+
+    def test_non_numeric_tier(self) -> None:
+        v = check_test("T", "S", ["tier:abc", "verify:robot"])
+        assert v is not None
+        assert any("tier" in issue.lower() for issue in v.issues)
+
+    def test_violation_has_test_name(self) -> None:
+        v = check_test("My Test Name", "My Suite", ["tier:0"])
+        assert v is not None
+        assert v.test_name == "My Test Name"
+        assert v.suite_name == "My Suite"
+
+
+# ── review_output_xml() integration tests ────────────────────────────
+
+# Minimal output.xml that robot.api.ExecutionResult can parse.
+_COMPLIANT_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<robot generator="Robot 7.4.1" generated="2026-03-20T10:00:00.000000">
+  <suite id="s1" name="Test Suite" source="/tmp/test.robot">
+    <test id="s1-t1" name="Compliant Test" line="5">
+      <tag>tier:0</tag>
+      <tag>verify:robot</tag>
+      <status status="PASS" start="2026-03-20T10:00:00.000000" elapsed="0.001"/>
+    </test>
+    <status status="PASS" start="2026-03-20T10:00:00.000000" elapsed="0.002"/>
+  </suite>
+  <statistics>
+    <total><stat pass="1" fail="0" skip="0">All Tests</stat></total>
+  </statistics>
+</robot>
+"""
+
+_MIXED_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<robot generator="Robot 7.4.1" generated="2026-03-20T10:00:00.000000">
+  <suite id="s1" name="Test Suite" source="/tmp/test.robot">
+    <test id="s1-t1" name="Good Test" line="5">
+      <tag>tier:0</tag>
+      <tag>verify:robot</tag>
+      <status status="PASS" start="2026-03-20T10:00:00.000000" elapsed="0.001"/>
+    </test>
+    <test id="s1-t2" name="Missing Tags" line="10">
+      <tag>IQ:100</tag>
+      <status status="PASS" start="2026-03-20T10:00:01.000000" elapsed="0.001"/>
+    </test>
+    <test id="s1-t3" name="Bad Tier" line="15">
+      <tag>tier:9</tag>
+      <tag>verify:robot</tag>
+      <status status="PASS" start="2026-03-20T10:00:02.000000" elapsed="0.001"/>
+    </test>
+    <status status="PASS" start="2026-03-20T10:00:00.000000" elapsed="0.003"/>
+  </suite>
+  <statistics>
+    <total><stat pass="3" fail="0" skip="0">All Tests</stat></total>
+  </statistics>
+</robot>
+"""
+
+
+class TestReviewOutputXml:
+    """Integration tests that parse real output.xml content."""
+
+    def test_compliant_file(self, tmp_path: Path) -> None:
+        xml_file = tmp_path / "output.xml"
+        xml_file.write_text(_COMPLIANT_XML)
+        result = review_output_xml(str(xml_file))
+        assert result.total_tests == 1
+        assert result.compliant == 1
+        assert len(result.violations) == 0
+
+    def test_mixed_file(self, tmp_path: Path) -> None:
+        xml_file = tmp_path / "output.xml"
+        xml_file.write_text(_MIXED_XML)
+        result = review_output_xml(str(xml_file))
+        assert result.total_tests == 3
+        assert result.compliant == 1
+        assert len(result.violations) == 2
+
+    def test_file_not_found(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            review_output_xml("/nonexistent/output.xml")
+
+    def test_file_path_stored(self, tmp_path: Path) -> None:
+        xml_file = tmp_path / "output.xml"
+        xml_file.write_text(_COMPLIANT_XML)
+        result = review_output_xml(str(xml_file))
+        assert result.file_path == str(xml_file)
+
+
+# ── print_report() output tests ─────────────────────────────────────
+
+
+class TestPrintReport:
+    """Test that print_report produces expected output."""
+
+    def test_compliant_report(self, capsys: pytest.CaptureFixture[str]) -> None:
+        results = [
+            ReviewResult(
+                total_tests=5,
+                compliant=5,
+                violations=[],
+                file_path="results/output.xml",
+            )
+        ]
+        print_report(results)
+        captured = capsys.readouterr().out
+        assert "5" in captured
+        assert "100" in captured  # 100%
+        assert (
+            "PASS" in captured
+            or "pass" in captured.lower()
+            or "compliant" in captured.lower()
+        )
+
+    def test_violation_report(self, capsys: pytest.CaptureFixture[str]) -> None:
+        results = [
+            ReviewResult(
+                total_tests=3,
+                compliant=1,
+                violations=[
+                    Violation(
+                        test_name="Bad Test",
+                        suite_name="Suite",
+                        issues=["missing tier:* tag"],
+                    ),
+                    Violation(
+                        test_name="Worse Test",
+                        suite_name="Suite",
+                        issues=["missing tier:* tag", "missing verify:* tag"],
+                    ),
+                ],
+                file_path="results/output.xml",
+            )
+        ]
+        print_report(results)
+        captured = capsys.readouterr().out
+        assert "Bad Test" in captured
+        assert "Worse Test" in captured


### PR DESCRIPTION
## Summary
Adds a new `robot_review.py` script that validates Robot Framework test tag compliance in `output.xml` files. Every test must have exactly one `tier:*` (0-6) and one `verify:*` (robot|python|llm|llms) tag. The script parses output.xml files via the Robot Framework API and reports violations with a non-zero exit code for CI gating.

## Key Changes
- **New script**: `scripts/robot_review.py` with the following components:
  - `check_test()`: Validates individual test tags and returns violations for non-compliant tests
  - `review_output_xml()`: Parses output.xml files and aggregates compliance results
  - `print_report()`: Generates formatted compliance reports with summary statistics
  - CLI interface with `--quiet` flag for suppressing individual violation details
  - Exit codes: 0 (compliant), 1 (violations found), 2 (file error)

- **Comprehensive test suite**: `tests/test_robot_review.py` with 232 lines covering:
  - Unit tests for `check_test()` with compliant and non-compliant scenarios
  - Integration tests for `review_output_xml()` with real XML parsing
  - Output validation tests for `print_report()`
  - Edge cases: duplicate tags, invalid values, missing tags, non-numeric values

- **Build system integration**:
  - Added `robot_review()` task to `tasks.py`
  - Added `robot-review` target to `Makefile`
  - Integrates with existing Robot Framework test workflow

## Implementation Details
- Uses Robot Framework's `ExecutionResult` API to parse output.xml files
- Recursively collects tests from nested suite hierarchies
- Validates tier values (0-6) and verify values (robot, python, llm, llms)
- Detects and reports multiple violations per test (missing tags, invalid values, duplicates)
- Provides detailed error messages with expected values for invalid tags
- Supports batch processing of multiple output.xml files with aggregated reporting

https://claude.ai/code/session_01N3NZYgNnUvJE5mje9hdHgW