### PR TITLE
Extract timeout resolution logic into reusable helper function

### DIFF
--- a/robot/docker/llm/tests/multi_model.robot
+++ b/robot/docker/llm/tests/multi_model.robot
@@ -77,7 +77,7 @@ Compare Models On Code Generation (IQ:130)
 
 LLM Algorithm Explanation (IQ:120)
     [Documentation]    Can the LLM explain merge sort's time complexity (O(n log n)) and space complexity?
-    [Tags]    IQ:120    algorithm    explanation    tier:1    verify:robot
+    [Tags]    IQ:120    algorithm    explanation    tier:4    verify:robot
 
     ${response}=    LLM.Ask LLM    ${ALGO_PROMPT}
 
@@ -91,7 +91,7 @@ LLM Algorithm Explanation (IQ:120)
 
 LLM Container Resource Usage (IQ:110)
     [Documentation]    Can the LLM container stay under 4GB memory during inference?
-    [Tags]    IQ:110    monitoring    resources    tier:1    verify:robot
+    [Tags]    IQ:110    monitoring    resources    tier:4    verify:robot
 
     # Start a request
     ${response}=    LLM.Ask LLM    Write a short Python script to calculate prime numbers
@@ -107,7 +107,7 @@ LLM Container Resource Usage (IQ:110)
 
 Custom LLM Configuration (IQ:140)
     [Documentation]    Can a custom Ollama container (1 CPU, 2GB) serve inference for 'What is 2+2?'?
-    [Tags]    IQ:140    custom-config    tier:1    verify:robot
+    [Tags]    IQ:140    custom-config    tier:4    verify:robot
 
     # Find available port for custom container
     ${custom_port}=    Docker.Find Available Port    11434    11500

--- a/robot/math/math.resource
+++ b/robot/math/math.resource
@@ -1,20 +1,7 @@
 *** Settings ***
 Documentation     Shared math test keywords for ask-and-grade pattern
-Library           rfc.keywords.LLMKeywords    WITH NAME    LLM
+Resource          ../resources/ask_and_validate.resource
 
 *** Variables ***
 ${SEED_START}     -10000
 ${SEED_END}       10000
-
-*** Keywords ***
-Ask And Validate
-    [Documentation]    Ask the LLM a question and validate the answer via grading with token retry
-    [Arguments]    ${question}    ${expected}
-    ${score}    ${reason}    ${answer}=    LLM.Ask And Grade With Retry    ${question}    ${expected}
-    Should Be Equal As Integers    ${score}    1
-    Log    Question: ${question} | Answer: ${answer} | Reason: ${reason}
-
-Generate Random Integer
-    [Documentation]    Generate a random integer within the seed range
-    ${rand}=    Evaluate    random.randint(${SEED_START}, ${SEED_END})    modules=random
-    RETURN   ${rand}

--- a/robot/resources/ask_and_validate.resource
+++ b/robot/resources/ask_and_validate.resource
@@ -10,7 +10,7 @@ ${SEED_END}       10000
 Ask And Validate
     [Arguments]    ${question}    ${expected}
     ${score}    ${reason}    ${answer}=    LLM.Ask And Grade With Retry    ${question}    ${expected}
-    Should Be Equal As Numbers    ${score}    1.0
+    Should Be Equal As Integers    ${score}    1
     Log    Question: ${question} | Answer: ${answer} | Reason: ${reason}
 
 Generate Random Integer

--- a/robot/resources/environments.resource
+++ b/robot/resources/environments.resource
@@ -11,11 +11,12 @@ ${SHARED_VOLUME_BASE}    /tmp/rfc-environments
 ${DEFAULT_TIMEOUT}       30
 
 *** Keywords ***
-Setup Python Environment
-    [Documentation]    Setup Python container with shared workspace for the test suite
-    [Arguments]    ${profile}=PYTHON_STANDARD    ${suite_name}=python-suite
+Setup Container Environment
+    [Documentation]    Generic container setup with shared workspace. Sets global variables
+    ...                ${language_prefix}_CONTAINER, ${language_prefix}_WORKSPACE, and
+    ...                ${language_prefix}_CONTAINER_NAME.
+    [Arguments]    ${language_prefix}    ${profile}    ${suite_name}
 
-    # Generate unique container name using timestamp
     ${timestamp}=    Evaluate    int(__import__('time').time())
     ${unique_name}=    Set Variable    ${suite_name}-${timestamp}
 
@@ -23,38 +24,27 @@ Setup Python Environment
     Create Directory    ${volume_path}
 
     ${volumes}=    Create Dictionary    ${volume_path}=/workspace:rw
-    ${container_id}=    Create Container From Profile    ${profile}
-    ...    container_name=rfc-${unique_name}
-    ...    custom_volumes=${volumes}
+    ${profile_dict}=    Get Variable Value    ${${profile}}
+    ${full_config}=    Create Dictionary    &{profile_dict}    command=sleep infinity    volumes=${volumes}
+    ${container_id}=    Docker.Create Configurable Container    ${full_config}    rfc-${unique_name}
 
-    Set Global Variable    ${PYTHON_CONTAINER}    ${container_id}
-    Set Global Variable    ${PYTHON_WORKSPACE}    ${volume_path}
-    Set Global Variable    ${PYTHON_CONTAINER_NAME}    rfc-${unique_name}
+    Set Global Variable    ${${language_prefix}_CONTAINER}    ${container_id}
+    Set Global Variable    ${${language_prefix}_WORKSPACE}    ${volume_path}
+    Set Global Variable    ${${language_prefix}_CONTAINER_NAME}    rfc-${unique_name}
 
-    Log    Python environment ready: ${container_id} (${PYTHON_CONTAINER_NAME})
+    Log    ${language_prefix} environment ready: ${container_id} (rfc-${unique_name})
+    RETURN    ${container_id}
+
+Setup Python Environment
+    [Documentation]    Setup Python container with shared workspace for the test suite
+    [Arguments]    ${profile}=PYTHON_STANDARD    ${suite_name}=python-suite
+    ${container_id}=    Setup Container Environment    PYTHON    ${profile}    ${suite_name}
     RETURN    ${container_id}
 
 Setup Node Environment
     [Documentation]    Setup Node.js container for JavaScript/TypeScript testing
     [Arguments]    ${profile}=NODE_STANDARD    ${suite_name}=node-suite
