### PR TITLE
Add swebench extra to install and update commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ help: ## Show this help
 # ── Setup ────────────────────────────────────────────────────────────
 
 install: ## Install Python dependencies
-	uv sync --extra dev --extra superset
+	uv sync --extra dev --extra superset --extra swebench
 
 update: ## Fetch, pull latest changes, and sync dependencies (stashes untracked files to avoid conflicts)
 	git fetch
@@ -60,7 +60,7 @@ update: ## Fetch, pull latest changes, and sync dependencies (stashes untracked 
 		$$STASHED && git stash pop || true; exit 1; \
 	fi; \
 	$$STASHED && git stash pop || true
-	uv sync --extra dev --extra superset
+	uv sync --extra dev --extra superset --extra swebench
 
 .env: ## Create .env from .env.example if missing
 	cp .env.example .env


### PR DESCRIPTION
## Summary
This change adds the `swebench` extra dependency group to both the `install` and `update` make targets, ensuring it is included whenever dependencies are synced.

## Key Changes
- Updated `install` target to include `--extra swebench` flag in the `uv sync` command
- Updated `update` target to include `--extra swebench` flag in the `uv sync` command

## Details
The `swebench` extra is now consistently installed alongside the existing `dev` and `superset` extras in both the initial setup and dependency update workflows. This ensures developers have access to swebench tools and dependencies in their development environment.

https://claude.ai/code/session_01J792yiLjhWTGWLgue84f2N