### PR TITLE
Redesign database schema: 2 tables, output.xml as source of truth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ export
         code-quality-lint code-quality-format code-quality-typecheck \
         code-quality-check code-quality-coverage code-quality-audit \
         docker-up docker-down docker-restart docker-logs bootstrap \
-        cache-flush superset-sanitize superset-export superset-import superset-diagnose \
+        cache-flush sync-metrics superset-sanitize superset-export superset-import superset-diagnose \
         ci-generate ci-report ci-deploy \
         opencode-pipeline-review opencode-local-review opencode-audit-markdown \
         build-check docker-build-app docker-test-app version
@@ -159,6 +159,11 @@ cache-flush: ## Flush caches and refresh all dashboards (Superset + RF Metrics)
 	@echo "Triggering RF Metrics dashboard regeneration..."
 	$(COMPOSE) restart metrics
 	@echo "Done — Superset will re-query on next load; RF Metrics are regenerating now."
+
+sync-metrics: ## Trigger immediate RF Metrics dashboard regeneration from output.xml files
+	@echo "Syncing output.xml files to RF Metrics dashboard..."
+	$(COMPOSE) exec -T metrics /bin/bash -c 'source /app/entrypoint.sh && generate_metrics'
+	@echo "Metrics sync complete — view at http://localhost:$${METRICS_PORT:-8089}"
 
 superset-sanitize: ## Truncate all RFC data tables (preserves dashboards/charts)
 	uv run python scripts/sanitize_superset_db.py

--- a/src/rfc/db_listener.py
+++ b/src/rfc/db_listener.py
@@ -103,8 +103,9 @@ class DbListener(ListenerV3):
     - ``RFC_DATA:expected_answer:<text>``
     - ``RFC_DATA:grading_reason:<text>``
 
-    At end_suite, reads output.xml, gzip-compresses it, and stores the
-    blob alongside run-level and test-level summaries.
+    At end_suite, stores run-level and test-level summaries.  In close()
+    — after Robot has flushed the output file — reads output.xml,
+    gzip-compresses it, and updates the database row.
 
     Usage:
         robot --listener rfc.db_listener.DbListener tests/
@@ -124,6 +125,7 @@ class DbListener(ListenerV3):
         # Per-test structured data captured from RFC_DATA: log messages.
         self._current_test_data: Dict[str, str] = {}
         self._current_test_name: Optional[str] = None
+        self._last_run_id: Optional[int] = None
 
     def _get_db(self) -> TestDatabase:
         if self._db is None:
@@ -295,8 +297,7 @@ class DbListener(ListenerV3):
 
         hostname = self._host_info.get("hostname", "")
 
-        # Read and gzip output.xml
-        output_xml_gz = _read_and_compress_output_xml()
+        # output.xml is read later in close(), after Robot flushes the file.
         output_xml_url = _build_output_xml_url()
         output_xml_source = _build_output_xml_source()
 
@@ -320,7 +321,7 @@ class DbListener(ListenerV3):
             hostname=hostname,
             rfc_version=__version__,
             output_xml_url=output_xml_url,
-            output_xml_gz=output_xml_gz,
+            output_xml_gz=b"",
             output_xml_source=output_xml_source,
             temperature=run_temperature,
             seed=run_seed,
@@ -331,6 +332,7 @@ class DbListener(ListenerV3):
         try:
             db = self._get_db()
             run_id = db.add_test_run(run)