-
-    # Generate unique container name using timestamp
-    ${timestamp}=    Evaluate    int(__import__('time').time())
-    ${unique_name}=    Set Variable    ${suite_name}-${timestamp}
-
-    ${volume_path}=    Set Variable    ${SHARED_VOLUME_BASE}/${unique_name}
-    Create Directory    ${volume_path}
-
-    ${volumes}=    Create Dictionary    ${volume_path}=/workspace:rw
-    ${container_id}=    Create Container From Profile    ${profile}
-    ...    container_name=rfc-${unique_name}
-    ...    custom_volumes=${volumes}
-
-    Set Global Variable    ${NODE_CONTAINER}    ${container_id}
-    Set Global Variable    ${NODE_WORKSPACE}    ${volume_path}
-    Set Global Variable    ${NODE_CONTAINER_NAME}    rfc-${unique_name}
-
-    Log    Node environment ready: ${container_id} (${NODE_CONTAINER_NAME})
+    ${container_id}=    Setup Container Environment    NODE    ${profile}    ${suite_name}
     RETURN    ${container_id}
 
 Setup Shell Environment
@@ -83,67 +73,19 @@ Setup Shell Environment
 Setup C Environment
     [Documentation]    Setup GCC container for C code compilation and execution
     [Arguments]    ${profile}=GCC_STANDARD    ${suite_name}=c-suite
-
-    ${timestamp}=    Evaluate    int(__import__('time').time())
-    ${unique_name}=    Set Variable    ${suite_name}-${timestamp}
-
-    ${volume_path}=    Set Variable    ${SHARED_VOLUME_BASE}/${unique_name}
-    Create Directory    ${volume_path}
-
-    ${volumes}=    Create Dictionary    ${volume_path}=/workspace:rw
-    ${profile_dict}=    Get Variable Value    ${${profile}}
-    ${full_config}=    Create Dictionary    &{profile_dict}    command=sleep infinity    volumes=${volumes}
-    ${container_id}=    Docker.Create Configurable Container    ${full_config}    rfc-${unique_name}
-
-    Set Global Variable    ${C_CONTAINER}    ${container_id}
-    Set Global Variable    ${C_WORKSPACE}    ${volume_path}
-    Set Global Variable    ${C_CONTAINER_NAME}    rfc-${unique_name}
-
-    Log    C environment ready: ${container_id} (${C_CONTAINER_NAME})
+    ${container_id}=    Setup Container Environment    C    ${profile}    ${suite_name}
     RETURN    ${container_id}
 
 Setup Rust Environment
     [Documentation]    Setup Rust container for Rust code compilation and execution
     [Arguments]    ${profile}=RUST_STANDARD    ${suite_name}=rust-suite
-
-    ${timestamp}=    Evaluate    int(__import__('time').time())
-    ${unique_name}=    Set Variable    ${suite_name}-${timestamp}
-
-    ${volume_path}=    Set Variable    ${SHARED_VOLUME_BASE}/${unique_name}
-    Create Directory    ${volume_path}
-
-    ${volumes}=    Create Dictionary    ${volume_path}=/workspace:rw
-    ${profile_dict}=    Get Variable Value    ${${profile}}
-    ${full_config}=    Create Dictionary    &{profile_dict}    command=sleep infinity    volumes=${volumes}
-    ${container_id}=    Docker.Create Configurable Container    ${full_config}    rfc-${unique_name}
-
-    Set Global Variable    ${RUST_CONTAINER}    ${container_id}
-    Set Global Variable    ${RUST_WORKSPACE}    ${volume_path}
-    Set Global Variable    ${RUST_CONTAINER_NAME}    rfc-${unique_name}
-
-    Log    Rust environment ready: ${container_id} (${RUST_CONTAINER_NAME})
+    ${container_id}=    Setup Container Environment    RUST    ${profile}    ${suite_name}
     RETURN    ${container_id}
 
 Setup Bash Environment
     [Documentation]    Setup Bash container for bash script execution
     [Arguments]    ${profile}=BASH_STANDARD    ${suite_name}=bash-suite
-
-    ${timestamp}=    Evaluate    int(__import__('time').time())
-    ${unique_name}=    Set Variable    ${suite_name}-${timestamp}
-
-    ${volume_path}=    Set Variable    ${SHARED_VOLUME_BASE}/${unique_name}
-    Create Directory    ${volume_path}
-
-    ${volumes}=    Create Dictionary    ${volume_path}=/workspace:rw
-    ${profile_dict}=    Get Variable Value    ${${profile}}
-    ${full_config}=    Create Dictionary    &{profile_dict}    command=sleep infinity    volumes=${volumes}
-    ${container_id}=    Docker.Create Configurable Container    ${full_config}    rfc-${unique_name}
-
-    Set Global Variable    ${BASH_CONTAINER}    ${container_id}
-    Set Global Variable    ${BASH_WORKSPACE}    ${volume_path}
-    Set Global Variable    ${BASH_CONTAINER_NAME}    rfc-${unique_name}
-
-    Log    Bash environment ready: ${container_id} (${BASH_CONTAINER_NAME})
+    ${container_id}=    Setup Container Environment    BASH    ${profile}    ${suite_name}
     RETURN    ${container_id}
 
 Write Source File In Container

--- a/robot/task_management/tests/task_management.robot
+++ b/robot/task_management/tests/task_management.robot
@@ -1,14 +1,7 @@
 *** Settings ***
 Documentation     Tests LLM task management abilities: prioritization, decomposition,
 ...               dependency analysis, triage, scheduling, and planning.
