### PR TITLE
feat: browser-based Superset + GitHub tests with LLM evaluation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,16 @@
 Read `ai/agents.md` for architecture, code style, and agent contract.
 Read `ai/testing.md` for grading tiers and test rules.
 
+## Working Style: Interview Mode
+
+**Before acting on any non-trivial task, stay in interview/plan mode.** Ask focused questions, push back on assumptions, and take time to understand the full picture before proposing a plan. Do not jump to implementation until:
+
+1. All ambiguities are resolved through questions
+2. A clear, agreed-upon plan exists
+3. The user has confirmed the plan
+
+When the prompt is specific and unambiguous (e.g., "fix this typo"), just do it. When it's broad or has hidden complexity, interview first — 2-4 focused questions minimum.
+
 ---
 
 ## Session startup

--- a/config/local_models.yaml
+++ b/config/local_models.yaml
@@ -174,6 +174,16 @@ test_suites:
     description: "Tool hallucination detection — real vs fake tool selection precision"
     timeout_seconds: 300
 
+  - name: "superset-dashboards"
+    path: "robot/superset/tests/dashboards.robot"
+    description: "Browser-based Superset dashboard evaluation with LLM feedback"
+    timeout_seconds: 600
+
+  - name: "github-review"
+    path: "robot/github/tests/"
+    description: "Browser-based GitHub repo and issue evaluation with LLM feedback"
+    timeout_seconds: 600
+
 # ---------------------------------------------------------------------------
 # Robot Framework execution settings
 # ---------------------------------------------------------------------------

--- a/config/test_suites.yaml
+++ b/config/test_suites.yaml
@@ -342,6 +342,18 @@ ci:
       output_dir: "results/agentic_coding"
       tags: ["agentic", "coding-agent"]
 
