### PR TITLE
feat: add configurable max_retries to Ask And Validate keyword

### DIFF
--- a/robot/c_interview/tests/c_concepts.robot
+++ b/robot/c_interview/tests/c_concepts.robot
@@ -136,5 +136,5 @@ C Interview - Reentrancy And Strtok (IQ:120)
 *** Keywords ***
 Ask C Interview Question
     [Documentation]    Ask a C interview question and grade the LLM response
-    [Arguments]    ${q}
-    Ask And Validate    ${q}[question]    ${q}[expected]
+    [Arguments]    ${q}    ${max_retries}=3
+    Ask And Validate    ${q}[question]    ${q}[expected]    max_retries=${max_retries}

--- a/robot/c_interview/tests/c_core.robot
+++ b/robot/c_interview/tests/c_core.robot
@@ -136,5 +136,5 @@ C Interview - Macros Vs Inline Functions (IQ:120)
 *** Keywords ***
 Ask C Interview Question
     [Documentation]    Ask a C interview question and grade the LLM response
-    [Arguments]    ${q}
-    Ask And Validate    ${q}[question]    ${q}[expected]
+    [Arguments]    ${q}    ${max_retries}=3
+    Ask And Validate    ${q}[question]    ${q}[expected]    max_retries=${max_retries}

--- a/robot/c_interview/tests/c_threading.robot
+++ b/robot/c_interview/tests/c_threading.robot
@@ -186,5 +186,5 @@ C Interview - Debugging Race Conditions (IQ:120)
 *** Keywords ***
 Ask C Interview Question
     [Documentation]    Ask a C interview question and grade the LLM response
-    [Arguments]    ${q}
-    Ask And Validate    ${q}[question]    ${q}[expected]
+    [Arguments]    ${q}    ${max_retries}=3
+    Ask And Validate    ${q}[question]    ${q}[expected]    max_retries=${max_retries}

--- a/robot/resources/ask_and_validate.resource
+++ b/robot/resources/ask_and_validate.resource
@@ -8,8 +8,8 @@ ${SEED_END}       10000
 
 *** Keywords ***
 Ask And Validate
-    [Arguments]    ${question}    ${expected}
-    ${score}    ${reason}    ${answer}=    LLM.Ask And Grade With Retry    ${question}    ${expected}
+    [Arguments]    ${question}    ${expected}    ${max_retries}=3
+    ${score}    ${reason}    ${answer}=    LLM.Ask And Grade With Retry    ${question}    ${expected}    max_retries=${max_retries}
     Should Be Equal As Integers    ${score}    1
     Log    Question: ${question} | Answer: ${answer} | Reason: ${reason}
 

--- a/uv.lock
+++ b/uv.lock
@@ -1513,7 +1513,7 @@ wheels = [
 
 [[package]]
 name = "robotframework-chat"
-version = "1.5.1"
+version = "1.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary\n\n- Expose `${max_retries}=3` parameter on the `Ask And Validate` Robot keyword, passing through to `Ask And Grade With Retry` (8x token scaling, 131072 ceiling)\n- Propagate `${max_retries}` through `Ask C Interview Question` in all 3 C interview test files (c_core, c_concepts, c_threading)\n\n## Test plan\n\n- [x] `uv run pytest` — 1289 passed (1 pre-existing failure unrelated to this change)\n- [x] `make robot-dryrun` — 277 tests passed\n- [x] `make code-quality-check` — pre-existing mypy stub warnings only\n\nhttps://claude.ai/code/session_01MnebR8B1w9z4ZYqrdweyuB