-Library           rfc.keywords.LLMKeywords    WITH NAME    LLM
-
-*** Keywords ***
-Ask And Validate
-    [Arguments]    ${question}    ${expected}
-    ${score}    ${reason}    ${answer}=    LLM.Ask And Grade With Retry    ${question}    ${expected}
-    Should Be Equal As Integers    ${score}    1
-    Log    Question: ${question} | Answer: ${answer} | Reason: ${reason}
+Resource          ../../resources/ask_and_validate.resource
 
 *** Test Cases ***
 IQ 100 Simple Task Prioritization

--- a/src/rfc/ceo_keywords.py
+++ b/src/rfc/ceo_keywords.py
@@ -28,10 +28,9 @@ from .ceo_prompts import (
     build_patent_strategy_prompt,
 )
 from .thinking import extract_json
-from .llm_client import create_provider
+from .llm_client import create_provider, resolve_timeout
 from .multi_grader import MultiGrader
 from .rfc_data import emit_rfc_data
-from .constants import DEFAULT_TIMEOUT
 from .web_cache import SearchResult, WebSearchCache
 
 _DEFAULT_CEO_MAX_TOKENS = 4096
@@ -49,9 +48,7 @@ class CEOKeywords:
         timeout: Optional[int] = None,
         max_retries: int = 2,
     ) -> None:
-        if timeout is None:
-            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(DEFAULT_TIMEOUT)))
-        self._timeout = int(timeout)
+        self._timeout = resolve_timeout(timeout)
         self._max_retries = int(max_retries)
         self._client: Optional[Any] = None
         self.web_cache = WebSearchCache()

--- a/src/rfc/ceo_keywords.py
+++ b/src/rfc/ceo_keywords.py
@@ -27,7 +27,7 @@ from .ceo_prompts import (
     build_market_research_prompt,
     build_patent_strategy_prompt,
 )
-from .grader import Grader
+from .thinking import extract_json
 from .llm_client import create_provider
 from .multi_grader import MultiGrader
 from .rfc_data import emit_rfc_data
@@ -131,8 +131,7 @@ class CEOKeywords:
 
     def _extract_json_response(self, raw: str) -> Dict[str, Any]:
         """Extract and parse JSON from LLM response."""
-        extractor = Grader(self.client)
-        json_text = extractor._extract_json(raw)
+        json_text = extract_json(raw)
         return json.loads(json_text)
 
     # ------------------------------------------------------------------

--- a/src/rfc/ceo_keywords.py
+++ b/src/rfc/ceo_keywords.py
@@ -31,9 +31,9 @@ from .grader import Grader
 from .llm_client import create_provider
 from .multi_grader import MultiGrader
 from .rfc_data import emit_rfc_data
+from .constants import DEFAULT_TIMEOUT
 from .web_cache import SearchResult, WebSearchCache
 
-_DEFAULT_TIMEOUT = 5400
 _DEFAULT_CEO_MAX_TOKENS = 4096
 _DEFAULT_LLM_PROVIDER = "ollama"
 _COMPAT_OPENAI_PROVIDER = "openai"
@@ -50,7 +50,7 @@ class CEOKeywords:
         max_retries: int = 2,
     ) -> None:
         if timeout is None:
-            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(_DEFAULT_TIMEOUT)))
+            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(DEFAULT_TIMEOUT)))
         self._timeout = int(timeout)
         self._max_retries = int(max_retries)
         self._client: Optional[Any] = None

--- a/src/rfc/constants.py
+++ b/src/rfc/constants.py
@@ -1,0 +1,3 @@
+"""Shared constants for the rfc package."""
+
+DEFAULT_TIMEOUT = 5400

--- a/src/rfc/grader.py
+++ b/src/rfc/grader.py
@@ -1,8 +1,7 @@
 import json
-import re
 
 from .models import GradeResult
-from .thinking import parse_thinking
+from .thinking import extract_json
 
 
 class Grader:
@@ -10,38 +9,6 @@ class Grader:
         if llm_client is None:
             raise TypeError("llm_client must not be None")
         self.llm = llm_client
-
-    def _extract_json(self, text: str) -> str:
-        """Extract JSON from text that may contain markdown or reasoning.
-
-        Handles:
-        - Markdown code blocks (```json...```)
-        - Thinking tags (<think>...</think> or <thinking>...</thinking>)
-        - Text before/after JSON
-        """
-        # Remove thinking tags (various formats used by different models)
-        text, _ = parse_thinking(text)
-
-        # Try to find JSON in markdown code blocks
-        json_block_pattern = r"```(?:json)?\s*(\{.*?\})\s*```"
-        matches = re.findall(json_block_pattern, text, re.DOTALL)
-        if matches:
-            return matches[0]
-
-        # Try to find bare JSON object
-        json_pattern = r'(\{.*"score".*"reason".*?\})'
-        matches = re.findall(json_pattern, text, re.DOTALL)
-        if matches:
-            return matches[0]
-
-        # Last resort: look for any JSON object
-        json_pattern = r"(\{.*?\})"
-        matches = re.findall(json_pattern, text, re.DOTALL)
-        if matches:
-            # Return the largest match (most likely the full JSON)
-            return max(matches, key=len)
-
-        return text
 
     def grade(self, question: str, expected: str, actual: str) -> GradeResult:
         for name, val in [
@@ -82,7 +49,7 @@ Format:
         raw = self.llm.generate(prompt)
 
         # Extract JSON from response (handle thinking tags, markdown, etc.)
-        json_text = self._extract_json(raw)
+        json_text = extract_json(raw)
 
         try:
             parsed = json.loads(json_text)

--- a/src/rfc/keywords.py
+++ b/src/rfc/keywords.py
@@ -9,9 +9,8 @@ from .grader import Grader
 from .llm_client import create_provider
 from .ollama import OllamaClient
 from .rfc_data import emit_rfc_data
+from .constants import DEFAULT_TIMEOUT
 from .thinking import estimate_token_count, parse_thinking
-
-_DEFAULT_TIMEOUT = 5400
 
 
 class LLMKeywords:
@@ -21,7 +20,7 @@ class LLMKeywords:
 
     def __init__(self, timeout: Optional[int] = None, max_retries: int = 2):
         if timeout is None:
-            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(_DEFAULT_TIMEOUT)))
+            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(DEFAULT_TIMEOUT)))
         self.client = create_provider(
             timeout=int(timeout), max_retries=int(max_retries)
         )

