### PR TITLE
Replace Get Variable Value with Set Variable in Robot resource files

### DIFF
--- a/robot/resources/container_profiles.resource
+++ b/robot/resources/container_profiles.resource
@@ -35,7 +35,7 @@ ${LONG_TIMEOUT}         300
 Create Container From Profile
     [Documentation]    Create a Docker container using a predefined profile
     [Arguments]    ${profile_name}    ${container_name}=None    ${custom_volumes}=None
-    ${profile}=    Get Variable Value    ${${profile_name}}
+    ${profile}=    Set Variable    ${${profile_name}}
     ${container_id}=    Docker.Create Configurable Container    ${profile}    ${container_name}
     RETURN    ${container_id}
 

--- a/robot/resources/environments.resource
+++ b/robot/resources/environments.resource
@@ -24,7 +24,7 @@ Setup Container Environment
     Create Directory    ${volume_path}
 
     ${volumes}=    Create Dictionary    ${volume_path}=/workspace:rw
-    ${profile_dict}=    Get Variable Value    ${${profile}}
+    ${profile_dict}=    Set Variable    ${${profile}}
     ${full_config}=    Create Dictionary    &{profile_dict}    command=sleep infinity    volumes=${volumes}
     ${container_id}=    Docker.Create Configurable Container    ${full_config}    rfc-${unique_name}
 
@@ -58,7 +58,7 @@ Setup Shell Environment
 
     # Create container with a command that keeps it running
     # Use read_only=False and user=root since shell tests need to create files
-    ${profile_dict}=    Get Variable Value    ${${profile}}
+    ${profile_dict}=    Set Variable    ${${profile}}
     ${full_config}=    Create Dictionary    &{profile_dict}    command=sleep infinity    read_only=False    user=root
     ${container_id}=    Docker.Create Configurable Container    ${full_config}    ${SHELL_CONTAINER_NAME}
 


### PR DESCRIPTION
## Summary
This PR updates Robot Framework resource files to use `Set Variable` instead of `Get Variable Value` for retrieving nested variable values.

## Key Changes
- **environments.resource**: Updated 2 occurrences in `Setup Container Environment` and `Setup Shell Environment` keywords
- **container_profiles.resource**: Updated 1 occurrence in `Create Container From Profile` keyword

All changes replace `Get Variable Value ${${variable}}` with `Set Variable ${${variable}}` for consistent variable resolution.

## Implementation Details
The change affects how nested variables (variables referenced through other variables) are resolved in Robot Framework. `Set Variable` is more appropriate for this use case as it properly evaluates the nested variable syntax `${${profile}}` and assigns the result to the target variable, whereas `Get Variable Value` is primarily intended for checking variable existence with optional defaults.

https://claude.ai/code/session_01GhLuV6cD9Ukq6HDxUrx4p5