+            self._last_run_id = run_id
 
             results = [
                 TestResult(
@@ -374,16 +376,48 @@ class DbListener(ListenerV3):
             db.add_test_results(results)
 
             dest = self._describe_database_destination()
-            blob_size = _format_size(len(output_xml_gz)) if output_xml_gz else "none"
             summary = (
                 f"DbListener: archived {len(results)} test result(s) "
-                f"+ output.xml ({blob_size}) "
-                f"to {dest} (run_id={run_id})"
+                f"to {dest} (run_id={run_id}), "
+                f"output.xml will be captured in close()"
             )
             logger.info(summary)
             logger.console(summary)
         except Exception as e:
             error_msg = f"DbListener: FAILED to archive results: {e}"
+            logger.warn(error_msg)
+            logger.console(error_msg)
+
+    def close(self) -> None:
+        """Read output.xml after Robot has flushed it and update the DB row.
+
+        Robot Framework calls ``close()`` after all loggers — including
+        the output-file writer — have finalised.  This guarantees the
+        file is complete, unlike ``end_suite()`` which fires before the
+        flush.
+        """
+        if self._last_run_id is None:
+            return
+
+        output_xml_gz = _read_and_compress_output_xml()
+        if not output_xml_gz:
+            return
+
+        try:
+            db = self._get_db()
+            db.update_output_xml(self._last_run_id, output_xml_gz)
+            blob_size = _format_size(len(output_xml_gz))
+            msg = (
+                f"DbListener: updated output.xml ({blob_size}) "
+                f"for run_id={self._last_run_id}"
+            )
+            logger.info(msg)
+            logger.console(msg)
+        except Exception as e:
+            error_msg = (
+                f"DbListener: FAILED to update output.xml "
+                f"for run_id={self._last_run_id}: {e}"
+            )
             logger.warn(error_msg)
             logger.console(error_msg)
 

--- a/src/rfc/rebot_merger.py
+++ b/src/rfc/rebot_merger.py
@@ -49,7 +49,7 @@ class MergeResult:
     merged_at: datetime = field(default_factory=datetime.now)
 
 
-def find_output_files(dirs: list[str]) -> list[str]:
+def find_output_files(dirs: list[str], *, exclude_dir: str = "") -> list[str]:
     """Recursively discover output.xml files in given directories.
 
     Deduplicates by absolute path to avoid processing the same file
@@ -57,18 +57,24 @@ def find_output_files(dirs: list[str]) -> list[str]:
 
     Args:
         dirs: List of directories to search.
+        exclude_dir: Absolute or relative path to skip (e.g. the merge
+            output directory) so that a previous merge result is not
+            fed back in as a source.
 
     Returns:
         Sorted list of unique output.xml file paths.
     """
     seen: set[str] = set()
     result: list[str] = []
+    exclude_abs = os.path.abspath(exclude_dir) if exclude_dir else ""
 
     for d in dirs:
         if not os.path.isdir(d):
             logger.warning("Directory not found, skipping: %s", d)
             continue
         for root, _subdirs, files in os.walk(d):
+            if exclude_abs and os.path.abspath(root).startswith(exclude_abs):
+                continue
             for fname in files:
                 if fname == "output.xml":
                     full_path = os.path.abspath(os.path.join(root, fname))
@@ -105,7 +111,7 @@ def merge_outputs(config: MergeConfig) -> Optional[MergeResult]:
     Returns:
         MergeResult with paths and provenance, or None if no files found.
     """
-    source_files = find_output_files(config.source_dirs)
+    source_files = find_output_files(config.source_dirs, exclude_dir=config.output_dir)
 
     if not source_files:
         logger.warning("No output.xml files found in: %s", config.source_dirs)

--- a/src/rfc/test_database.py
+++ b/src/rfc/test_database.py
@@ -147,6 +147,9 @@ class _Backend(abc.ABC):
     def get_table_row_count(self, table_name: str) -> int: ...
 
     @abc.abstractmethod
+    def update_output_xml(self, run_id: int, output_xml_gz: bytes) -> None: ...
+
+    @abc.abstractmethod
     def upsert_model(self, model: "Model") -> None: ...
 
 
@@ -415,6 +418,13 @@ class _SQLiteBackend(_Backend):
                     )
                     for r in results
                 ],
+            )
+
+    def update_output_xml(self, run_id: int, output_xml_gz: bytes) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "UPDATE test_runs SET output_xml_gz = ? WHERE id = ?",
+                (output_xml_gz, run_id),
             )
 
     def get_recent_runs(self, limit: int = 10) -> List[Dict[str, Any]]:
@@ -785,6 +795,14 @@ class _SQLAlchemyBackend(_Backend):
                 ],
             )
 
+    def update_output_xml(self, run_id: int, output_xml_gz: bytes) -> None:
+        with self.engine.begin() as conn:
+            conn.execute(
+                self._test_runs.update()
+                .where(self._test_runs.c.id == run_id)
+                .values(output_xml_gz=output_xml_gz)
+            )
+
     def get_recent_runs(self, limit: int = 10) -> List[Dict[str, Any]]:
         with self.engine.connect() as conn:
             result = conn.execute(
@@ -905,6 +923,9 @@ class TestDatabase:
 
     def add_test_results(self, results: List[TestResult]) -> None:
         self._backend.add_test_results(results)
+
+    def update_output_xml(self, run_id: int, output_xml_gz: bytes) -> None:
+        self._backend.update_output_xml(run_id, output_xml_gz)
 
     def get_recent_runs(self, limit: int = 10) -> List[Dict[str, Any]]:
         return self._backend.get_recent_runs(limit)

--- a/tasks.py
+++ b/tasks.py
@@ -197,6 +197,25 @@ def robot_autopilot() -> None:
     _run(["bash", str(ROOT / "scripts" / "robot_autopilot.sh")])
 
 
+def sync_metrics() -> None:
+    """Trigger immediate RF Metrics dashboard regeneration from output.xml files."""
+    print("Syncing output.xml files to RF Metrics dashboard...")
+    _run(
+        [
+            "docker",
+            "compose",
+            "exec",
+            "-T",
+            "metrics",
+            "/bin/bash",
+            "-c",
+            "source /app/entrypoint.sh && generate_metrics",
+        ],
+    )
+    port = os.environ.get("METRICS_PORT", "8089")
+    print(f"Metrics sync complete — view at http://localhost:{port}")
+
+
 def superset_sanitize() -> None:
     """Truncate all RFC data tables (preserves dashboards/charts)."""
     _ensure_env()
@@ -229,6 +248,7 @@ TARGETS: dict[str, object] = {
     "analytics-refresh": analytics_refresh,
     "analytics-regressions": analytics_regressions,
     "rebot-merge": rebot_merge,
+    "sync-metrics": sync_metrics,
     "superset-sanitize": superset_sanitize,
     "docker-build-app": docker_build_app,
     "docker-test-app": docker_test_app,

--- a/tests/test_db_listener.py
+++ b/tests/test_db_listener.py
@@ -1166,3 +1166,91 @@ class TestGetRobotInt:
         monkeypatch.delenv("SEED", raising=False)
         result = _get_robot_int("SEED")
         assert result == 0
+
+
+# ── close() deferred output.xml capture ──────────────────────────────
+
+
+class TestCloseDefersOutputXmlCapture:
+    """Verify that output.xml is read in close(), not end_suite().
+
+    Robot Framework calls end_suite() *before* flushing the output file,
+    so reading it there yields an empty or truncated blob.  The close()
+    hook fires after all loggers — including the output writer — have
+    finished, guaranteeing the file is complete.
+    """
+
+    @patch("rfc.db_listener._build_output_xml_source", return_value="/tmp/output.xml")
+    @patch("rfc.db_listener._build_output_xml_url", return_value="")
+    @patch("rfc.db_listener._read_and_compress_output_xml", return_value=b"")
+    @patch("rfc.db_listener.collect_ci_metadata", return_value={})
+    @patch("rfc.db_listener.BuiltIn")
+    def test_end_suite_does_not_call_read_and_compress(
+        self,
+        _mock_builtin: MagicMock,
+        _mock_ci: MagicMock,
+        mock_read: MagicMock,
+        _mock_url: MagicMock,
+        _mock_source: MagicMock,
+    ) -> None:
+        """end_suite must NOT read output.xml — that's close()'s job."""
+        listener = DbListener(database_url="sqlite:///")
+        listener._db = MagicMock()
+        listener._db.add_test_run.return_value = 1
+        listener.start_suite(_mock_suite_data("Top"), _mock_suite_result())
+        listener.end_suite(_mock_suite_data("Top"), _mock_suite_result(total=0))
+        mock_read.assert_not_called()
+
+    @patch("rfc.db_listener._build_output_xml_source", return_value="/tmp/output.xml")
+    @patch("rfc.db_listener._build_output_xml_url", return_value="")
+    @patch("rfc.db_listener.collect_ci_metadata", return_value={})
+    @patch("rfc.db_listener.BuiltIn")
+    def test_close_reads_output_xml_and_updates_db(
+        self,
+        _mock_builtin: MagicMock,
+        _mock_ci: MagicMock,
+        _mock_url: MagicMock,
+        _mock_source: MagicMock,
+        tmp_path: object,
+    ) -> None:
+        """close() should read the now-flushed output.xml and update the DB row."""
+        output_xml = tmp_path / "output.xml"  # type: ignore[operator]
+        output_xml.write_text("<robot/>")
+
+        listener = DbListener(database_url="sqlite:///")
+        mock_db = MagicMock()
+        mock_db.add_test_run.return_value = 42
+        listener._db = mock_db
+
+        listener.start_suite(_mock_suite_data("Top"), _mock_suite_result())
+        listener.end_suite(_mock_suite_data("Top"), _mock_suite_result(total=0))
+
+        # Simulate close() after Robot has flushed
+        with patch(
+            "rfc.db_listener._resolve_output_file", return_value=str(output_xml)
+        ):
+            listener.close()
+
+        mock_db.update_output_xml.assert_called_once()
+        call_args = mock_db.update_output_xml.call_args
+        assert call_args[0][0] == 42  # run_id
+        import gzip as _gzip
+
+        assert _gzip.decompress(call_args[0][1]) == b"<robot/>"
+
+    @patch("rfc.db_listener._build_output_xml_source", return_value="/tmp/output.xml")
+    @patch("rfc.db_listener._build_output_xml_url", return_value="")
+    @patch("rfc.db_listener.collect_ci_metadata", return_value={})
+    @patch("rfc.db_listener.BuiltIn")
+    def test_close_without_end_suite_is_noop(
+        self,
+        _mock_builtin: MagicMock,
+        _mock_ci: MagicMock,
+        _mock_url: MagicMock,
+        _mock_source: MagicMock,
+    ) -> None:
+        """close() should be a no-op if end_suite never stored a run_id."""
+        listener = DbListener(database_url="sqlite:///")
+        listener._db = MagicMock()
+        listener.close()
+        listener._db.update_output_xml.assert_not_called()

--- a/tests/test_rebot_merger.py
+++ b/tests/test_rebot_merger.py
@@ -88,6 +88,27 @@ class TestFindOutputFiles:
         files = find_output_files([str(d), str(d)])
         assert len(files) == 1
 
+    def test_excludes_output_dir(self, tmp_path: Path) -> None:
+        """find_output_files must skip the output_dir to avoid self-inclusion.
+
+        When `make rebot-merge-all` runs `rfc.rebot_merger results/`, the
+        output goes to `results/combined/output.xml`.  On the next run,
+        that stale aggregate must not be picked up as a source — otherwise
+        it gets merged back in, duplicating every test case.
+        """
+        results = tmp_path / "results"
+        math = results / "math"
+        combined = results / "combined"
+        math.mkdir(parents=True)
+        combined.mkdir(parents=True)
+        (math / "output.xml").write_text(MINIMAL_OUTPUT_XML)
+        (combined / "output.xml").write_text(MINIMAL_OUTPUT_XML)
+
+        files = find_output_files([str(results)], exclude_dir=str(combined))
+        assert len(files) == 1
+        assert "math" in files[0]
+        assert "combined" not in files[0]
+
 
 # ── _run_rebot ───────────────────────────────────────────────────────
 

--- a/tests/test_test_database.py
+++ b/tests/test_test_database.py
@@ -150,6 +150,29 @@ class TestSQLiteBackend:
         assert len(runs) == 1
         assert runs[0]["hostname"] == "dev1"
 
+    def test_update_output_xml(self, tmp_path: object) -> None:
+        db = TestDatabase(db_path=str(tmp_path / "test.db"))  # type: ignore[operator]
+        run_id = db.add_test_run(_make_run())
+
+        # Initially empty
+        runs = db.get_recent_runs(limit=1)
+        assert runs[0]["output_xml_gz"] == b""
+
+        # Update with compressed blob
+        compressed = gzip.compress(b"<robot>full output</robot>")
+        db.update_output_xml(run_id, compressed)
+
+        runs = db.get_recent_runs(limit=1)
+        assert runs[0]["output_xml_gz"] == compressed
+        assert (
+            gzip.decompress(runs[0]["output_xml_gz"]) == b"<robot>full output</robot>"
+        )
+
+    def test_update_output_xml_nonexistent_run(self, tmp_path: object) -> None:
+        """update_output_xml on a missing run_id should not raise."""
+        db = TestDatabase(db_path=str(tmp_path / "test.db"))  # type: ignore[operator]
+        db.update_output_xml(9999, gzip.compress(b"<robot/>"))
+
 
 class TestTestDatabase:
     def test_explicit_db_path_uses_sqlite(self, tmp_path: object) -> None:


### PR DESCRIPTION
## Summary

Simplifies the RFC test database from 13 tables to 2 core tables (`test_runs` and `test_results`), with `output.xml` as the single source of truth. This eliminates data duplication, reduces complexity, and makes the schema maintainable while preserving all essential test metadata.

## Key Changes

### Database Schema Redesign
- **Dropped 11 tables**: `keyword_results`, `ollama_metrics`, `host_info`, `models`, `pipeline_results`, `robot_dry_run_results`, and 5 analytics tables
- **Kept 2 tables**:
  - `test_runs`: Test suite execution metadata (timestamp, model, test counts, git info, hostname, RFC version)
  - `test_results`: Individual test outcomes (test name, status, score, Q&A data, grading reason)
- **Added blob storage**: `output_xml_gz` (BYTEA) and `output_xml_url` (TEXT) fields to store compressed output.xml and web access URL
- **Removed redundant fields**: Model release date, parameters, pipeline URL, runner metadata (now derivable from output.xml)

### Core Library Updates
- **`test_database.py`**: Updated `TestRun` and `TestResult` dataclasses to match 2-table schema; removed `PipelineResult` and `DryRunResult` classes
- **`db_listener.py`**: Simplified to store test run summaries and results only; removed keyword-level timing and pipeline tracking
- **`result_importer.py`** (new): Imports output.xml files with deduplication and gzip compression
- **`rebot_merger.py`** (new): Orchestrates Robot Framework rebot merges with provenance tracking

### New Modules
- **`ceo_keywords.py`**: Robot Framework keywords for CEO agent pipeline stages (brainstorm, market research, IP analysis, patent strategy, licensing)
- **`ceo_models.py`**: Typed dataclasses for CEO pipeline stage inputs/outputs
- **`ceo_prompts.py`**: Prompt templates for CEO agent stages
- **`openai_client.py`**: OpenAI Chat Completions API client
- **`multi_grader.py`**: Multi-LLM consensus grader for tier:3 verification
- **`web_cache.py`**: SQLite-backed web search cache for CEO agent
- **`thinking.py`**: Thinking token parser for LLM responses
- **`rfc_data.py`**: Centralized RFC_DATA structured log message emission
- **`retry.py`**: Retry helper for transient HTTP errors
- **`benchmark_keywords.py`**: Token output benchmarking keywords
- **`superset_keywords.py`**: Superset/PostgreSQL connectivity check keywords
- **`constants.py`**: Shared constants (DEFAULT_TIMEOUT)

### Test Suites & Skills
- **New test suites**: CEO agent (brainstorm, market research, IP analysis, patent strategy, licensing), accounting, task management, legal document analysis, benchmark token output
- **New programming challenges**: Bash, C, Rust, Python (YAML-driven)
- **New skill guides**: Create tier:0/tier:1 tests, convert existing tests, import Hugging Face datasets
- **New legal test data**: Software agreement with planted needles and loopholes for LLM testing

### Infrastructure & Tooling
- **`diagnose_superset_db.py`** (new): Diagnose Superset database connectivity and data pipeline issues
- **`collect_coverage.py`** (new): Parse pytest-cov JSON and insert coverage data into PostgreSQL
- **`sanitize_superset_db.py`** (new): Truncate RFC data tables while preserving schema
- **`cron_run_local_models.sh`** (new): Hourly cron job for model sync and test runs
- **`robot_autopilot.sh`** (new): Poll for git updates and auto-run tests on change
- **Dockerfile** (new): Dev-ready application image with make, uv, and full project
- **Docker Compose**:

https://claude.ai/code/session_01JjqTvDcfcBCW2rDEJLJFFH