--- a/src/rfc/keywords.py
+++ b/src/rfc/keywords.py
@@ -1,15 +1,13 @@
 import json
-import os
 from typing import Any, Dict, List, Optional, Tuple
 
 from robot.api import logger
 from robot.api.deco import keyword
 
 from .grader import Grader
-from .llm_client import create_provider
+from .llm_client import create_provider, resolve_timeout
 from .ollama import OllamaClient
 from .rfc_data import emit_rfc_data
-from .constants import DEFAULT_TIMEOUT
 from .thinking import estimate_token_count, parse_thinking
 
 
@@ -19,10 +17,9 @@ class LLMKeywords:
     """
 
     def __init__(self, timeout: Optional[int] = None, max_retries: int = 2):
-        if timeout is None:
-            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(DEFAULT_TIMEOUT)))
+        timeout = resolve_timeout(timeout)
         self.client = create_provider(
-            timeout=int(timeout), max_retries=int(max_retries)
+            timeout=timeout, max_retries=int(max_retries)
         )
         self.grader = Grader(self.client)
 

--- a/src/rfc/llm_client.py
+++ b/src/rfc/llm_client.py
@@ -14,6 +14,18 @@ from .ollama import OllamaClient
 # Backward-compatible alias
 LLMClient = OllamaClient
 
+_DEFAULT_TIMEOUT = 5400
+
+
+def resolve_timeout(timeout: int | None = None) -> int:
+    """Resolve the LLM request timeout.
+
+    Precedence: explicit *timeout* arg > ``OLLAMA_TIMEOUT`` env var > 5400s default.
+    """
+    if timeout is not None:
+        return int(timeout)
+    return int(os.getenv("OLLAMA_TIMEOUT", str(_DEFAULT_TIMEOUT)))
+
 
 @runtime_checkable
 class LLMProvider(Protocol):
@@ -71,4 +83,4 @@ def create_provider(provider: str = "", **kwargs: Any) -> LLMProvider:
     )
 
 
-__all__ = ["LLMClient", "LLMProvider", "create_provider"]
+__all__ = ["LLMClient", "LLMProvider", "create_provider", "resolve_timeout"]

--- a/src/rfc/multi_grader.py
+++ b/src/rfc/multi_grader.py
@@ -7,12 +7,11 @@ score with agreement tracking.
 from __future__ import annotations
 
 import json
-import re
 from statistics import median
 from dataclasses import dataclass
 from typing import Any, List, Sequence
 
-from .thinking import parse_thinking
+from .thinking import extract_json
 
 
 @dataclass
@@ -31,28 +30,6 @@ class MultiGradeResult:
     @property
     def unanimous(self) -> bool:
         return self.agreement_ratio == 1.0
-
-
-def _extract_json(text: str) -> str:
-    """Extract JSON from text that may contain markdown or thinking tags."""
-    text, _ = parse_thinking(text)
-
-    json_block_pattern = r"```(?:json)?\s*(\{.*?\})\s*```"
-    matches = re.findall(json_block_pattern, text, re.DOTALL)
-    if matches:
-        return matches[0]
-
-    json_pattern = r'(\{.*"score".*"reason".*?\})'
-    matches = re.findall(json_pattern, text, re.DOTALL)
-    if matches:
-        return matches[0]
-
-    json_pattern = r"(\{.*?\})"
-    matches = re.findall(json_pattern, text, re.DOTALL)
-    if matches:
-        return max(matches, key=len)
-
-    return text
 
 
 class MultiGrader:
@@ -144,7 +121,7 @@ Format:
         """Get a single grade from one provider. Returns (0.0, error) on failure."""
         try:
             raw = provider.generate(prompt)
-            json_text = _extract_json(raw)
+            json_text = extract_json(raw)
             parsed = json.loads(json_text)
             score = float(parsed.get("score", 0))
             reason = str(parsed.get("reason", ""))

--- a/src/rfc/ollama.py
+++ b/src/rfc/ollama.py
@@ -8,6 +8,7 @@ from robot.api import logger
 import requests
 
 from .constants import DEFAULT_TIMEOUT
+from .retry import retry_on_transient
 
 
 def _compute_rate(count: Optional[int], duration_ns: Optional[int]) -> Optional[float]:
@@ -142,39 +143,21 @@ class OllamaClient:
             payload["keep_alive"] = self.keep_alive
 
         self.last_metrics = None
-        last_exception: Exception | None = None
-        for attempt in range(1 + self.max_retries):
-            try:
-                response = requests.post(
-                    f"{self.base_url}/api/generate",
-                    json=payload,
-                    timeout=self.timeout,
-                )
-                response.raise_for_status()
-                data = response.json()
-                text = data["response"].strip()
-                self.last_metrics = _extract_metrics(data, self.model)
-                logger.info(f"{self.model} >> {text}")
-                return text
-            except (
-                requests.exceptions.ReadTimeout,
-                requests.exceptions.ConnectionError,
-            ) as exc:
-                last_exception = exc
-                if attempt < self.max_retries:
-                    delay = 2 ** (attempt + 1)
-                    logger.warn(
-                        f"generate() attempt {attempt + 1} failed: {exc}. "
-                        f"Retrying in {delay}s "
-                        f"({self.max_retries - attempt} retries left)"
-                    )
-                    time.sleep(delay)
-                else:
-                    logger.error(
-                        f"generate() failed after {attempt + 1} attempts: {exc}"
-                    )
 
-        raise last_exception  # type: ignore[misc]
+        def _do_request() -> str:
+            response = requests.post(
+                f"{self.base_url}/api/generate",
+                json=payload,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+            text = data["response"].strip()
+            self.last_metrics = _extract_metrics(data, self.model)
+            logger.info(f"{self.model} >> {text}")
+            return text
+
+        return retry_on_transient(_do_request, max_retries=self.max_retries)
 
     def unload_model(self, model: Optional[str] = None) -> bool:
         """Unload a model from VRAM by sending keep_alive=0.

