### PR TITLE
Add format compliance test suite with structured output validation

### DIFF
--- a/config/local_models.yaml
+++ b/config/local_models.yaml
@@ -134,6 +134,11 @@ test_suites:
     description: "Demographic parity bias detection across hiring, financial, medical, and performance scenarios"
     timeout_seconds: 600
 
+  - name: "format"
+    path: "robot/format/tests/"
+    description: "Format compliance: structured output, length, and negative constraints"
+    timeout_seconds: 300
+
   - name: "swebench"
     path: "robot/swebench/"
     description: "SWE-bench patch generation and validation"

--- a/config/local_models.yaml
+++ b/config/local_models.yaml
@@ -135,7 +135,7 @@ test_suites:
     timeout_seconds: 600
 
   - name: "format"
-    path: "robot/format/tests/"
+    path: "robot/format/"
     description: "Format compliance: structured output, length, and negative constraints"
     timeout_seconds: 300
 

--- a/config/test_suites.yaml
+++ b/config/test_suites.yaml
@@ -162,6 +162,11 @@ test_suites:
     path: "robot/bias/tests"
     description: "Demographic parity bias detection across hiring, financial, medical, and performance scenarios"
 
+  format:
+    label: "Format Compliance"
+    path: "robot/format/tests"
+    description: "Structured output validation, length compliance, and negative constraint following"
+
   swebench:
     label: "SWE-bench Evaluation"
     path: "robot/swebench"

--- a/config/test_suites.yaml
+++ b/config/test_suites.yaml
@@ -164,7 +164,7 @@ test_suites:
 
   format:
     label: "Format Compliance"
-    path: "robot/format/tests"
+    path: "robot/format"
     description: "Structured output validation, length compliance, and negative constraint following"
 
   swebench:

--- a/robot/format/__init__.robot
+++ b/robot/format/__init__.robot
@@ -1,0 +1,15 @@
+*** Settings ***
+Documentation     Format Compliance Test Suite
+...
+...               Tests LLM ability to follow output format constraints:
+...               - Structured output: JSON, YAML, CSV with schema validation
+...               - Length compliance: exact sentence count, word limits
+...               - Negative constraints: forbidden word avoidance
+
+Resource          format.resource
+Resource          ../resources/llm_setup.resource
+
+Suite Setup       Run Keywords    Verify LLM Available    AND    Setup Format Test Environment
+Suite Teardown    Log    Format compliance test suite completed
+
+Force Tags        format    regression

--- a/robot/format/format.resource
+++ b/robot/format/format.resource
@@ -1,0 +1,79 @@
+*** Settings ***
+Documentation     Shared keywords for format compliance tests.
+...
+...               Provides keywords for asking the LLM for structured output,
+...               validating format constraints, and checking negative constraints.
+
+Library           rfc.keywords.LLMKeywords    WITH NAME    LLM
+Library           rfc.format_keywords.FormatKeywords    WITH NAME    Format
+Variables         ${CURDIR}/variables/format_scenarios.yaml
+
+*** Variables ***
+${FORMAT_MAX_TOKENS}    1024
+
+*** Keywords ***
+Setup Format Test Environment
+    [Documentation]    Initialize LLM parameters for format compliance tests.
+    LLM.Set LLM Parameters    temperature=0.0    max_tokens=${FORMAT_MAX_TOKENS}
+    Log    Format compliance test environment initialized
+
+Ask For Structured Output
+    [Documentation]    Send a prompt requesting structured output and return the response.
+    [Arguments]    ${prompt}
+    ${response}=    LLM.Ask LLM    ${prompt}
+    Should Not Be Empty    ${response}    LLM returned empty response
+    RETURN    ${response}
+
+Ask And Validate JSON
+    [Documentation]    Ask LLM for JSON output and validate against expected keys.
+    ...    Returns the validation score (0.0–1.0).
+    [Arguments]    ${prompt}    ${expected_keys}    ${min_score}=1.0
+    ${response}=    Ask For Structured Output    ${prompt}
+    ${score}=    Format.Validate JSON Response    ${response}    ${expected_keys}
+    Should Be True    ${score} >= ${min_score}
+    ...    JSON validation score ${score} below threshold ${min_score}
+    RETURN    ${score}
+
+Ask And Validate YAML
+    [Documentation]    Ask LLM for YAML output and validate against expected keys.
+    [Arguments]    ${prompt}    ${expected_keys}    ${min_score}=1.0
+    ${response}=    Ask For Structured Output    ${prompt}
+    ${score}=    Format.Validate YAML Response    ${response}    ${expected_keys}
+    Should Be True    ${score} >= ${min_score}
+    ...    YAML validation score ${score} below threshold ${min_score}
+    RETURN    ${score}
+
+Ask And Validate CSV
+    [Documentation]    Ask LLM for CSV output and validate structure.
+    [Arguments]    ${prompt}    ${expected_columns}    ${min_rows}    ${min_score}=1.0
+    ${response}=    Ask For Structured Output    ${prompt}
+    ${score}=    Format.Validate CSV Response    ${response}    ${expected_columns}    ${min_rows}
+    Should Be True    ${score} >= ${min_score}
+    ...    CSV validation score ${score} below threshold ${min_score}
+    RETURN    ${score}
+
+Ask And Check Sentence Count
+    [Documentation]    Ask LLM and assert the response has exactly N sentences.
+    [Arguments]    ${prompt}    ${expected_sentences}
+    ${response}=    Ask For Structured Output    ${prompt}
+    ${count}=    Format.Count Sentences    ${response}
+    Should Be Equal As Integers    ${count}    ${expected_sentences}
+    ...    Expected ${expected_sentences} sentences but got ${count}
+    RETURN    ${count}
+
+Ask And Check Word Limit
+    [Documentation]    Ask LLM and assert the response is under M words.
+    [Arguments]    ${prompt}    ${max_words}
+    ${response}=    Ask For Structured Output    ${prompt}
+    ${count}=    Format.Count Words    ${response}
+    Should Be True    ${count} <= ${max_words}
+    ...    Expected at most ${max_words} words but got ${count}
+    RETURN    ${count}
+
+Ask And Check Forbidden Words
+    [Documentation]    Ask LLM and assert no forbidden words appear in the response.
+    [Arguments]    ${prompt}    ${forbidden_words}
+    ${response}=    Ask For Structured Output    ${prompt}
+    ${violations}=    Format.Check Forbidden Words    ${response}    ${forbidden_words}
+    Should Be Empty    ${violations}    Found forbidden words: ${violations}
+    RETURN    ${violations}

--- a/robot/format/tests/__init__.robot
+++ b/robot/format/tests/__init__.robot
@@ -1,0 +1,2 @@
+*** Settings ***
+Name              Format Compliance Tests

