### PR TITLE
Fix SQL comment handling in _create_tables() to prevent empty query errors

### DIFF
--- a/superset/bootstrap_dashboards.py
+++ b/superset/bootstrap_dashboards.py
@@ -41,7 +41,7 @@ DROP TABLE IF EXISTS analytics_model_comparison CASCADE;
 DROP TABLE IF EXISTS analytics_regression_alerts CASCADE;
 DROP TABLE IF EXISTS analytics_performance_fingerprints CASCADE;
 
--- The view joins columns we are about to drop; take it down first.
+-- The view joins columns we are about to drop, take it down first.
 DROP VIEW IF EXISTS test_results_full;
 
 CREATE TABLE IF NOT EXISTS test_runs (
@@ -1595,9 +1595,14 @@ def _create_tables() -> None:
     engine = create_engine(uri)
     with engine.begin() as conn:
         for statement in _TABLE_DDL.split(";"):
-            statement = statement.strip()
-            if statement:
-                conn.execute(text(statement))
+            # Strip SQL comment lines so comment-only fragments are skipped.
+            executable = "\n".join(
+                ln
+                for ln in statement.splitlines()
+                if ln.strip() and not ln.strip().startswith("--")
+            ).strip()
+            if executable:
+                conn.execute(text(statement.strip()))
     engine.dispose()
     log.info("Created 2-table schema (test_runs, test_results).")
 

--- a/tests/test_bootstrap_dashboards.py
+++ b/tests/test_bootstrap_dashboards.py
@@ -655,6 +655,31 @@ def _pg_to_sqlite(sql: str) -> str:
     return sql
 
 
+class TestTableDDLSplitting:
+    """Guard against SQL comments with semicolons breaking _create_tables()."""
+
+    def test_no_comment_only_fragments_after_split(self) -> None:
+        """Splitting _TABLE_DDL on ';' must not produce comment-only fragments.
+
+        The _create_tables() function splits on ';' and executes each piece.
+        A SQL comment containing a semicolon would produce a fragment that is
+        non-empty but has no executable SQL, causing psycopg2 to raise
+        ``ProgrammingError: can't execute an empty query``.
+        """
+        for i, fragment in enumerate(_TABLE_DDL.split(";")):
+            # Strip comment lines and whitespace
+            executable = "\n".join(
+                ln
+                for ln in fragment.splitlines()
+                if ln.strip() and not ln.strip().startswith("--")
+            ).strip()
+            raw_stripped = fragment.strip()
+            assert not (raw_stripped and not executable), (
+                f"Fragment {i} is comment-only after ';' split — this will crash "
+                f"_create_tables():\n{raw_stripped!r}"
+            )
+
+
 class TestResultsFullViewConsistency:
     """Guard against drift between the rfc.test_database view SQL and
     the copy embedded in superset/bootstrap_dashboards.py::_TABLE_DDL."""


### PR DESCRIPTION
## Summary
Fixed a bug in `_create_tables()` where SQL comments containing semicolons would cause `psycopg2.ProgrammingError: can't execute an empty query` when the DDL is split on semicolons.

## Changes
- **superset/bootstrap_dashboards.py**: Updated `_create_tables()` to strip SQL comment lines before checking if a statement fragment is executable. This prevents comment-only fragments from being executed as empty queries.
- **superset/bootstrap_dashboards.py**: Fixed a SQL comment in `_TABLE_DDL` that had a semicolon in it (changed "drop;" to "drop,") to prevent future issues.
- **tests/test_bootstrap_dashboards.py**: Added `TestTableDDLSplitting` test class with `test_no_comment_only_fragments_after_split()` to guard against this issue recurring.

## Implementation Details
The fix works by:
1. Extracting non-comment lines from each statement fragment after splitting on ";"
2. Only executing fragments that contain actual executable SQL (not just comments and whitespace)
3. This prevents the "can't execute an empty query" error that occurs when a fragment contains only comments

The test validates that no comment-only fragments are produced when splitting `_TABLE_DDL` on semicolons, ensuring the schema initialization won't crash due to this issue.

https://claude.ai/code/session_01P8k9MveZxHCBjufdHKvF3R