### PR TITLE
fix: emit actual_answer in creativity keywords

### DIFF
--- a/src/rfc/creativity_keywords.py
+++ b/src/rfc/creativity_keywords.py
@@ -68,6 +68,7 @@ class CreativityKeywords:
             clean_answer, thinking_text = parse_thinking(raw_response)
             logger.info(f"Joke response: {clean_answer}")
             emit_rfc_data("joke_response", clean_answer)
+            emit_rfc_data("actual_answer", clean_answer)
             if thinking_text is not None:
                 emit_rfc_data("thinking_text", thinking_text)
             return clean_answer
@@ -96,6 +97,7 @@ class CreativityKeywords:
         clean_answer, thinking_text = parse_thinking(raw_response)
         logger.info(f"Conversation response: {clean_answer}")
         emit_rfc_data("conversation_response", clean_answer)
+        emit_rfc_data("actual_answer", clean_answer)
         if thinking_text is not None:
             emit_rfc_data("thinking_text", thinking_text)
         return clean_answer

--- a/tests/test_creativity_keywords.py
+++ b/tests/test_creativity_keywords.py
@@ -205,6 +205,39 @@ class TestCreativityKeywords:
             or "detail" in second_joke_prompt.lower()
         )
 
+    @patch("rfc.creativity_keywords.emit_rfc_data")
+    @patch("rfc.creativity_keywords.create_provider")
+    def test_ask_for_joke_emits_actual_answer(
+        self, mock_create: MagicMock, mock_emit: MagicMock
+    ) -> None:
+        mock_client = MagicMock()
+        mock_client.generate.return_value = "A funny joke!"
+        mock_client.temperature = 0.0
+        mock_client.max_tokens = 256
+        mock_client.last_metrics = None
+        mock_client.num_ctx = None
+        mock_create.return_value = mock_client
+        kw = CreativityKeywords()
+        kw.ask_for_joke("Tell me a joke")
+        mock_emit.assert_any_call("actual_answer", "A funny joke!")
+
+    @patch("rfc.creativity_keywords.emit_rfc_data")
+    @patch("rfc.creativity_keywords.create_provider")
+    def test_ask_with_conversation_emits_actual_answer(
+        self, mock_create: MagicMock, mock_emit: MagicMock
+    ) -> None:
+        mock_client = MagicMock()
+        mock_client.generate.return_value = "Your name is Alice!"
+        mock_client.temperature = 0.0
+        mock_client.max_tokens = 256
+        mock_client.last_metrics = None
+        mock_client.num_ctx = None
+        mock_create.return_value = mock_client
+        kw = CreativityKeywords()
+        messages = [{"role": "user", "content": "Hello"}]
+        kw.ask_with_conversation(messages)
+        mock_emit.assert_any_call("actual_answer", "Your name is Alice!")
+
     @patch("rfc.creativity_keywords.create_provider")
     def test_ask_and_grade_joke_empty_response_no_retry(
         self, mock_create: MagicMock


### PR DESCRIPTION
## Summary

- `ask_for_joke` and `ask_with_conversation` in `creativity_keywords.py` emitted domain-specific keys (`joke_response`, `conversation_response`) but never `actual_answer`
- `DbListener` only persists `actual_answer` for test output capture, so creativity test results had empty answer text in the database
- Added `emit_rfc_data("actual_answer", clean_answer)` alongside the existing domain-specific emits in both methods

## Test plan

- [x] Added `test_ask_for_joke_emits_actual_answer` — verifies `emit_rfc_data("actual_answer", ...)` is called
- [x] Added `test_ask_with_conversation_emits_actual_answer` — same for conversation path
- [x] All 14 creativity keyword tests pass
- [x] Full test suite passes (1317 passed, 1 pre-existing unrelated failure)

https://claude.ai/code/session_01MRXLfaxnyaXKTo5ai45TqA