--- a/robot/format/tests/test_length_compliance.robot
+++ b/robot/format/tests/test_length_compliance.robot
@@ -1,0 +1,68 @@
+*** Settings ***
+Documentation     Length Compliance Format Tests
+...
+...               Instruct the model to respond in exactly N sentences or under
+...               M words. Assert against the constraint. Bridges with existing
+...               tokens: benchmark infrastructure.
+
+Resource          ../format.resource
+
+Default Tags      length-compliance    tier:1    verify:python
+
+*** Test Cases ***
+
+# ---------- Sentence Count ----------
+
+Exactly 3 Sentences
+    [Documentation]    Ask for exactly 3 sentences and verify count.
+    [Tags]    sentences    tokens:1024
+    ${scenario}=    Set Variable    ${SENTENCE_COUNT_SCENARIOS}[0]
+    Ask And Check Sentence Count    ${scenario}[prompt]    ${scenario}[expected_sentences]
+
+Exactly 5 Sentences
+    [Documentation]    Ask for exactly 5 sentences and verify count.
+    [Tags]    sentences    tokens:1024
+    ${scenario}=    Set Variable    ${SENTENCE_COUNT_SCENARIOS}[1]
+    Ask And Check Sentence Count    ${scenario}[prompt]    ${scenario}[expected_sentences]
+
+Exactly 1 Sentence
+    [Documentation]    Ask for exactly 1 sentence and verify count.
+    [Tags]    sentences    tokens:1024
+    ${scenario}=    Set Variable    ${SENTENCE_COUNT_SCENARIOS}[2]
+    Ask And Check Sentence Count    ${scenario}[prompt]    ${scenario}[expected_sentences]
+
+# ---------- Word Limits ----------
+
+Under 50 Words
+    [Documentation]    Ask for a response under 50 words and verify.
+    [Tags]    words    tokens:1024
+    ${scenario}=    Set Variable    ${WORD_LIMIT_SCENARIOS}[0]
+    Ask And Check Word Limit    ${scenario}[prompt]    ${scenario}[max_words]
+
+Under 20 Words
+    [Documentation]    Ask for a response under 20 words and verify.
+    [Tags]    words    tokens:512
+    ${scenario}=    Set Variable    ${WORD_LIMIT_SCENARIOS}[1]
+    Ask And Check Word Limit    ${scenario}[prompt]    ${scenario}[max_words]
+
+Under 100 Words
+    [Documentation]    Ask for a response under 100 words and verify.
+    [Tags]    words    tokens:1024
+    ${scenario}=    Set Variable    ${WORD_LIMIT_SCENARIOS}[2]
+    Ask And Check Word Limit    ${scenario}[prompt]    ${scenario}[max_words]
+
+# ---------- Batch ----------
+
+Batch Sentence Count - All Scenarios
+    [Documentation]    Validate all sentence count scenarios in sequence.
+    [Tags]    batch    sentences    tokens:1024
+    FOR    ${scenario}    IN    @{SENTENCE_COUNT_SCENARIOS}
+        Ask And Check Sentence Count    ${scenario}[prompt]    ${scenario}[expected_sentences]
+    END
+
+Batch Word Limit - All Scenarios
+    [Documentation]    Validate all word limit scenarios in sequence.
+    [Tags]    batch    words    tokens:1024
+    FOR    ${scenario}    IN    @{WORD_LIMIT_SCENARIOS}
+        Ask And Check Word Limit    ${scenario}[prompt]    ${scenario}[max_words]
+    END

--- a/robot/format/tests/test_negative_constraint_following.robot
+++ b/robot/format/tests/test_negative_constraint_following.robot
@@ -1,0 +1,45 @@
+*** Settings ***
+Documentation     Negative Constraint Following Tests
+...
+...               Instruct the model to answer without using certain words
+...               (e.g., "do not use the word 'however'"). Assert the forbidden
+...               words are absent from the response.
+
+Resource          ../format.resource
+
+Default Tags      negative-constraint    tier:1    verify:python
+
+*** Test Cases ***
+
+No However
+    [Documentation]    Answer without using the word "however".
+    [Tags]    single-word
+    ${scenario}=    Set Variable    ${FORBIDDEN_WORD_SCENARIOS}[0]
+    Ask And Check Forbidden Words    ${scenario}[prompt]    ${scenario}[forbidden_words]
+
+No Therefore And Furthermore
+    [Documentation]    Answer without using "therefore" or "furthermore".
+    [Tags]    multi-word
+    ${scenario}=    Set Variable    ${FORBIDDEN_WORD_SCENARIOS}[1]
+    Ask And Check Forbidden Words    ${scenario}[prompt]    ${scenario}[forbidden_words]
+
+No Filler Words
+    [Documentation]    Answer without using "basically", "actually", or "literally".
+    [Tags]    multi-word
+    ${scenario}=    Set Variable    ${FORBIDDEN_WORD_SCENARIOS}[2]
+    Ask And Check Forbidden Words    ${scenario}[prompt]    ${scenario}[forbidden_words]
+
+No Very Or Really
+    [Documentation]    Answer without using "very" or "really".
+    [Tags]    multi-word
+    ${scenario}=    Set Variable    ${FORBIDDEN_WORD_SCENARIOS}[3]
+    Ask And Check Forbidden Words    ${scenario}[prompt]    ${scenario}[forbidden_words]
+
+# ---------- Batch ----------
+
+Batch Forbidden Words - All Scenarios
+    [Documentation]    Validate all forbidden word scenarios in sequence.
+    [Tags]    batch
+    FOR    ${scenario}    IN    @{FORBIDDEN_WORD_SCENARIOS}
+        Ask And Check Forbidden Words    ${scenario}[prompt]    ${scenario}[forbidden_words]
+    END

