### PR TITLE
Refactor DEFAULT_MODEL to use suite variable instead of env var

### DIFF
--- a/robot/docker/llm/__init__.robot
+++ b/robot/docker/llm/__init__.robot
@@ -7,6 +7,7 @@ Suite Teardown    Cleanup LLM Suite
 
 *** Variables ***
 ${OLLAMA_CONTAINER_NAME}    rfc-ollama-${SUITE_NAME}
+${DEFAULT_MODEL}            %{DEFAULT_MODEL}
 
 *** Keywords ***
 Start LLM Suite
@@ -19,7 +20,7 @@ Start LLM Suite
     Set Suite Variable    ${OLLAMA_CONTAINER_NAME}    ${unique_name}
 
     # Start fresh container with unique name
-    ${container}=    Start LLM Container    OLLAMA_CPU    ${OLLAMA_CONTAINER_NAME}    %{DEFAULT_MODEL}
+    ${container}=    Start LLM Container    OLLAMA_CPU    ${OLLAMA_CONTAINER_NAME}    ${DEFAULT_MODEL}
     Log    LLM suite started with container: ${container} (${OLLAMA_CONTAINER_NAME}) on port ${OLLAMA_PORT}
 
 Cleanup LLM Suite


### PR DESCRIPTION
## Summary

Refactored the LLM test suite to define `DEFAULT_MODEL` as a Robot Framework suite variable instead of reading it directly from the environment variable on each use. This improves code consistency and makes the variable value available throughout the suite.

## How to review

**Start here:** `robot/docker/llm/__init__.robot` — the change is straightforward variable initialization and usage.

**Key changes:**
- Added `${DEFAULT_MODEL}` suite variable that reads from `%{DEFAULT_MODEL}` environment variable
- Updated `Start LLM Suite` keyword to use the suite variable `${DEFAULT_MODEL}` instead of the environment variable `%{DEFAULT_MODEL}`

**What to ignore:** None — this is a minimal, focused change.

## Evidence of testing

The change is a simple variable refactoring with no functional impact. Existing Robot Framework tests will validate the behavior.

## Critical changes

None — this is a refactoring that maintains identical runtime behavior while improving code organization.

## Checklist

- [ ] robot-dryrun passes
- [ ] Self-reviewed diff — no scope creep
- [ ] No unresolved `TODO`/`FIXME` in changed files

https://claude.ai/code/session_01JbpaZMaZ6RDtUNKgRemJ9t