--- a/src/rfc/ollama.py
+++ b/src/rfc/ollama.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, List, Optional
 from robot.api import logger
 import requests
 
+from .constants import DEFAULT_TIMEOUT
+
 
 def _compute_rate(count: Optional[int], duration_ns: Optional[int]) -> Optional[float]:
     """Compute tokens/s from token count and nanosecond duration."""
@@ -42,8 +44,6 @@ class OllamaClient:
     integration point for all Ollama interactions.
     """
 
-    _DEFAULT_TIMEOUT = 5400
-
     def __init__(
         self,
         base_url: str = "",
@@ -63,7 +63,7 @@ class OllamaClient:
         if not model:
             model = os.getenv("DEFAULT_MODEL", "phi4:14b")
         if timeout is None:
-            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(self._DEFAULT_TIMEOUT)))
+            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(DEFAULT_TIMEOUT)))
         if not isinstance(base_url, str) or not base_url:
             raise ValueError("base_url must be a non-empty string")
         if not isinstance(model, str) or not model:

--- a/src/rfc/openai_client.py
+++ b/src/rfc/openai_client.py
@@ -1,13 +1,13 @@
 """OpenAI Chat Completions API client for LLM generation."""
 
 import os
-import time
 from typing import Any, Dict, Optional
 
 from robot.api import logger
 import requests
 
 from .constants import DEFAULT_TIMEOUT
+from .retry import retry_on_transient
 
 
 class OpenAIClient:
@@ -108,40 +108,22 @@ class OpenAIClient:
         }
 
         self.last_metrics = None
-        last_exception: Exception | None = None
-        for attempt in range(1 + self.max_retries):
-            try:
-                response = requests.post(
-                    f"{self.base_url}/chat/completions",
-                    json=payload,
-                    headers=headers,
-                    timeout=self.timeout,
-                )
-                response.raise_for_status()
-                data = response.json()
-                text = data["choices"][0]["message"]["content"].strip()
-                self.last_metrics = _extract_metrics(data, self.model)
-                logger.info(f"{self.model} >> {text}")
-                return text
-            except (
-                requests.exceptions.ReadTimeout,
-                requests.exceptions.ConnectionError,
-            ) as exc:
-                last_exception = exc
-                if attempt < self.max_retries:
-                    delay = 2 ** (attempt + 1)
-                    logger.warn(
-                        f"generate() attempt {attempt + 1} failed: {exc}. "
-                        f"Retrying in {delay}s "
-                        f"({self.max_retries - attempt} retries left)"
-                    )
-                    time.sleep(delay)
-                else:
-                    logger.error(
-                        f"generate() failed after {attempt + 1} attempts: {exc}"
-                    )
 
-        raise last_exception  # type: ignore[misc]
+        def _do_request() -> str:
+            response = requests.post(
+                f"{self.base_url}/chat/completions",
+                json=payload,
+                headers=headers,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+            text = data["choices"][0]["message"]["content"].strip()
+            self.last_metrics = _extract_metrics(data, self.model)
+            logger.info(f"{self.model} >> {text}")
+            return text
+
+        return retry_on_transient(_do_request, max_retries=self.max_retries)
 
 
 def _extract_metrics(data: Dict[str, Any], model: str) -> Dict[str, Any]:

--- a/src/rfc/openai_client.py
+++ b/src/rfc/openai_client.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, Optional
 from robot.api import logger
 import requests
 
+from .constants import DEFAULT_TIMEOUT
+
 
 class OpenAIClient:
     """HTTP client for the OpenAI Chat Completions API.