--- a/robot/format/tests/test_structured_output.robot
+++ b/robot/format/tests/test_structured_output.robot
@@ -1,0 +1,77 @@
+*** Settings ***
+Documentation     Structured Output Format Tests
+...
+...               Ask the LLM for JSON, YAML, and CSV output with a schema.
+...               Parse the result programmatically and assert it validates
+...               against the schema. Uses score: tags for partial-credit grading.
+
+Resource          ../format.resource
+
+Default Tags      structured-output    tier:1    verify:python
+
+*** Test Cases ***
+
+# ---------- JSON ----------
+
+JSON Person Object
+    [Documentation]    Ask for a JSON object with name, age, email keys.
+    [Tags]    json    score:partial
+    ${scenario}=    Set Variable    ${JSON_SCENARIOS}[0]
+    Ask And Validate JSON    ${scenario}[prompt]    ${scenario}[expected_keys]    min_score=0.5
+
+JSON Product Array
+    [Documentation]    Ask for a JSON array of products with id, name, price keys.
+    [Tags]    json    score:partial
+    ${scenario}=    Set Variable    ${JSON_SCENARIOS}[1]
+    Ask And Validate JSON    ${scenario}[prompt]    ${scenario}[expected_keys]    min_score=0.5
+
+JSON Address Object
+    [Documentation]    Ask for a JSON object with street, city, state, zip keys.
+    [Tags]    json    score:partial
+    ${scenario}=    Set Variable    ${JSON_SCENARIOS}[2]
+    Ask And Validate JSON    ${scenario}[prompt]    ${scenario}[expected_keys]    min_score=0.5
+
+# ---------- YAML ----------
+
+YAML Server Config
+    [Documentation]    Ask for YAML with host, port, debug, workers keys.
+    [Tags]    yaml    score:partial
+    ${scenario}=    Set Variable    ${YAML_SCENARIOS}[0]
+    Ask And Validate YAML    ${scenario}[prompt]    ${scenario}[expected_keys]    min_score=0.5
+
+YAML Database Config
+    [Documentation]    Ask for YAML with engine, host, port, name, user keys.
+    [Tags]    yaml    score:partial
+    ${scenario}=    Set Variable    ${YAML_SCENARIOS}[1]
+    Ask And Validate YAML    ${scenario}[prompt]    ${scenario}[expected_keys]    min_score=0.5
+
+# ---------- CSV ----------
+
+CSV Employee Table
+    [Documentation]    Ask for CSV with 3 columns and 3 data rows.
+    [Tags]    csv    score:partial
+    ${scenario}=    Set Variable    ${CSV_SCENARIOS}[0]
+    Ask And Validate CSV
+    ...    ${scenario}[prompt]
+    ...    ${scenario}[expected_columns]
+    ...    ${scenario}[min_rows]
+    ...    min_score=0.5
+
+CSV Inventory Table
+    [Documentation]    Ask for CSV with 4 columns and 4 data rows.
+    [Tags]    csv    score:partial
+    ${scenario}=    Set Variable    ${CSV_SCENARIOS}[1]
+    Ask And Validate CSV
+    ...    ${scenario}[prompt]
+    ...    ${scenario}[expected_columns]
+    ...    ${scenario}[min_rows]
+    ...    min_score=0.5
+
+# ---------- Batch ----------
+
+Batch JSON Validation - All Scenarios
+    [Documentation]    Validate all JSON scenarios in sequence.
+    [Tags]    batch    json    score:partial
+    FOR    ${scenario}    IN    @{JSON_SCENARIOS}
+        Ask And Validate JSON    ${scenario}[prompt]    ${scenario}[expected_keys]    min_score=0.5
+    END

--- a/robot/format/variables/format_scenarios.yaml
+++ b/robot/format/variables/format_scenarios.yaml
@@ -1,0 +1,125 @@
+# Format Compliance Test Scenarios
+#
+# Test data for structured output, length compliance, and negative
+# constraint following tests.
+
+# ---------------------------------------------------------------------------
+# Structured Output Scenarios
+# ---------------------------------------------------------------------------
+
+JSON_SCENARIOS:
+  - name: "person_object"
+    prompt: >-
+      Return ONLY a JSON object (no explanation) with these exact keys:
+      name (string), age (integer), email (string).
+      Use realistic values. Output raw JSON only.
+    expected_keys: "name,age,email"
+
+  - name: "product_array"
+    prompt: >-
+      Return ONLY a JSON array of 3 products. Each product must have
+      these exact keys: id (integer), name (string), price (number).
+      Output raw JSON only, no explanation.
+    expected_keys: "id,name,price"
+
+  - name: "address_object"
+    prompt: >-
+      Return ONLY a JSON object representing a US mailing address with
+      these exact keys: street, city, state, zip.
+      Output raw JSON only, no explanation.
+    expected_keys: "street,city,state,zip"
+
+YAML_SCENARIOS:
+  - name: "server_config"
+    prompt: >-
+      Return ONLY a YAML configuration for a web server. Include these
+      exact top-level keys: host, port, debug, workers.
+      Output raw YAML only, no explanation.
+    expected_keys: "host,port,debug,workers"
+
+  - name: "database_config"
+    prompt: >-
+      Return ONLY a YAML configuration for a database connection. Include
+      these exact top-level keys: engine, host, port, name, user.
+      Output raw YAML only, no explanation.
+    expected_keys: "engine,host,port,name,user"
+
+CSV_SCENARIOS:
+  - name: "employee_table"
+    prompt: >-
+      Return ONLY a CSV table with columns: name, department, salary.
+      Include a header row and exactly 3 data rows.
+      Output raw CSV only, no explanation.
+    expected_columns: 3
+    min_rows: 3
+
+  - name: "inventory_table"
+    prompt: >-
+      Return ONLY a CSV table with columns: item, quantity, unit_price, category.
+      Include a header row and exactly 4 data rows.
+      Output raw CSV only, no explanation.
+    expected_columns: 4
+    min_rows: 4
+
+# ---------------------------------------------------------------------------
+# Length Compliance Scenarios
+# ---------------------------------------------------------------------------
+
+SENTENCE_COUNT_SCENARIOS:
+  - name: "exactly_3_sentences"
+    prompt: "Explain what Python is in exactly 3 sentences. No more, no less."
+    expected_sentences: 3
+
+  - name: "exactly_5_sentences"
+    prompt: "Describe the solar system in exactly 5 sentences. No more, no less."
+    expected_sentences: 5
+
+  - name: "exactly_1_sentence"
+    prompt: "Define recursion in exactly 1 sentence."
+    expected_sentences: 1
+
+WORD_LIMIT_SCENARIOS:
+  - name: "under_50_words"
+    prompt: "Explain gravity in under 50 words. Be concise."
+    max_words: 50
+
+  - name: "under_20_words"
+    prompt: "Define recursion in under 20 words."
+    max_words: 20
+
+  - name: "under_100_words"
+    prompt: "Describe the water cycle in under 100 words."
+    max_words: 100
+
+# ---------------------------------------------------------------------------
+# Negative Constraint (Forbidden Word) Scenarios
+# ---------------------------------------------------------------------------
+
+FORBIDDEN_WORD_SCENARIOS:
+  - name: "no_however"
+    prompt: >-
+      Explain the difference between Python and Java.
+      Do not use the word 'however' anywhere in your response.
+    forbidden_words: "however"
+    topic: "Python vs Java comparison"
+
+  - name: "no_therefore_furthermore"
+    prompt: >-
+      Describe the benefits of cloud computing.
+      Do not use the words 'therefore' or 'furthermore' in your response.
+    forbidden_words: "therefore,furthermore"
+    topic: "cloud computing benefits"
+
+  - name: "no_filler_words"
+    prompt: >-
+      Explain what machine learning is.
+      Do not use the words 'basically', 'actually', or 'literally'.
+    forbidden_words: "basically,actually,literally"
+    topic: "machine learning explanation"
+
+  - name: "no_very_really"
+    prompt: >-
+      Describe the importance of exercise for health.
+      Do not use the words 'very' or 'really' in your response.
+    forbidden_words: "very,really"
+    topic: "exercise and health"

