### PR TITLE
Add Hugging Face authentication documentation and .env setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,13 @@ WEB_SEARCH_ENDPOINT=
 # Web cache TTL in seconds (default: 86400 = 24 hours)
 WEB_CACHE_TTL=86400
 
+# ── Hugging Face ──────────────────────────────────────────────────────
+# Token for Hugging Face API (datasets library, model downloads).
+# Only "Read" (public) access is required — no write/org permissions needed.
+# Create at: https://huggingface.co/settings/tokens
+# Used by: scripts/import_hf_dataset.py, rfc.huggingface_keywords
+HF_TOKEN=
+
 # ── AI Code Review (OpenCode + OpenRouter) ───────────────────────────
 # Required for the review pipeline stage (ci/review.sh)
 OPENROUTER_API_KEY=

--- a/ai/dev.md
+++ b/ai/dev.md
@@ -82,6 +82,12 @@ The `.env` file is loaded automatically by:
 | `GITLAB_PROJECT_ID` | Numeric project ID | (empty) | suite_config.py, pipeline_summary.py |
 | `GITLAB_TOKEN` | API token (`read_api` scope) | (empty) | ci/review.sh, ci/report.sh, pipeline_summary.py |
 
+### Hugging Face
+
+| Variable | Purpose | Default | Used By |
+|----------|---------|---------|---------|
+| `HF_TOKEN` | API token (read-only access is sufficient) | (empty) | scripts/import_hf_dataset.py, huggingface_keywords, `datasets` lib |
+
 ### AI Code Review
 
 | Variable | Purpose | Default | Used By |

--- a/ai/skills/import-huggingface.md
+++ b/ai/skills/import-huggingface.md
@@ -18,6 +18,19 @@ local models against established benchmarks like GSM8K, MMLU, TruthfulQA, and ot
 | HellaSwag | `Rowan/hellaswag` | New suite | 2+ (commonsense) |
 | HumanEval | `openai/openai_humaneval` | `robot/docker/python/` | 4 (code exec) |
 
+## Authentication
+
+The `datasets` library automatically picks up the `HF_TOKEN` environment variable.
+Set it in your `.env` file (see `.env.example`).
+
+| Scenario | Token required? | Permission needed |
+|----------|----------------|-------------------|
+| Public datasets (GSM8K, MMLU, TruthfulQA, etc.) | Optional (avoids rate limits) | Read |
+| Gated models/datasets (Llama 3, etc.) | Yes | Read + accept model license on HF |
+| Uploading or publishing | N/A (not used in this project) | Write |
+
+Create a token at: https://huggingface.co/settings/tokens — select **Read** access.
+
 ## Approach A: Static Import (Recommended for Deterministic Tests)
 
 Best for tier:0/tier:1 tests where answers are known and fixed (e.g., GSM8K math).


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation and configuration guidance for Hugging Face API authentication, which is required for importing datasets and models in the project.

## Key Changes
- **ai/skills/import-huggingface.md**: Added new "Authentication" section documenting:
  - How the `datasets` library automatically picks up the `HF_TOKEN` environment variable
  - A reference table clarifying token requirements for different scenarios (public datasets, gated models, uploading)
  - Instructions for creating a read-only token at huggingface.co/settings/tokens

- **.env.example**: Added `HF_TOKEN` configuration variable with:
  - Clear documentation that only "Read" access is required
  - Link to token creation page
  - Notes on which scripts/modules use this token

- **ai/dev.md**: Added "Hugging Face" section to the environment variables reference table documenting:
  - `HF_TOKEN` variable purpose and usage
  - Which modules depend on this token (import_hf_dataset.py, huggingface_keywords, datasets library)

## Implementation Details
- All changes are documentation-focused with no code logic modifications
- Consistent messaging across all three files regarding token requirements (read-only access)
- Clear guidance that this is optional for public datasets but required for gated models

https://claude.ai/code/session_01AhDdc74Va9t8fsWuqgS9i2