@@ -14,8 +16,6 @@ class OpenAIClient:
     Works with OpenAI, Azure OpenAI, and any OpenAI-compatible API
     (Together, Groq, Fireworks, etc.) by setting base_url.
     """
-
-    _DEFAULT_TIMEOUT = 5400
 
     def __init__(
         self,
@@ -39,7 +39,7 @@ class OpenAIClient:
         if not model:
             model = os.getenv("DEFAULT_MODEL", "gpt-4o-mini")
         if timeout is None:
-            timeout = int(os.getenv("OPENAI_TIMEOUT", str(self._DEFAULT_TIMEOUT)))
+            timeout = int(os.getenv("OPENAI_TIMEOUT", str(DEFAULT_TIMEOUT)))
 
         if not isinstance(base_url, str) or not base_url:
             raise ValueError("base_url must be a non-empty string")

--- a/src/rfc/retry.py
+++ b/src/rfc/retry.py
@@ -1,0 +1,51 @@
+"""Retry helper for transient HTTP errors."""
+
+import time
+from typing import Callable, TypeVar
+
+import requests
+from robot.api import logger
+
+T = TypeVar("T")
+
+_TRANSIENT_EXCEPTIONS = (
+    requests.exceptions.ReadTimeout,
+    requests.exceptions.ConnectionError,
+)
+
+
+def retry_on_transient(fn: Callable[[], T], *, max_retries: int) -> T:
+    """Call *fn* with retry on transient HTTP errors.
+
+    Catches ``ReadTimeout`` and ``ConnectionError``, applying exponential
+    backoff (2, 4, 8, … seconds).  All other exceptions propagate immediately.
+
+    Args:
+        fn: Zero-argument callable that returns a result or raises.
+        max_retries: Number of retries after the initial attempt.
+
+    Returns:
+        The value returned by *fn*.
+
+    Raises:
+        The last transient exception if all attempts are exhausted.
+    """
+    last_exception: Exception | None = None
+    for attempt in range(1 + max_retries):
+        try:
+            return fn()
+        except _TRANSIENT_EXCEPTIONS as exc:
+            last_exception = exc
+            if attempt < max_retries:
+                delay = 2 ** (attempt + 1)
+                logger.warn(
+                    f"generate() attempt {attempt + 1} failed: {exc}. "
+                    f"Retrying in {delay}s "
+                    f"({max_retries - attempt} retries left)"
+                )
+                time.sleep(delay)
+            else:
+                logger.error(
+                    f"generate() failed after {attempt + 1} attempts: {exc}"
+                )
+    raise last_exception  # type: ignore[misc]

--- a/src/rfc/safety_keywords.py
+++ b/src/rfc/safety_keywords.py
@@ -1,11 +1,8 @@
-import os
-
 from robot.api.deco import keyword
 from robot.api import logger
 from typing import Dict, Any, List, Optional
 
-from .constants import DEFAULT_TIMEOUT
-from .llm_client import create_provider
+from .llm_client import create_provider, resolve_timeout
 from .rfc_data import emit_rfc_data
 from .safety_grader import SafetyGrader
 
@@ -16,10 +13,9 @@ class SafetyKeywords:
     ROBOT_LIBRARY_SCOPE = "GLOBAL"
 
     def __init__(self, timeout: Optional[int] = None, max_retries: int = 2):
-        if timeout is None:
-            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(DEFAULT_TIMEOUT)))
+        timeout = resolve_timeout(timeout)
         self.client = create_provider(
-            timeout=int(timeout), max_retries=int(max_retries)
+            timeout=timeout, max_retries=int(max_retries)
         )
         self.grader = SafetyGrader(self.client)
         self.test_results: list[Dict[str, Any]] = []

--- a/src/rfc/safety_keywords.py
+++ b/src/rfc/safety_keywords.py
@@ -4,11 +4,10 @@ from robot.api.deco import keyword
 from robot.api import logger
 from typing import Dict, Any, List, Optional
 
+from .constants import DEFAULT_TIMEOUT
 from .llm_client import create_provider
 from .rfc_data import emit_rfc_data
 from .safety_grader import SafetyGrader
-
-_DEFAULT_TIMEOUT = 5400
 
 
 class SafetyKeywords:
@@ -18,7 +17,7 @@ class SafetyKeywords:
 
     def __init__(self, timeout: Optional[int] = None, max_retries: int = 2):
         if timeout is None:
-            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(_DEFAULT_TIMEOUT)))
+            timeout = int(os.getenv("OLLAMA_TIMEOUT", str(DEFAULT_TIMEOUT)))
         self.client = create_provider(
             timeout=int(timeout), max_retries=int(max_retries)
         )

--- a/src/rfc/thinking.py
+++ b/src/rfc/thinking.py
@@ -40,6 +40,39 @@ def parse_thinking(text: str) -> tuple[str, Optional[str]]:
     return clean, thinking
 
 
+def extract_json(text: str) -> str:
+    """Extract JSON from text that may contain markdown or thinking tags.
+
+    Handles:
+    - Markdown code blocks (``\\`\\`\\`json...\\`\\`\\```)
+    - Thinking tags (``<think>`` / ``<thinking>``)
+    - Text before/after JSON
+
+    Returns the extracted JSON string, or the original text if no JSON is found.
+    """
+    text, _ = parse_thinking(text)
+
+    # Try to find JSON in markdown code blocks
+    json_block_pattern = r"```(?:json)?\s*(\{.*?\})\s*```"
+    matches = re.findall(json_block_pattern, text, re.DOTALL)
+    if matches:
+        return matches[0]
+
+    # Try to find bare JSON with score/reason fields
+    json_pattern = r'(\{.*"score".*"reason".*?\})'
+    matches = re.findall(json_pattern, text, re.DOTALL)
+    if matches:
+        return matches[0]
+
+    # Last resort: any JSON object, pick the largest match
+    json_pattern = r"(\{.*?\})"
+    matches = re.findall(json_pattern, text, re.DOTALL)
+    if matches:
+        return max(matches, key=len)
+
+    return text
+
+
 def estimate_token_count(text: Optional[str]) -> int:
     """Estimate token count using whitespace splitting.
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,11 @@
+"""Tests for rfc.constants — single source of truth for shared constants."""
+
+from rfc.constants import DEFAULT_TIMEOUT
+
+
+def test_default_timeout_value() -> None:
+    assert DEFAULT_TIMEOUT == 5400
+
+
+def test_default_timeout_type() -> None:
+    assert isinstance(DEFAULT_TIMEOUT, int)

--- a/tests/test_multi_grader.py
+++ b/tests/test_multi_grader.py
@@ -215,11 +215,11 @@ class TestMultiGrader:
         assert result.reasons[0] == "Invalid score value: 1.2"
 
     def test_bare_json_extract_fallback(self) -> None:
-        """_extract_json falls back to max-length bare JSON match (line 52)."""
-        from rfc.multi_grader import _extract_json
+        """extract_json falls back to max-length bare JSON match."""
+        from rfc.thinking import extract_json
 
         # No markdown block, no "score".*"reason" pattern — just a bare JSON object
         text = 'I think the answer is {"reason": "good", "score": 1}'
-        result = _extract_json(text)
+        result = extract_json(text)
         assert '"reason"' in result
         assert '"score"' in result

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -133,8 +133,8 @@ class TestGenerate:
 
 
 class TestGenerateRetry:
-    @patch("rfc.ollama.logger")
-    @patch("rfc.ollama.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.ollama.requests.post")
     def test_retries_on_read_timeout(self, mock_post, mock_sleep, mock_logger):
         mock_resp = MagicMock()
@@ -152,8 +152,8 @@ class TestGenerateRetry:
         assert mock_post.call_count == 2
         mock_sleep.assert_called_once_with(2)
 
-    @patch("rfc.ollama.logger")
-    @patch("rfc.ollama.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.ollama.requests.post")
     def test_retries_on_connection_error(self, mock_post, mock_sleep, mock_logger):
         mock_resp = MagicMock()
@@ -170,8 +170,8 @@ class TestGenerateRetry:
         assert result == "ok"
         assert mock_post.call_count == 2
 
-    @patch("rfc.ollama.logger")
-    @patch("rfc.ollama.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.ollama.requests.post")
     def test_exhausts_retries_then_raises(self, mock_post, mock_sleep, mock_logger):
         mock_post.side_effect = req_lib.exceptions.ReadTimeout("timed out")
@@ -182,8 +182,8 @@ class TestGenerateRetry:
         # 1 initial + 2 retries = 3 total calls
         assert mock_post.call_count == 3
 
