### PR TITLE
Change Docker setup verification failures to skips

### DIFF
--- a/robot/docker/__init__.robot
+++ b/robot/docker/__init__.robot
@@ -14,10 +14,10 @@ Verify Docker Setup
     ...    Fails the suite with a diagnostic message if any check fails.
     ${result}=    Docker.Check Docker Setup
     IF    not ${result}[docker_cli]
-        Fail    Docker CLI is not installed or not on PATH. Install Docker: https://docs.docker.com/get-docker/
+        Skip    Docker CLI is not installed or not on PATH. Install Docker: https://docs.docker.com/get-docker/
     END
     IF    not ${result}[daemon_running]
-        Fail    Docker daemon is not running. Please start Docker and try again.
+        Skip    Docker daemon is not running. Please start Docker and try again.
     END
     Log    Docker setup OK: v${result}[docker_version] (API v${result}[api_version]) at ${result}[docker_cli_path]
 


### PR DESCRIPTION
## Summary
Updated the Docker setup verification logic to skip tests instead of failing when Docker prerequisites are not met.

## Key Changes
- Changed `Fail` to `Skip` when Docker CLI is not installed or not on PATH
- Changed `Fail` to `Skip` when Docker daemon is not running

## Implementation Details
This change allows test suites to gracefully skip Docker-dependent tests when the Docker environment is not available, rather than causing the entire suite to fail. This is more appropriate for optional Docker functionality and provides better test reporting when Docker is not configured on the system.

https://claude.ai/code/session_01WdQFzD6NhZBcKZC9dB6PbM