+  superset-dashboards:
+    label: "Superset Dashboards"
+    path: "robot/superset/tests/dashboards.robot"
+    description: "Browser-based Superset dashboard evaluation with LLM feedback"
+    extra_deps: ["playwright"]
+
+  github-review:
+    label: "GitHub Repo Review"
+    path: "robot/github/tests"
+    description: "Browser-based GitHub repo and issue evaluation with LLM feedback"
+    extra_deps: ["playwright"]
+
 # ---------------------------------------------------------------------------
 # Monitoring Configuration
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ Issues = "https://github.com/tkarcheski/robotframework-chat/issues"
 [project.optional-dependencies]
 playwright = [
     "robotframework-browser>=18.0.0",
+    "markdownify>=0.14.1",
 ]
 superset = [
     "sqlalchemy>=2.0",

--- a/robot/github/tests/__init__.robot
+++ b/robot/github/tests/__init__.robot
@@ -1,0 +1,2 @@
+*** Settings ***
+Documentation     GitHub repository health and issue triage tests.

--- a/robot/github/tests/repo_review.robot
+++ b/robot/github/tests/repo_review.robot
@@ -1,0 +1,77 @@
+*** Settings ***
+Documentation     Browser-based GitHub repository evaluation.
+...               Visits the public GitHub repo and issues page, converts to
+...               markdown, and asks the LLM to evaluate project health and
+...               suggest improvements.
+Library           Browser    WITH NAME    Playwright
+Library           rfc.browser_keywords.BrowserKeywords    WITH NAME    Page
+Library           rfc.keywords.LLMKeywords    WITH NAME    LLM
+Library           String
+
+Suite Setup       New Browser    chromium    headless=true
+Suite Teardown    Close Browser
+
+*** Variables ***
+${GITHUB_REPO_URL}      https://github.com/tkarcheski/robotframework-chat
+${GITHUB_ISSUES_URL}    https://github.com/tkarcheski/robotframework-chat/issues
+
+*** Test Cases ***
+GitHub Repo Page Loads
+    [Documentation]    Can the browser reach the public GitHub repo page?
+    [Tags]    tier:0    verify:robot    github
+    New Page    ${GITHUB_REPO_URL}
+    Wait For Load State    networkidle    timeout=30s
+    ${title}=    Get Title
+    Should Contain    ${title}    robotframework-chat
+    Log    Page title: ${title}
+
+LLM Evaluates Repository Health
+    [Documentation]    Does the LLM find the repo well-maintained and documented?
+    [Tags]    tier:2    verify:llm    github    repo-health
+    New Page    ${GITHUB_REPO_URL}
+    Wait For Load State    networkidle    timeout=30s
+    ${html}=    Get Page Source
+    ${markdown}=    Page.Convert HTML To Markdown    ${html}
+    Log    Repo markdown:\n${markdown}    level=DEBUG
+    ${prompt}=    Page.Build Evaluation Prompt
+    ...    ${markdown}
+    ...    page_type=repository
+    ...    context=This is the robotframework-chat project — an LLM benchmarking harness using Robot Framework. The default branch is claude-code-staging. Evaluate the README, recent activity, and overall project health.
+    ${feedback}=    LLM.Ask LLM    ${prompt}
+    Log    LLM Feedback: ${feedback}
+    Should Not Be Empty    ${feedback}
+
+LLM Reviews Open Issues
+    [Documentation]    Does the LLM identify priority issues and suggest next actions?
+    [Tags]    tier:2    verify:llm    github    issue-triage
+    New Page    ${GITHUB_ISSUES_URL}
+    Wait For Load State    networkidle    timeout=30s
+    ${html}=    Get Page Source
+    ${markdown}=    Page.Convert HTML To Markdown    ${html}
+    Log    Issues markdown:\n${markdown}    level=DEBUG
+    ${prompt}=    Page.Build Evaluation Prompt
+    ...    ${markdown}
+    ...    page_type=issues
+    ...    context=This is the robotframework-chat issue tracker. Issues prefixed with 'claw:' are automated improvement tasks from the OpenClaw AI agent system. Focus on which issues to prioritize next.
+    ${feedback}=    LLM.Ask LLM    ${prompt}
+    Log    LLM Feedback: ${feedback}
+    Should Not Be Empty    ${feedback}
+
+GitHub Issues Count Is Reasonable
+    [Documentation]    Are there a manageable number of open issues (not spiraling)?
+    [Tags]    tier:0    verify:robot    github    issue-count
+    New Page    ${GITHUB_ISSUES_URL}
+    Wait For Load State    networkidle    timeout=30s
+    ${html}=    Get Page Source
+    ${markdown}=    Page.Convert HTML To Markdown    ${html}
+    # Extract issue count from the page — GitHub shows "N Open" in the issues tab
+    ${matches}=    Get Regexp Matches    ${markdown}    (\\d+)\\s+Open    1
+    ${count}=    Get Length    ${matches}
+    IF    ${count} > 0
+        ${open_count}=    Convert To Integer    ${matches}[0]
+        Log    Open issues: ${open_count}
+        Should Be True    ${open_count} < 50
+        ...    Too many open issues (${open_count}). Triage needed.
+    ELSE
+        Log    Could not extract issue count from page.
+    END

--- a/robot/github/tests/repo_review.robot
+++ b/robot/github/tests/repo_review.robot
@@ -3,13 +3,12 @@ Documentation     Browser-based GitHub repository evaluation.
 ...               Visits the public GitHub repo and issues page, converts to
 ...               markdown, and asks the LLM to evaluate project health and
 ...               suggest improvements.
-Library           Browser    WITH NAME    Playwright
 Library           rfc.browser_keywords.BrowserKeywords    WITH NAME    Page
 Library           rfc.keywords.LLMKeywords    WITH NAME    LLM
 Library           String
 
-Suite Setup       New Browser    chromium    headless=true
-Suite Teardown    Close Browser
+Suite Setup       Import Browser Or Skip
+Suite Teardown    Run Keyword And Ignore Error    Close Browser
 
 *** Variables ***
 ${GITHUB_REPO_URL}      https://github.com/tkarcheski/robotframework-chat
@@ -73,5 +72,15 @@ GitHub Issues Count Is Reasonable
         Should Be True    ${open_count} < 50
         ...    Too many open issues (${open_count}). Triage needed.
     ELSE
-        Log    Could not extract issue count from page.
+        Fail    Could not extract issue count from page. GitHub markup may have changed.
     END
+
+*** Keywords ***
+Import Browser Or Skip
+    [Documentation]    Import Browser library; skip suite if playwright is not installed.
+    TRY
+        Import Library    Browser
+    EXCEPT
+        Skip    Browser library not installed. Install with: uv sync --extra playwright && rfbrowser init
+    END
+    New Browser    chromium    headless=true

--- a/robot/superset/tests/dashboards.robot
+++ b/robot/superset/tests/dashboards.robot
@@ -1,0 +1,101 @@
+*** Settings ***
+Documentation     Browser-based Superset dashboard evaluation.
+...               Logs into Superset, visits each dashboard, converts the page
+...               to markdown, and asks the LLM to evaluate data quality and
+...               suggest improvements.
+Library           Browser    WITH NAME    Playwright
+Library           rfc.browser_keywords.BrowserKeywords    WITH NAME    Page
+Library           rfc.keywords.LLMKeywords    WITH NAME    LLM
+Library           String
+Library           OperatingSystem
+
+Suite Setup       Open Superset And Login
+Suite Teardown    Close Browser
+
+*** Variables ***
+${SUPERSET_URL}         http://ai1:8088
+${SUPERSET_USER}        admin
+${SUPERSET_PASSWORD}    changeme
+${DASHBOARD_IDS}        11,12,13,14,15,16
+
+*** Test Cases ***
+Superset Login Page Loads
+    [Documentation]    Can the browser reach the Superset login page?
+    [Tags]    tier:0    verify:robot    superset
+    Get Title    contains    Superset
+
+All Dashboards Load Successfully
+    [Documentation]    Do all configured dashboards render without HTTP errors?
+    [Tags]    tier:0    verify:robot    superset
+    @{ids}=    Split String    ${DASHBOARD_IDS}    ,
+    FOR    ${id}    IN    @{ids}
+        Go To    ${SUPERSET_URL}/superset/dashboard/${id}/
+        Wait For Load State    networkidle    timeout=30s
+        ${title}=    Get Title
+        Should Not Contain    ${title}    404
+        Should Not Contain    ${title}    Error
+        Log    Dashboard ${id}: ${title}
+    END
+
+LLM Evaluates Model Performance Dashboard
+    [Documentation]    Does the Model Performance dashboard contain meaningful data?
+    [Tags]    tier:2    verify:llm    superset    dashboard:model-performance
+    ${feedback}=    Evaluate Dashboard    14    Model Performance
+    Should Not Contain    ${feedback}    empty
+    Log    LLM Feedback: ${feedback}
+
+LLM Evaluates RFC Test Health Dashboard
+    [Documentation]    Does the RFC Test Health dashboard show actionable test metrics?
+    [Tags]    tier:2    verify:llm    superset    dashboard:test-health
+    ${feedback}=    Evaluate Dashboard    15    RFC Test Health
+    Log    LLM Feedback: ${feedback}
+
+LLM Evaluates Test Results Dashboard
+    [Documentation]    Does the Test Results dashboard display recent test data?
+    [Tags]    tier:2    verify:llm    superset    dashboard:test-results
+    ${feedback}=    Evaluate Dashboard    13    Test Results
+    Log    LLM Feedback: ${feedback}
+
+LLM Evaluates Test Infrastructure Dashboard
+    [Documentation]    Does the Test Infrastructure dashboard show healthy infra?
+    [Tags]    tier:2    verify:llm    superset    dashboard:test-infra
+    ${feedback}=    Evaluate Dashboard    16    Test Infrastructure
+    Log    LLM Feedback: ${feedback}
+
+LLM Evaluates Host Metrics Dashboard
+    [Documentation]    Does the Host Metrics dashboard show current node data?
+    [Tags]    tier:2    verify:llm    superset    dashboard:host-metrics
+    ${feedback}=    Evaluate Dashboard    11    Host Metrics
+    Log    LLM Feedback: ${feedback}
+
+LLM Evaluates Model Details Dashboard
+    [Documentation]    Does the Model Details dashboard provide useful model info?
+    [Tags]    tier:2    verify:llm    superset    dashboard:model-details
+    ${feedback}=    Evaluate Dashboard    12    Model Details
+    Log    LLM Feedback: ${feedback}
+
+*** Keywords ***
+Open Superset And Login
+    [Documentation]    Launch browser, navigate to Superset, and authenticate.
+    New Browser    chromium    headless=true
+    New Page    ${SUPERSET_URL}/login/
+    Wait For Load State    networkidle    timeout=30s
+    Fill Text    id=username    ${SUPERSET_USER}
+    Fill Text    id=password    ${SUPERSET_PASSWORD}
+    Click    input[type="submit"]
+    Wait For Load State    networkidle    timeout=15s
+
+Evaluate Dashboard
+    [Documentation]    Navigate to a dashboard, convert to markdown, ask LLM to evaluate.
+    [Arguments]    ${dashboard_id}    ${dashboard_name}
+    Go To    ${SUPERSET_URL}/superset/dashboard/${dashboard_id}/
+    Wait For Load State    networkidle    timeout=30s
+    ${html}=    Get Page Source
+    ${markdown}=    Page.Convert HTML To Markdown    ${html}
+    Log    Markdown for ${dashboard_name}:\n${markdown}    level=DEBUG
+    ${prompt}=    Page.Build Evaluation Prompt
+    ...    ${markdown}
+    ...    page_type=dashboard
+    ...    context=Dashboard: ${dashboard_name}. This is part of the robotframework-chat LLM benchmarking system. Dashboards visualize test results from Robot Framework test suites running against Ollama models.
+    ${feedback}=    LLM.Ask LLM    ${prompt}
+    RETURN    ${feedback}

--- a/robot/superset/tests/dashboards.robot
+++ b/robot/superset/tests/dashboards.robot
@@ -3,14 +3,13 @@ Documentation     Browser-based Superset dashboard evaluation.
 ...               Logs into Superset, visits each dashboard, converts the page
 ...               to markdown, and asks the LLM to evaluate data quality and
 ...               suggest improvements.
-Library           Browser    WITH NAME    Playwright
 Library           rfc.browser_keywords.BrowserKeywords    WITH NAME    Page
 Library           rfc.keywords.LLMKeywords    WITH NAME    LLM
 Library           String
 Library           OperatingSystem
 
-Suite Setup       Open Superset And Login
-Suite Teardown    Close Browser
+Suite Setup       Import Browser And Login Or Skip
+Suite Teardown    Run Keyword And Ignore Error    Close Browser
 
 *** Variables ***
 ${SUPERSET_URL}         http://ai1:8088
@@ -75,8 +74,13 @@ LLM Evaluates Model Details Dashboard
     Log    LLM Feedback: ${feedback}
 
 *** Keywords ***
-Open Superset And Login
-    [Documentation]    Launch browser, navigate to Superset, and authenticate.
+Import Browser And Login Or Skip
+    [Documentation]    Import Browser library; skip suite if playwright is not installed.
+    TRY
+        Import Library    Browser
+    EXCEPT
+        Skip    Browser library not installed. Install with: uv sync --extra playwright && rfbrowser init
+    END
     New Browser    chromium    headless=true
     New Page    ${SUPERSET_URL}/login/
     Wait For Load State    networkidle    timeout=30s

--- a/src/rfc/browser_keywords.py
+++ b/src/rfc/browser_keywords.py
@@ -1,0 +1,146 @@
+"""Robot Framework keywords for browser-based page evaluation.
+
+Converts page HTML to markdown for LLM analysis instead of passing
+raw HTML or screenshots. This gives the LLM structured text to reason
+about rather than noisy markup.
+"""
+
+from __future__ import annotations
+
+from robot.api.deco import keyword
+
+try:
+    from markdownify import markdownify as md
+except ImportError:
+    md = None  # type: ignore[assignment]
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:
+    BeautifulSoup = None  # type: ignore[assignment,misc]
+
+
+class BrowserKeywords:
+    """Keywords for converting web page content to markdown for LLM evaluation."""
+
+    ROBOT_LIBRARY_SCOPE = "SUITE"
+
+    @keyword("Convert HTML To Markdown")
+    def convert_html_to_markdown(
+        self,
+        html: str,
+        *,
+        strip: str = "img,script,style,svg,noscript,iframe",
+        max_length: int = 8000,
+    ) -> str:
+        """Convert HTML content to clean markdown for LLM consumption.
+
+        Args:
+            html: Raw HTML string from a browser page.
+            strip: Comma-separated HTML tags to strip before conversion.
+            max_length: Truncate output to this many characters.
+
+        Returns:
+            Cleaned markdown string.
+        """
+        if md is None:
+            raise RuntimeError(
+                "markdownify is not installed. "
+                "Run: uv sync --extra playwright"
+            )
+
+        strip_tags = [t.strip() for t in strip.split(",") if t.strip()]
+
+        # Pre-process: remove unwanted tags entirely (including content)
+        if BeautifulSoup is not None and strip_tags:
+            soup = BeautifulSoup(html, "html.parser")
+            for tag_name in strip_tags:
+                for tag in soup.find_all(tag_name):
+                    tag.decompose()
+            html = str(soup)
+
+        result: str = md(
+            html,
+            heading_style="ATX",
+            bullets="-",
+        )
+
+        # Collapse excessive whitespace
+        lines = result.split("\n")
+        cleaned: list[str] = []
+        blank_count = 0
+        for line in lines:
+            stripped = line.rstrip()
+            if not stripped:
+                blank_count += 1
+                if blank_count <= 2:
+                    cleaned.append("")
+            else:
+                blank_count = 0
+                cleaned.append(stripped)
+
+        output = "\n".join(cleaned).strip()
+
+        if len(output) > max_length:
+            output = output[:max_length] + "\n\n[...truncated]"
+
+        return output
+
+    @keyword("Build Evaluation Prompt")
+    def build_evaluation_prompt(
+        self,
+        markdown: str,
+        page_type: str = "dashboard",
+        context: str = "",
+    ) -> str:
+        """Build an LLM evaluation prompt for a page converted to markdown.
+
+        Args:
+            markdown: The markdown content to evaluate.
+            page_type: Type of page (dashboard, repository, issues).
+            context: Additional context for the evaluation.
+
+        Returns:
+            A structured prompt for the LLM.
+        """
+        prompts = {
+            "dashboard": (
+                "You are reviewing an Apache Superset dashboard. "
+                "The dashboard content has been converted to markdown below.\n\n"
+                "Evaluate the following:\n"
+                "1. Does the dashboard contain meaningful data or is it empty?\n"
+                "2. Are there any charts with missing data, errors, or stale dates?\n"
+                "3. Is the layout logical and the information actionable?\n"
+                "4. What specific improvements would you suggest?\n\n"
+                "Be concise. List issues as bullet points. "
+                "If everything looks good, say so briefly.\n\n"
+            ),
+            "repository": (
+                "You are reviewing a GitHub repository page. "
+                "The page content has been converted to markdown below.\n\n"
+                "Evaluate the following:\n"
+                "1. Is the README clear and complete?\n"
+                "2. How many open issues and PRs are visible?\n"
+                "3. Is the project actively maintained (recent commits)?\n"
+                "4. What improvements would you suggest for the repo?\n\n"
+                "Be concise. List findings as bullet points.\n\n"
+            ),
+            "issues": (
+                "You are reviewing a GitHub issues page. "
+                "The page content has been converted to markdown below.\n\n"
+                "Evaluate the following:\n"
+                "1. How many issues are open?\n"
+                "2. Are issues well-labeled and categorized?\n"
+                "3. Which issues are highest priority based on labels and age?\n"
+                "4. Are there stale issues that should be closed?\n"
+                "5. Suggest the top 3 issues to work on next and why.\n\n"
+                "Be concise. List findings as bullet points.\n\n"
+            ),
+        }
+
+        prompt = prompts.get(page_type, prompts["dashboard"])
+        if context:
+            prompt += f"Additional context: {context}\n\n"
+        prompt += f"--- PAGE CONTENT (markdown) ---\n\n{markdown}"
+
+        return prompt


### PR DESCRIPTION
## Summary
- Add browser-based test suites using robotframework-browser (Playwright) that convert pages to markdown for LLM evaluation
- **Superset dashboards** (8 tests): login, load all 6 dashboards, LLM evaluates data quality via markdown
- **GitHub repo** (4 tests): repo health, issue triage, issue count — all against the public URL
- New `BrowserKeywords` library: HTML → BeautifulSoup strip → markdownify → clean markdown → LLM prompt
- Interview mode instruction added to CLAUDE.md

## Test plan
- [x] `uv run robot --dryrun` passes for both suites (12/12)
- [x] `tier:0` GitHub tests pass live (page loads, issue count < 50)
- [x] `BrowserKeywords` unit tested: script/style/img tags stripped correctly
- [ ] `tier:2` LLM evaluation tests run during nightly `make run-local-models`
- [ ] Superset tests require `ai1:8088` reachable and Playwright installed (`rfbrowser init`)

🤖 Generated with [Claude Code](https://claude.ai/code)