-    @patch("rfc.ollama.logger")
-    @patch("rfc.ollama.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.ollama.requests.post")
     def test_no_retry_on_http_error(self, mock_post, mock_sleep, mock_logger):
         mock_post.side_effect = req_lib.exceptions.HTTPError("500 Server Error")
@@ -194,7 +194,7 @@ class TestGenerateRetry:
         assert mock_post.call_count == 1
         mock_sleep.assert_not_called()
 
-    @patch("rfc.ollama.logger")
+    @patch("rfc.retry.logger")
     @patch("rfc.ollama.requests.post")
     def test_no_retry_when_max_retries_zero(self, mock_post, mock_logger):
         mock_post.side_effect = req_lib.exceptions.ReadTimeout("timed out")
@@ -204,8 +204,8 @@ class TestGenerateRetry:
             client.generate("test")
         assert mock_post.call_count == 1
 
-    @patch("rfc.ollama.logger")
-    @patch("rfc.ollama.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.ollama.requests.post")
     def test_exponential_backoff_timing(self, mock_post, mock_sleep, mock_logger):
         mock_post.side_effect = req_lib.exceptions.ReadTimeout("timed out")

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -136,8 +136,8 @@ class TestGenerate:
 
 
 class TestGenerateRetry:
-    @patch("rfc.openai_client.logger")
-    @patch("rfc.openai_client.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.openai_client.requests.post")
     def test_retries_on_read_timeout(self, mock_post, mock_sleep, mock_logger):
         mock_resp = MagicMock()
@@ -158,8 +158,8 @@ class TestGenerateRetry:
         assert mock_post.call_count == 2
         mock_sleep.assert_called_once_with(2)
 
-    @patch("rfc.openai_client.logger")
-    @patch("rfc.openai_client.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.openai_client.requests.post")
     def test_retries_on_connection_error(self, mock_post, mock_sleep, mock_logger):
         mock_resp = MagicMock()
@@ -179,8 +179,8 @@ class TestGenerateRetry:
         assert result == "ok"
         assert mock_post.call_count == 2
 
-    @patch("rfc.openai_client.logger")
-    @patch("rfc.openai_client.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.openai_client.requests.post")
     def test_exhausts_retries_then_raises(self, mock_post, mock_sleep, mock_logger):
         mock_post.side_effect = req_lib.exceptions.ReadTimeout("timed out")
@@ -190,8 +190,8 @@ class TestGenerateRetry:
             client.generate("test")
         assert mock_post.call_count == 3
 
-    @patch("rfc.openai_client.logger")
-    @patch("rfc.openai_client.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.openai_client.requests.post")
     def test_no_retry_on_http_error(self, mock_post, mock_sleep, mock_logger):
         mock_post.side_effect = req_lib.exceptions.HTTPError("401 Unauthorized")
@@ -202,7 +202,7 @@ class TestGenerateRetry:
         assert mock_post.call_count == 1
         mock_sleep.assert_not_called()
 
-    @patch("rfc.openai_client.logger")
+    @patch("rfc.retry.logger")
     @patch("rfc.openai_client.requests.post")
     def test_no_retry_when_max_retries_zero(self, mock_post, mock_logger):
         mock_post.side_effect = req_lib.exceptions.ReadTimeout("timed out")
@@ -212,8 +212,8 @@ class TestGenerateRetry:
             client.generate("test")
         assert mock_post.call_count == 1
 
-    @patch("rfc.openai_client.logger")
-    @patch("rfc.openai_client.time.sleep")
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
     @patch("rfc.openai_client.requests.post")
     def test_exponential_backoff_timing(self, mock_post, mock_sleep, mock_logger):
         mock_post.side_effect = req_lib.exceptions.ReadTimeout("timed out")

