### PR TITLE
Fix view recreation by explicitly dropping before creating

### DIFF
--- a/src/rfc/test_database.py
+++ b/src/rfc/test_database.py
@@ -570,7 +570,8 @@ class _SQLAlchemyBackend(_Backend):
         # Migrate score column from INTEGER to REAL (float).
         "ALTER TABLE test_results ALTER COLUMN score TYPE REAL USING score::real",
         # Joined view for Superset — one flat dataset with all columns.
-        """CREATE OR REPLACE VIEW test_results_full AS
+        "DROP VIEW IF EXISTS test_results_full",
+        """CREATE VIEW test_results_full AS
         SELECT
             tr.id AS result_id,
             tr.run_id,

--- a/superset/bootstrap_dashboards.py
+++ b/superset/bootstrap_dashboards.py
@@ -105,7 +105,8 @@ CREATE INDEX IF NOT EXISTS idx_coverage_reports_timestamp
 CREATE INDEX IF NOT EXISTS idx_coverage_reports_git_commit
     ON coverage_reports(git_commit);
 
-CREATE OR REPLACE VIEW test_results_full AS
+DROP VIEW IF EXISTS test_results_full;
+CREATE VIEW test_results_full AS
 SELECT
     tr.id AS result_id,
     tr.run_id,


### PR DESCRIPTION
## Summary
Updated the database schema migration and bootstrap scripts to properly handle view recreation by explicitly dropping the view before creating it, rather than using `CREATE OR REPLACE VIEW`.

## Key Changes
- Changed `CREATE OR REPLACE VIEW test_results_full` to a two-step process: `DROP VIEW IF EXISTS` followed by `CREATE VIEW` in both `src/rfc/test_database.py` and `superset/bootstrap_dashboards.py`
- This ensures the view is properly recreated even when its structure changes significantly

## Implementation Details
The `CREATE OR REPLACE VIEW` statement in PostgreSQL has limitations—it can only be used when the new view definition is compatible with the old one (same column names and types in the same order). By explicitly dropping the view first with `DROP VIEW IF EXISTS`, we avoid these constraints and allow for more flexible schema changes to the underlying view definition.

https://claude.ai/code/session_01NkMDyBFVXxLSCGnnJKRCNM