--- a/src/rfc/format_keywords.py
+++ b/src/rfc/format_keywords.py
@@ -18,9 +18,16 @@ from robot.api.deco import keyword
 
 from .rfc_data import emit_rfc_data
 
-# Common abbreviations that should not be treated as sentence endings.
-_ABBREVIATIONS = {"mr", "mrs", "ms", "dr", "prof", "sr", "jr", "st", "vs",
-                  "etc", "inc", "ltd", "corp", "approx", "e.g", "i.e"}
+# Title abbreviations precede a name (e.g. "Dr. Smith") and never end a
+# sentence — even when followed by a capitalized word.
+_TITLE_ABBREVIATIONS = {"mr", "mrs", "ms", "dr", "prof", "sr", "jr", "st"}
+
+# Suffix abbreviations may end a sentence (e.g. "Acme Inc. It ships."). They
+# only suppress a sentence break when followed by a lowercase continuation.
+_SUFFIX_ABBREVIATIONS = {"inc", "ltd", "corp", "etc", "vs", "approx",
+                         "e.g", "i.e"}
+
+_ABBREVIATIONS = _TITLE_ABBREVIATIONS | _SUFFIX_ABBREVIATIONS
 
 # Splits on sentence-ending punctuation followed by whitespace or end of string.
 _SENTENCE_SPLIT = re.compile(r"[.!?](?:\s|$)")
@@ -198,20 +205,26 @@ class FormatKeywords:
 
         # Header is first row; data rows are the rest
         actual_columns = len(rows[0])
-        data_rows = len(rows) - 1  # exclude header
+        data_row_widths = [len(r) for r in rows[1:]]
+        data_rows = len(data_row_widths)
+
+        # All data rows must match the expected column count for full credit
+        all_rows_match = (
+            actual_columns == expected_columns
+            and all(w == expected_columns for w in data_row_widths)
+        )
 
         emit_rfc_data("actual_columns", str(actual_columns))
         emit_rfc_data("actual_rows", str(data_rows))
 
-        # Score: 0.5 for parseable, +0.25 for column match, +0.25 for row match
+        # Score: 0.5 for parseable, +0.25 for full column match (header + all
+        # data rows), +0.25 for meeting min_rows. Full 1.0 requires both.
         score = 0.5
-        if actual_columns == expected_columns:
+        if all_rows_match:
             score += 0.25
         if data_rows >= min_rows:
             score += 0.25
-
-        # Full score only when both match
-        if actual_columns == expected_columns and data_rows >= min_rows:
+        if all_rows_match and data_rows >= min_rows:
             score = 1.0
 
         emit_rfc_data("score", f"{score:.4f}")
@@ -239,11 +252,21 @@ class FormatKeywords:
         count = 0
         for match in _SENTENCE_SPLIT.finditer(text):
             pos = match.start()
-            # Check if the period is preceded by an abbreviation
-            prefix = text[:pos].rstrip()
-            last_word = prefix.split()[-1].lower().rstrip(".") if prefix.split() else ""
-            if text[pos] == "." and last_word in _ABBREVIATIONS:
-                continue
+            if text[pos] == ".":
+                # Check if the period is preceded by an abbreviation
+                prefix = text[:pos].rstrip()
+                words = prefix.split()
+                last_word = words[-1].lower().rstrip(".") if words else ""
+                if last_word in _TITLE_ABBREVIATIONS:
+                    # Titles always continue into a name — never break.
+                    continue
+                if last_word in _SUFFIX_ABBREVIATIONS:
+                    # Suffix abbreviations may end a sentence. Only skip the
+                    # boundary if the next word looks like a mid-sentence
+                    # continuation (starts with a lowercase letter).
+                    rest = text[match.end():].lstrip()
+                    if rest and rest[0].islower():
+                        continue
             count += 1
 
         # If text has content but no sentence-ending punctuation, count as 1