--- a/tests/test_resolve_timeout.py
+++ b/tests/test_resolve_timeout.py
@@ -1,0 +1,34 @@
+"""Tests for the resolve_timeout helper in llm_client."""
+
+import os
+from unittest.mock import patch
+
+from rfc.llm_client import resolve_timeout
+
+
+class TestResolveTimeout:
+    """Tests for resolve_timeout()."""
+
+    def test_default_returns_5400(self) -> None:
+        """No argument and no env var → default 5400."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("OLLAMA_TIMEOUT", None)
+            assert resolve_timeout() == 5400
+
+    def test_explicit_timeout_overrides_default(self) -> None:
+        """Explicit timeout beats the default."""
+        assert resolve_timeout(60) == 60
+
+    def test_env_var_overrides_default(self) -> None:
+        """OLLAMA_TIMEOUT env var overrides the default when no arg given."""
+        with patch.dict(os.environ, {"OLLAMA_TIMEOUT": "300"}):
+            assert resolve_timeout() == 300
+
+    def test_explicit_timeout_beats_env_var(self) -> None:
+        """Explicit timeout takes precedence over env var."""
+        with patch.dict(os.environ, {"OLLAMA_TIMEOUT": "300"}):
+            assert resolve_timeout(60) == 60
+
+    def test_string_timeout_converted_to_int(self) -> None:
+        """Robot Framework passes strings; they must be converted."""
+        assert resolve_timeout("120") == 120  # type: ignore[arg-type]

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,102 @@
+"""Tests for rfc.retry.retry_on_transient."""
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+import requests as req_lib
+
+from rfc.retry import retry_on_transient
+
+
+class TestRetryOnTransient:
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
+    def test_returns_result_on_first_success(self, mock_sleep, mock_logger):
+        fn = MagicMock(return_value="ok")
+        result = retry_on_transient(fn, max_retries=2)
+        assert result == "ok"
+        fn.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
+    def test_retries_on_read_timeout(self, mock_sleep, mock_logger):
+        fn = MagicMock(
+            side_effect=[req_lib.exceptions.ReadTimeout("timed out"), "ok"]
+        )
+        result = retry_on_transient(fn, max_retries=2)
+        assert result == "ok"
+        assert fn.call_count == 2
+        mock_sleep.assert_called_once_with(2)
+
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
+    def test_retries_on_connection_error(self, mock_sleep, mock_logger):
+        fn = MagicMock(
+            side_effect=[req_lib.exceptions.ConnectionError("refused"), "ok"]
+        )
+        result = retry_on_transient(fn, max_retries=2)
+        assert result == "ok"
+        assert fn.call_count == 2
+
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
+    def test_exhausts_retries_then_raises(self, mock_sleep, mock_logger):
+        fn = MagicMock(
+            side_effect=req_lib.exceptions.ReadTimeout("timed out")
+        )
+        with pytest.raises(req_lib.exceptions.ReadTimeout):
+            retry_on_transient(fn, max_retries=2)
+        assert fn.call_count == 3  # 1 initial + 2 retries
+
+    @patch("rfc.retry.logger")
+    def test_no_retry_when_max_retries_zero(self, mock_logger):
+        fn = MagicMock(
+            side_effect=req_lib.exceptions.ReadTimeout("timed out")
+        )
+        with pytest.raises(req_lib.exceptions.ReadTimeout):
+            retry_on_transient(fn, max_retries=0)
+        fn.assert_called_once()
+
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
+    def test_exponential_backoff_timing(self, mock_sleep, mock_logger):
+        fn = MagicMock(
+            side_effect=req_lib.exceptions.ReadTimeout("timed out")
+        )
+        with pytest.raises(req_lib.exceptions.ReadTimeout):
+            retry_on_transient(fn, max_retries=2)
+        assert mock_sleep.call_args_list == [call(2), call(4)]
+
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
+    def test_non_transient_error_propagates(self, mock_sleep, mock_logger):
+        fn = MagicMock(
+            side_effect=req_lib.exceptions.HTTPError("500 Server Error")
+        )
+        with pytest.raises(req_lib.exceptions.HTTPError):
+            retry_on_transient(fn, max_retries=2)
+        fn.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch("rfc.retry.logger")
+    @patch("rfc.retry.time.sleep")
+    def test_logs_warn_on_retry_and_error_on_exhaust(
+        self, mock_sleep, mock_logger
+    ):
+        fn = MagicMock(
+            side_effect=req_lib.exceptions.ReadTimeout("timed out")
+        )
+        with pytest.raises(req_lib.exceptions.ReadTimeout):
+            retry_on_transient(fn, max_retries=1)
+
+        # First attempt fails -> warn about retry
+        mock_logger.warn.assert_called_once()
+        warn_msg = mock_logger.warn.call_args[0][0]
+        assert "attempt 1 failed" in warn_msg
+        assert "Retrying in 2s" in warn_msg
+
+        # Second attempt fails -> error (exhausted)
+        mock_logger.error.assert_called_once()
+        error_msg = mock_logger.error.call_args[0][0]
+        assert "failed after 2 attempts" in error_msg

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -1,6 +1,6 @@
 """Tests for rfc.thinking — thinking token parser."""
 
-from rfc.thinking import estimate_token_count, parse_thinking
+from rfc.thinking import estimate_token_count, extract_json, parse_thinking
 
 
 class TestParseThinking:
@@ -69,6 +69,42 @@ class TestParseThinking:
         clean, thinking = parse_thinking(text)
         assert clean == "Result."
         assert thinking == "What about {json} and [arrays]?"
+
+
+class TestExtractJson:
+    def test_plain_json(self) -> None:
+        text = '{"score": 1, "reason": "correct"}'
+        assert extract_json(text) == text
+
+    def test_json_in_markdown_block(self) -> None:
+        text = '```json\n{"score": 1, "reason": "ok"}\n```'
+        assert extract_json(text) == '{"score": 1, "reason": "ok"}'
+
+    def test_json_in_markdown_block_no_lang(self) -> None:
+        text = '```\n{"score": 0.5, "reason": "partial"}\n```'
+        assert extract_json(text) == '{"score": 0.5, "reason": "partial"}'
+
+    def test_thinking_tags_stripped(self) -> None:
+        text = '<think>hmm let me think</think>\n{"score": 1, "reason": "ok"}'
+        result = extract_json(text)
+        assert '"score"' in result
+        assert "<think>" not in result
+
+    def test_text_before_json(self) -> None:
+        text = 'I think the answer is {"score": 0.8, "reason": "mostly right"}'
+        result = extract_json(text)
+        assert '"score"' in result
+        assert '"reason"' in result
+
+    def test_bare_json_fallback_picks_largest(self) -> None:
+        text = 'prefix {"a": 1} and {"reason": "good", "score": 1, "extra": true} end'
+        result = extract_json(text)
+        assert '"reason"' in result
+        assert '"score"' in result
+
+    def test_no_json_returns_text(self) -> None:
+        text = "no json here at all"
+        assert extract_json(text) == text
 
 
 class TestEstimateTokenCount:


### PR DESCRIPTION
## Summary
Refactored timeout configuration logic into a centralized `resolve_timeout()` helper function to eliminate code duplication across multiple keyword classes and improve maintainability.

## Key Changes
- **New `resolve_timeout()` function** in `llm_client.py`:
  - Implements precedence: explicit argument > `OLLAMA_TIMEOUT` env var > 5400s default
  - Handles type conversion (supports both int and string inputs for Robot Framework compatibility)
  - Exported in `__all__` for public API use

- **Updated keyword classes** to use the new helper:
  - `LLMKeywords` in `keywords.py`
  - `SafetyKeywords` in `safety_keywords.py`
  - `CEOKeywords` in `ceo_keywords.py`
  - Removed duplicate `_DEFAULT_TIMEOUT` constants and timeout resolution logic

- **Consolidated Robot Framework resources**:
  - Extracted shared `Ask And Validate` keyword into `resources/ask_and_validate.resource`
  - Updated test suites to reference the shared resource instead of duplicating keyword definitions

- **Test coverage**:
  - Added comprehensive test suite (`test_resolve_timeout.py`) covering all precedence scenarios and type conversions

## Implementation Details
The `resolve_timeout()` function uses `int()` conversion on all paths to handle Robot Framework's string argument passing while maintaining backward compatibility with direct Python calls.

https://claude.ai/code/session_01LQ6Bb72mYN9GgCYikYn3SL