--- a/src/rfc/format_keywords.py
+++ b/src/rfc/format_keywords.py
@@ -1,0 +1,303 @@
+"""Robot Framework keywords for validating LLM output format compliance.
+
+Provides keywords to validate structured output (JSON, YAML, CSV),
+count sentences and words, and check for forbidden words in responses.
+All keywords emit RFC_DATA for database capture.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import re
+from typing import Any
+
+import yaml
+from robot.api.deco import keyword
+
+from .rfc_data import emit_rfc_data
+
+# Common abbreviations that should not be treated as sentence endings.
+_ABBREVIATIONS = {"mr", "mrs", "ms", "dr", "prof", "sr", "jr", "st", "vs",
+                  "etc", "inc", "ltd", "corp", "approx", "e.g", "i.e"}
+
+# Splits on sentence-ending punctuation followed by whitespace or end of string.
+_SENTENCE_SPLIT = re.compile(r"[.!?](?:\s|$)")
+
+# Markdown code-fence pattern for extracting content.
+_CODE_FENCE = re.compile(r"```\w*\s*\n?(.*?)```", re.DOTALL)
+
+
+def _strip_code_fences(text: str) -> str:
+    """Extract content from markdown code fences if present."""
+    match = _CODE_FENCE.search(text)
+    if match:
+        return match.group(1).strip()
+    return text.strip()
+
+
+def _parse_expected_keys(expected_keys: str) -> list[str]:
+    """Split comma-separated key string, stripping whitespace."""
+    return [k.strip() for k in expected_keys.split(",") if k.strip()]
+
+
+def _compute_key_score(
+    parsed: dict[str, Any], expected: list[str]
+) -> tuple[float, list[str]]:
+    """Compute partial-credit score based on key presence.
+
+    Returns (score, missing_keys) where score ranges from 0.0 to 1.0.
+    Parse credit (0.5) + key fraction credit (0.5 * keys_found/keys_expected).
+    """
+    if not expected:
+        return 1.0, []
+    present = [k for k in expected if k in parsed]
+    missing = [k for k in expected if k not in parsed]
+    key_ratio = len(present) / len(expected)
+    score = 0.5 + 0.5 * key_ratio
+    return score, missing
+
+
+class FormatKeywords:
+    """Keywords for validating LLM output format compliance."""
+
+    @keyword("Validate JSON Response")
+    def validate_json_response(
+        self, response: str, expected_keys: str
+    ) -> float:
+        """Parse JSON from response and validate expected keys.
+
+        Supports JSON objects and arrays (validates keys of first element).
+        Extracts JSON from markdown code fences if present.
+
+        Args:
+            response: Raw LLM response that should contain JSON.
+            expected_keys: Comma-separated list of expected keys.
+
+        Returns:
+            Score from 0.0 to 1.0. Partial credit: 0.5 for valid parse
+            but missing keys, 1.0 for all keys present.
+        """
+        keys = _parse_expected_keys(expected_keys)
+        text = _strip_code_fences(response)
+        try:
+            parsed = json.loads(text)
+        except (json.JSONDecodeError, ValueError):
+            emit_rfc_data("score", "0.0000")
+            emit_rfc_data("parse_valid", "false")
+            emit_rfc_data("missing_keys", ",".join(keys))
+            return 0.0
+
+        emit_rfc_data("parse_valid", "true")
+
+        # For arrays, validate against first element
+        target: dict[str, Any]
+        if isinstance(parsed, list):
+            if not parsed or not isinstance(parsed[0], dict):
+                score = 0.5  # Valid JSON array but no dict elements
+                emit_rfc_data("score", f"{score:.4f}")
+                emit_rfc_data("missing_keys", ",".join(keys))
+                return score
+            target = parsed[0]
+        elif isinstance(parsed, dict):
+            target = parsed
+        else:
+            score = 0.5  # Valid JSON but not a dict/list
+            emit_rfc_data("score", f"{score:.4f}")
+            emit_rfc_data("missing_keys", ",".join(keys))
+            return score
+
+        score, missing = _compute_key_score(target, keys)
+        emit_rfc_data("score", f"{score:.4f}")
+        emit_rfc_data("missing_keys", ",".join(missing))
+        return score
+
+    @keyword("Validate YAML Response")
+    def validate_yaml_response(
+        self, response: str, expected_keys: str
+    ) -> float:
+        """Parse YAML from response and validate expected keys.
+
+        Args:
+            response: Raw LLM response that should contain YAML.
+            expected_keys: Comma-separated list of expected top-level keys.
+
+        Returns:
+            Score from 0.0 to 1.0.
+        """
+        keys = _parse_expected_keys(expected_keys)
+        text = _strip_code_fences(response)
+        try:
+            parsed = yaml.safe_load(text)
+        except yaml.YAMLError:
+            emit_rfc_data("score", "0.0000")
+            emit_rfc_data("parse_valid", "false")
+            emit_rfc_data("missing_keys", ",".join(keys))
+            return 0.0
+
+        if not isinstance(parsed, dict):
+            emit_rfc_data("score", "0.0000")
+            emit_rfc_data("parse_valid", "false")
+            emit_rfc_data("missing_keys", ",".join(keys))
+            return 0.0
+
+        emit_rfc_data("parse_valid", "true")
+        score, missing = _compute_key_score(parsed, keys)
+        emit_rfc_data("score", f"{score:.4f}")
+        emit_rfc_data("missing_keys", ",".join(missing))
+        return score
+
+    @keyword("Validate CSV Response")
+    def validate_csv_response(
+        self,
+        response: str,
+        expected_columns: int,
+        min_rows: int = 1,
+    ) -> float:
+        """Parse CSV from response and validate structure.
+
+        Args:
+            response: Raw LLM response that should contain CSV.
+            expected_columns: Expected number of columns.
+            min_rows: Minimum number of data rows (excluding header).
+
+        Returns:
+            Score from 0.0 to 1.0. Partial credit for parseable but
+            wrong structure.
+        """
+        expected_columns = int(expected_columns)
+        min_rows = int(min_rows)
+        text = _strip_code_fences(response)
+
+        if not text.strip():
+            emit_rfc_data("score", "0.0000")
+            emit_rfc_data("parse_valid", "false")
+            emit_rfc_data("actual_columns", "0")
+            emit_rfc_data("actual_rows", "0")
+            return 0.0
+
+        try:
+            reader = csv.reader(io.StringIO(text))
+            rows = list(reader)
+        except csv.Error:
+            emit_rfc_data("score", "0.0000")
+            emit_rfc_data("parse_valid", "false")
+            emit_rfc_data("actual_columns", "0")
+            emit_rfc_data("actual_rows", "0")
+            return 0.0
+
+        if not rows:
+            emit_rfc_data("score", "0.0000")
+            emit_rfc_data("parse_valid", "false")
+            emit_rfc_data("actual_columns", "0")
+            emit_rfc_data("actual_rows", "0")
+            return 0.0
+
+        emit_rfc_data("parse_valid", "true")
+
+        # Header is first row; data rows are the rest
+        actual_columns = len(rows[0])
+        data_rows = len(rows) - 1  # exclude header
+
+        emit_rfc_data("actual_columns", str(actual_columns))
+        emit_rfc_data("actual_rows", str(data_rows))
+
+        # Score: 0.5 for parseable, +0.25 for column match, +0.25 for row match
+        score = 0.5
+        if actual_columns == expected_columns:
+            score += 0.25
+        if data_rows >= min_rows:
+            score += 0.25
+
+        # Full score only when both match
+        if actual_columns == expected_columns and data_rows >= min_rows:
+            score = 1.0
+
+        emit_rfc_data("score", f"{score:.4f}")
+        return score
+
+    @keyword("Count Sentences")
+    def count_sentences(self, text: str) -> int:
+        """Count sentences in text using punctuation splitting.
+
+        Handles common abbreviations (Mr., Dr., etc.) to avoid
+        false splits. Text without trailing punctuation counts as
+        one sentence if non-empty.
+
+        Args:
+            text: Text to count sentences in.
+
+        Returns:
+            Number of sentences (0 for empty text).
+        """
+        if not text or not text.strip():
+            emit_rfc_data("sentence_count", "0")
+            return 0
+
+        # Find all positions where sentence-ending punctuation occurs
+        count = 0
+        for match in _SENTENCE_SPLIT.finditer(text):
+            pos = match.start()
+            # Check if the period is preceded by an abbreviation
+            prefix = text[:pos].rstrip()
+            last_word = prefix.split()[-1].lower().rstrip(".") if prefix.split() else ""
+            if text[pos] == "." and last_word in _ABBREVIATIONS:
+                continue
+            count += 1
+
+        # If text has content but no sentence-ending punctuation, count as 1
+        if count == 0 and text.strip():
+            count = 1
+
+        emit_rfc_data("sentence_count", str(count))
+        return count
+
+    @keyword("Count Words")
+    def count_words(self, text: str) -> int:
+        """Count words in text using whitespace splitting.
+
+        Args:
+            text: Text to count words in.
+
+        Returns:
+            Word count (0 for empty or whitespace-only text).
+        """
+        if not text or not text.strip():
+            emit_rfc_data("word_count", "0")
+            return 0
+        count = len(text.split())
+        emit_rfc_data("word_count", str(count))
+        return count
+
+    @keyword("Check Forbidden Words")
+    def check_forbidden_words(
+        self, response: str, forbidden_words: str
+    ) -> list[str]:
+        """Check for forbidden words in response using word-boundary matching.
+
+        Case-insensitive. Uses ``\\b`` word boundaries to avoid matching
+        substrings (e.g. 'show' does not match forbidden word 'how').
+
+        Args:
+            response: LLM response text to check.
+            forbidden_words: Comma-separated list of forbidden words.
+
+        Returns:
+            List of forbidden words found (empty if none).
+        """
+        words = _parse_expected_keys(forbidden_words)
+        if not words or not response:
+            emit_rfc_data("violations", "")
+            emit_rfc_data("violation_count", "0")
+            return []
+
+        violations: list[str] = []
+        for word in words:
+            pattern = rf"\b{re.escape(word)}\b"
+            if re.search(pattern, response, re.IGNORECASE):
+                violations.append(word)
+
+        emit_rfc_data("violations", ",".join(violations))
+        emit_rfc_data("violation_count", str(len(violations)))
+        return violations

--- a/src/rfc/format_keywords.py
+++ b/src/rfc/format_keywords.py
@@ -29,8 +29,9 @@ _SUFFIX_ABBREVIATIONS = {"inc", "ltd", "corp", "etc", "vs", "approx",
 
 _ABBREVIATIONS = _TITLE_ABBREVIATIONS | _SUFFIX_ABBREVIATIONS
 
-# Splits on sentence-ending punctuation followed by whitespace or end of string.
-_SENTENCE_SPLIT = re.compile(r"[.!?](?:\s|$)")
+# Splits on sentence-ending punctuation, optionally followed by closing
+# quotes/brackets, then whitespace or end of string.
+_SENTENCE_SPLIT = re.compile(r"[.!?][\"')\]}]*(?:\s|$)")
 
 # Markdown code-fence pattern for extracting content.
 _CODE_FENCE = re.compile(r"```\w*\s*\n?(.*?)```", re.DOTALL)
@@ -98,26 +99,40 @@ class FormatKeywords:
 
         emit_rfc_data("parse_valid", "true")
 
-        # For arrays, validate against first element
-        target: dict[str, Any]
+        # For arrays, validate every element and average the per-element score.
+        # Any non-dict element scores as a structural failure (0.5 parse credit
+        # only). All missing keys across elements are reported.
         if isinstance(parsed, list):
-            if not parsed or not isinstance(parsed[0], dict):
-                score = 0.5  # Valid JSON array but no dict elements
+            if not parsed:
+                score = 0.5  # Valid JSON array but empty
                 emit_rfc_data("score", f"{score:.4f}")
                 emit_rfc_data("missing_keys", ",".join(keys))
                 return score
-            target = parsed[0]
-        elif isinstance(parsed, dict):
-            target = parsed
-        else:
-            score = 0.5  # Valid JSON but not a dict/list
+            element_scores: list[float] = []
+            all_missing: set[str] = set()
+            for element in parsed:
+                if not isinstance(element, dict):
+                    element_scores.append(0.5)
+                    all_missing.update(keys)
+                    continue
+                el_score, el_missing = _compute_key_score(element, keys)
+                element_scores.append(el_score)
+                all_missing.update(el_missing)
+            score = sum(element_scores) / len(element_scores)
             emit_rfc_data("score", f"{score:.4f}")
-            emit_rfc_data("missing_keys", ",".join(keys))
+            emit_rfc_data("missing_keys", ",".join(sorted(all_missing)))
             return score
 
-        score, missing = _compute_key_score(target, keys)
+        if isinstance(parsed, dict):
+            score, missing = _compute_key_score(parsed, keys)
+            emit_rfc_data("score", f"{score:.4f}")
+            emit_rfc_data("missing_keys", ",".join(missing))
+            return score
+
+        # Valid JSON but not a dict/list
+        score = 0.5
         emit_rfc_data("score", f"{score:.4f}")
-        emit_rfc_data("missing_keys", ",".join(missing))
+        emit_rfc_data("missing_keys", ",".join(keys))
         return score
 
     @keyword("Validate YAML Response")

--- a/tests/test_format_keywords.py
+++ b/tests/test_format_keywords.py
@@ -153,6 +153,14 @@ class TestValidateCsvResponse:
         score = self.fk.validate_csv_response(response, 2, 2)
         assert score == 1.0
 
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_csv_ragged_data_row(self, mock_emit: patch) -> None:
+        """CSV with header width matching but a data row with fewer columns
+        must not score 1.0 — every data row must match the column count."""
+        response = "name,department,salary\nAlice,Engineering,100000\nBob,Marketing"
+        score = self.fk.validate_csv_response(response, 3, 2)
+        assert score < 1.0
+
 
 class TestCountSentences:
     def setup_method(self) -> None:
@@ -192,6 +200,22 @@ class TestCountSentences:
     def test_abbreviations_not_split(self, mock_emit: patch) -> None:
         """Common abbreviations like Mr. Dr. etc. should not split sentences."""
         text = "Dr. Smith went to Washington. He had a meeting."
+        count = self.fk.count_sentences(text)
+        assert count == 2
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_abbreviation_at_sentence_end(self, mock_emit: patch) -> None:
+        """An abbreviation that genuinely ends a sentence must still count.
+        'Acme Inc. It ships globally.' has 2 sentences."""
+        text = "Acme Inc. It ships globally."
+        count = self.fk.count_sentences(text)
+        assert count == 2
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_abbreviation_mid_and_end(self, mock_emit: patch) -> None:
+        """Abbreviation mid-sentence not split, but if next word is capitalized
+        and starts a new sentence, split. 'I work at Foo Inc. Bar Corp. is next.'"""
+        text = "I work at Foo Inc. Bar Corp. is next."
         count = self.fk.count_sentences(text)
         assert count == 2
 

--- a/tests/test_format_keywords.py
+++ b/tests/test_format_keywords.py
@@ -1,0 +1,278 @@
+"""Tests for rfc.format_keywords.FormatKeywords."""
+
+from unittest.mock import patch
+
+from rfc.format_keywords import FormatKeywords
+
+
+class TestValidateJsonResponse:
+    def setup_method(self) -> None:
+        self.fk = FormatKeywords()
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_valid_json_all_keys(self, mock_emit: patch) -> None:
+        """Valid JSON with all expected keys scores 1.0."""
+        response = '{"name": "Alice", "age": 30, "email": "alice@example.com"}'
+        score = self.fk.validate_json_response(response, "name,age,email")
+        assert score == 1.0
+        mock_emit.assert_any_call("score", "1.0000")
+        mock_emit.assert_any_call("parse_valid", "true")
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_invalid_json(self, mock_emit: patch) -> None:
+        """Unparseable JSON scores 0.0."""
+        response = "This is not JSON at all"
+        score = self.fk.validate_json_response(response, "name,age")
+        assert score == 0.0
+        mock_emit.assert_any_call("score", "0.0000")
+        mock_emit.assert_any_call("parse_valid", "false")
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_missing_keys_partial_credit(self, mock_emit: patch) -> None:
+        """JSON with some missing keys gets partial credit."""
+        response = '{"name": "Alice"}'
+        score = self.fk.validate_json_response(response, "name,age,email")
+        # 1 of 3 keys present: parse credit (0.5) + key fraction (0.5 * 1/3)
+        assert 0.0 < score < 1.0
+        mock_emit.assert_any_call("parse_valid", "true")
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_extra_keys_still_full_score(self, mock_emit: patch) -> None:
+        """Extra keys beyond expected do not penalize."""
+        response = '{"name": "Alice", "age": 30, "email": "a@b.c", "phone": "555"}'
+        score = self.fk.validate_json_response(response, "name,age,email")
+        assert score == 1.0
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_json_in_markdown_code_block(self, mock_emit: patch) -> None:
+        """JSON wrapped in markdown code fences is extracted and parsed."""
+        response = '```json\n{"name": "Alice", "age": 30}\n```'
+        score = self.fk.validate_json_response(response, "name,age")
+        assert score == 1.0
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_json_array_first_element(self, mock_emit: patch) -> None:
+        """JSON array validates keys against the first element."""
+        response = '[{"id": 1, "name": "Widget"}, {"id": 2, "name": "Gadget"}]'
+        score = self.fk.validate_json_response(response, "id,name")
+        assert score == 1.0
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_string_coercion_from_robot(self, mock_emit: patch) -> None:
+        """Robot Framework passes strings — ensure expected_keys works."""
+        response = '{"x": 1}'
+        score = self.fk.validate_json_response(response, "x")
+        assert score == 1.0
+
+
+class TestValidateYamlResponse:
+    def setup_method(self) -> None:
+        self.fk = FormatKeywords()
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_valid_yaml_all_keys(self, mock_emit: patch) -> None:
+        """Valid YAML with all expected keys scores 1.0."""
+        response = "host: localhost\nport: 8080\ndebug: true"
+        score = self.fk.validate_yaml_response(response, "host,port,debug")
+        assert score == 1.0
+        mock_emit.assert_any_call("parse_valid", "true")
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_invalid_yaml(self, mock_emit: patch) -> None:
+        """Unparseable YAML (or non-dict result) scores 0.0."""
+        response = ":\n  :\n    - ]["
+        score = self.fk.validate_yaml_response(response, "host,port")
+        assert score == 0.0
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_yaml_missing_keys(self, mock_emit: patch) -> None:
+        """YAML with some missing keys gets partial credit."""
+        response = "host: localhost"
+        score = self.fk.validate_yaml_response(response, "host,port,debug")
+        assert 0.0 < score < 1.0
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_yaml_plain_string_not_dict(self, mock_emit: patch) -> None:
+        """YAML that parses to a plain string (not dict) scores 0.0."""
+        response = "just a plain string"
+        score = self.fk.validate_yaml_response(response, "host,port")
+        assert score == 0.0
+        mock_emit.assert_any_call("parse_valid", "false")
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_yaml_in_code_block(self, mock_emit: patch) -> None:
+        """YAML wrapped in markdown code fences is extracted."""
+        response = "```yaml\nhost: localhost\nport: 8080\n```"
+        score = self.fk.validate_yaml_response(response, "host,port")
+        assert score == 1.0
+
+
+class TestValidateCsvResponse:
+    def setup_method(self) -> None:
+        self.fk = FormatKeywords()
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_valid_csv(self, mock_emit: patch) -> None:
+        """CSV with correct columns and enough rows scores 1.0."""
+        response = "name,department,salary\nAlice,Engineering,100000\nBob,Marketing,90000"
+        score = self.fk.validate_csv_response(response, 3, 2)
+        assert score == 1.0
+        mock_emit.assert_any_call("parse_valid", "true")
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_csv_wrong_column_count(self, mock_emit: patch) -> None:
+        """CSV with wrong number of columns gets partial credit."""
+        response = "name,department\nAlice,Engineering\nBob,Marketing"
+        score = self.fk.validate_csv_response(response, 3, 2)
+        assert 0.0 < score < 1.0
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_csv_too_few_rows(self, mock_emit: patch) -> None:
+        """CSV with too few data rows gets partial credit."""
+        response = "name,dept,salary\nAlice,Eng,100000"
+        score = self.fk.validate_csv_response(response, 3, 3)
+        assert 0.0 < score < 1.0
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_csv_empty_response(self, mock_emit: patch) -> None:
+        """Empty response scores 0.0."""
+        score = self.fk.validate_csv_response("", 3, 2)
+        assert score == 0.0
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_csv_string_coercion(self, mock_emit: patch) -> None:
+        """Robot passes strings for int args — ensure coercion works."""
+        response = "a,b,c\n1,2,3"
+        score = self.fk.validate_csv_response(response, "3", "1")
+        assert score == 1.0
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_csv_in_code_block(self, mock_emit: patch) -> None:
+        """CSV wrapped in markdown code fences is extracted."""
+        response = "```csv\nname,age\nAlice,30\nBob,25\n```"
+        score = self.fk.validate_csv_response(response, 2, 2)
+        assert score == 1.0
+
+
+class TestCountSentences:
+    def setup_method(self) -> None:
+        self.fk = FormatKeywords()
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_three_sentences(self, mock_emit: patch) -> None:
+        text = "First sentence. Second sentence. Third sentence."
+        count = self.fk.count_sentences(text)
+        assert count == 3
+        mock_emit.assert_any_call("sentence_count", "3")
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_single_sentence(self, mock_emit: patch) -> None:
+        count = self.fk.count_sentences("Just one sentence.")
+        assert count == 1
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_empty_string(self, mock_emit: patch) -> None:
+        count = self.fk.count_sentences("")
+        assert count == 0
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_question_and_exclamation(self, mock_emit: patch) -> None:
+        text = "Is this a question? Yes it is! And a statement."
+        count = self.fk.count_sentences(text)
+        assert count == 3
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_no_trailing_punctuation(self, mock_emit: patch) -> None:
+        """Text without trailing punctuation still counts as a sentence."""
+        text = "This has no period"
+        count = self.fk.count_sentences(text)
+        assert count == 1
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_abbreviations_not_split(self, mock_emit: patch) -> None:
+        """Common abbreviations like Mr. Dr. etc. should not split sentences."""
+        text = "Dr. Smith went to Washington. He had a meeting."
+        count = self.fk.count_sentences(text)
+        assert count == 2
+
+
+class TestCountWords:
+    def setup_method(self) -> None:
+        self.fk = FormatKeywords()
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_normal_text(self, mock_emit: patch) -> None:
+        count = self.fk.count_words("The quick brown fox")
+        assert count == 4
+        mock_emit.assert_any_call("word_count", "4")
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_empty_string(self, mock_emit: patch) -> None:
+        count = self.fk.count_words("")
+        assert count == 0
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_whitespace_only(self, mock_emit: patch) -> None:
+        count = self.fk.count_words("   \n\t  ")
+        assert count == 0
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_multi_space(self, mock_emit: patch) -> None:
+        """Multiple spaces between words should not inflate count."""
+        count = self.fk.count_words("hello    world")
+        assert count == 2
+
+
+class TestCheckForbiddenWords:
+    def setup_method(self) -> None:
+        self.fk = FormatKeywords()
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_no_violations(self, mock_emit: patch) -> None:
+        """Response without forbidden words returns empty list."""
+        violations = self.fk.check_forbidden_words(
+            "Python is great for scripting.", "however,therefore"
+        )
+        assert violations == []
+        mock_emit.assert_any_call("violation_count", "0")
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_single_violation(self, mock_emit: patch) -> None:
+        violations = self.fk.check_forbidden_words(
+            "Python is great. However, Java is faster.", "however"
+        )
+        assert violations == ["however"]
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_case_insensitive(self, mock_emit: patch) -> None:
+        """Detection is case-insensitive."""
+        violations = self.fk.check_forbidden_words(
+            "HOWEVER, this works.", "however"
+        )
+        assert violations == ["however"]
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_multiple_violations(self, mock_emit: patch) -> None:
+        violations = self.fk.check_forbidden_words(
+            "However, therefore we proceed.", "however,therefore"
+        )
+        assert sorted(violations) == ["however", "therefore"]
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_word_boundary_no_false_positive(self, mock_emit: patch) -> None:
+        """Should not match substrings: 'show' should not trigger 'how'."""
+        violations = self.fk.check_forbidden_words(
+            "Let me show you the way.", "how"
+        )
+        assert violations == []
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_empty_response(self, mock_emit: patch) -> None:
+        violations = self.fk.check_forbidden_words("", "however")
+        assert violations == []
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_empty_forbidden_list(self, mock_emit: patch) -> None:
+        """Empty forbidden words string returns no violations."""
+        violations = self.fk.check_forbidden_words("Some text here.", "")
+        assert violations == []

--- a/tests/test_format_keywords.py
+++ b/tests/test_format_keywords.py
@@ -58,6 +58,14 @@ class TestValidateJsonResponse:
         assert score == 1.0
 
     @patch("rfc.format_keywords.emit_rfc_data")
+    def test_json_array_inconsistent_elements(self, mock_emit: patch) -> None:
+        """JSON array where later elements miss required keys must not score 1.0.
+        Validation must check every element, not just the first."""
+        response = '[{"id": 1, "name": "x", "price": 1}, {"id": 2}]'
+        score = self.fk.validate_json_response(response, "id,name,price")
+        assert score < 1.0
+
+    @patch("rfc.format_keywords.emit_rfc_data")
     def test_string_coercion_from_robot(self, mock_emit: patch) -> None:
         """Robot Framework passes strings — ensure expected_keys works."""
         response = '{"x": 1}'
@@ -208,6 +216,20 @@ class TestCountSentences:
         """An abbreviation that genuinely ends a sentence must still count.
         'Acme Inc. It ships globally.' has 2 sentences."""
         text = "Acme Inc. It ships globally."
+        count = self.fk.count_sentences(text)
+        assert count == 2
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_sentence_boundary_before_closing_quote(self, mock_emit: patch) -> None:
+        """A period inside closing quotes still ends a sentence."""
+        text = '"Hi." Then she left.'
+        count = self.fk.count_sentences(text)
+        assert count == 2
+
+    @patch("rfc.format_keywords.emit_rfc_data")
+    def test_sentence_boundary_before_closing_paren(self, mock_emit: patch) -> None:
+        """A period before a closing paren still ends a sentence."""
+        text = "Done.) Next we wait."
         count = self.fk.count_sentences(text)
         assert count == 2
 


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive format compliance test suite for validating LLM output against structured format constraints. It includes keywords for parsing and validating JSON, YAML, and CSV responses, as well as keywords for checking length compliance (sentence/word counts) and enforcing negative constraints (forbidden words).

## Key Changes

### Core Implementation
- **`src/rfc/format_keywords.py`** (new): Implements `FormatKeywords` class with Robot Framework keywords:
  - `Validate JSON Response`: Parses JSON and validates expected keys with partial-credit scoring (0.5 for valid parse, +0.5 for key presence)
  - `Validate YAML Response`: Similar validation for YAML structured output
  - `Validate CSV Response`: Validates CSV structure (column count, row count) with partial credit
  - `Count Sentences`: Counts sentences with abbreviation handling (Mr., Dr., etc.)
  - `Count Words`: Simple whitespace-based word counting
  - `Check Forbidden Words`: Case-insensitive word-boundary matching to detect forbidden words in responses
  - All keywords emit RFC_DATA for database capture and test result tracking

### Test Coverage
- **`tests/test_format_keywords.py`** (new): Comprehensive unit tests covering:
  - Valid and invalid structured output parsing
  - Partial-credit scoring scenarios
  - Markdown code fence extraction
  - Edge cases (empty input, wrong types, abbreviations)
  - Word boundary matching to avoid false positives

### Robot Framework Test Suite
- **`robot/format/format.resource`** (new): Shared keywords for format tests
  - `Ask For Structured Output`: Wrapper for LLM queries
  - `Ask And Validate JSON/YAML/CSV`: Combined prompt + validation keywords
  - `Ask And Check Sentence Count/Word Limit/Forbidden Words`: Length and constraint checking
  
- **`robot/format/tests/test_structured_output.robot`** (new): Tests for JSON, YAML, CSV validation
- **`robot/format/tests/test_length_compliance.robot`** (new): Tests for sentence count and word limit constraints
- **`robot/format/tests/test_negative_constraint_following.robot`** (new): Tests for forbidden word avoidance

### Test Data
- **`robot/format/variables/format_scenarios.yaml`** (new): Parameterized test scenarios for:
  - JSON objects and arrays with various schemas
  - YAML configurations
  - CSV tables with different dimensions
  - Sentence count requirements (1, 3, 5 sentences)
  - Word limits (20, 50, 100 words)
  - Forbidden word constraints (single and multiple words)

### Configuration
- **`config/local_models.yaml`** and **`config/test_suites.yaml`** (modified): Added format test suite registration

## Notable Implementation Details

- **Partial-Credit Scoring**: JSON/YAML validation awards 0.5 points for successful parsing and up to 0.5 additional points based on key presence ratio
- **Code Fence Extraction**: Automatically extracts structured content from markdown code blocks (```json, ```yaml, ```csv)
- **Abbreviation Handling**: Sentence counting respects common abbreviations to avoid false sentence splits
- **Word Boundary Matching**: Uses regex word boundaries (`\b`) to prevent substring matches (e.g., "show" won't trigger forbidden word "how")
- **RFC Data Emission**: All keywords emit structured data for test result capture and analysis

https://claude.ai/code/session_01Y1xnmkgPu62GstJhsR5NCc