### PR TITLE
Add JSON schema validation keywords with retry logic

### DIFF
--- a/config/local_models.yaml
+++ b/config/local_models.yaml
@@ -144,6 +144,11 @@ test_suites:
     description: "GAIA-style tool-use tests for LLM tool selection and invocation"
     timeout_seconds: 300
 
+  - name: "json-schema"
+    path: "robot/json_schema/"
+    description: "JSON schema validation with retry logic and parse failure rate measurement"
+    timeout_seconds: 300
+
   - name: "ifeval"
     path: "robot/ifeval/tests/"
     description: "Instruction following evaluation with deterministic constraint checking"

--- a/config/test_suites.yaml
+++ b/config/test_suites.yaml
@@ -172,6 +172,11 @@ test_suites:
     path: "robot/gaia/tests"
     description: "GAIA-style tests for LLM tool selection, argument formatting, chaining, and refusal"
 
+  json_schema:
+    label: "JSON Schema Validation"
+    path: "robot/json_schema"
+    description: "JSON schema validation with retry logic and parse failure rate measurement across models"
+
   ifeval:
     label: "IFEval Instruction Following"
     path: "robot/ifeval/tests"

--- a/robot/json_schema/__init__.robot
+++ b/robot/json_schema/__init__.robot
@@ -1,0 +1,8 @@
+*** Settings ***
+Documentation     JSON Schema Validation Test Suite
+...
+...               Tests LLM ability to generate JSON conforming to
+...               specified schemas. Includes retry logic testing
+...               to measure parse failure rates and recovery.
+
+Metadata          ENVIRONMENT_VARS    DEFAULT_MODEL    OVERRIDE_MODEL

--- a/robot/json_schema/json_schema.resource
+++ b/robot/json_schema/json_schema.resource
@@ -33,7 +33,7 @@ Ask For JSON With Retries
     ...    Measures how many attempts needed for successful validation.
     [Arguments]    ${prompt}    ${schema}    ${schema_name}=custom    ${max_retries}=5
     ${score}    ${attempt}=    JSONSchema.Validate JSON With Retries    ${prompt}    ${schema}    ${schema_name}    ${max_retries}
-    Should Be True    ${score} >= 0.5    JSON schema validation failed after ${attempt} attempts
+    Should Be True    ${score} == 1.0    JSON schema validation failed after ${attempt} attempts with score ${score}
     Log    JSON schema validation succeeded on attempt ${attempt} with score ${score}
     RETURN    ${score}    ${attempt}
 

--- a/robot/json_schema/json_schema.resource
+++ b/robot/json_schema/json_schema.resource
@@ -1,0 +1,49 @@
+*** Settings ***
+Documentation     Shared keywords for JSON schema validation tests.
+...
+...               Provides keywords for asking the LLM to generate JSON
+...               conforming to schemas and validating the results.
+
+Library           rfc.keywords.LLMKeywords    WITH NAME    LLM
+Library           rfc.json_schema_keywords.JSONSchemaKeywords    WITH NAME    JSONSchema
+Variables         ${CURDIR}/variables/schema_scenarios.yaml
+
+*** Variables ***
+${SCHEMA_MAX_TOKENS}    512
+
+*** Keywords ***
+Setup JSON Schema Test Environment
+    [Documentation]    Initialize LLM for JSON schema validation tests.
+    LLM.Set LLM Parameters    temperature=0.0    max_tokens=${SCHEMA_MAX_TOKENS}
+    Log    JSON schema test environment initialized
+
+Ask For JSON With Schema
+    [Documentation]    Ask LLM to generate JSON and validate against schema.
+    ...    Returns the validation score (0.0–1.0).
+    [Arguments]    ${prompt}    ${schema}    ${schema_name}=custom    ${min_score}=0.5
+    ${response}=    LLM.Ask LLM    ${prompt}
+    Should Not Be Empty    ${response}    LLM returned empty response
+    ${score}=    JSONSchema.Validate JSON With Schema    ${response}    ${schema}    ${schema_name}
+    Should Be True    ${score} >= ${min_score}
+    ...    JSON schema validation score ${score} below threshold ${min_score}
+    RETURN    ${score}
+
+Ask For JSON With Retries
+    [Documentation]    Ask LLM to generate JSON with retry logic.
+    ...    Measures how many attempts needed for successful validation.
+    [Arguments]    ${prompt}    ${schema}    ${schema_name}=custom    ${max_retries}=5
+    ${score}    ${attempt}=    JSONSchema.Validate JSON With Retries    ${prompt}    ${schema}    ${schema_name}    ${max_retries}
+    Should Be True    ${score} >= 0.5    JSON schema validation failed after ${attempt} attempts
+    Log    JSON schema validation succeeded on attempt ${attempt} with score ${score}
+    RETURN    ${score}    ${attempt}
+
+Test JSON Schema Across Scenarios
+    [Documentation]    Test multiple JSON schema scenarios in sequence.
+    [Arguments]    @{scenarios}
+    FOR    ${scenario}    IN    @{scenarios}
+        Ask For JSON With Schema
+        ...    ${scenario}[prompt]
+        ...    ${scenario}[schema]
+        ...    schema_name=${scenario}[name]
+        ...    min_score=${scenario}[min_score]
+    END

--- a/robot/json_schema/tests/__init__.robot
+++ b/robot/json_schema/tests/__init__.robot
@@ -1,0 +1,2 @@
+*** Settings ***
+Documentation     JSON Schema Validation Test Cases

--- a/robot/json_schema/tests/validation.robot
+++ b/robot/json_schema/tests/validation.robot
@@ -6,62 +6,45 @@ Documentation     JSON Schema Validation Tests
 ...               retry logic, and optional model comparison.
 
 Resource          ../json_schema.resource
+Suite Setup       Setup JSON Schema Test Environment
 
 Default Tags      json-schema    tier:2    verify:llm
 
 *** Test Cases ***
 
 Basic Profile JSON Validation
-    [Documentation]    Ask for a user profile in JSON and validate the schema.
     [Tags]    basic    score:partial
-    Setup JSON Schema Test Environment
-    ${scenario}=    Set Variable    ${basic_profile}
-    Ask For JSON With Schema
-    ...    ${scenario}[prompt]
-    ...    ${scenario}[schema]
-    ...    schema_name=${scenario}[name]
-    ...    min_score=${scenario}[min_score]
+    Validate Scenario    ${basic_profile}
 
 Product List JSON Validation
-    [Documentation]    Ask for a product list in JSON and validate schema.
     [Tags]    array    score:partial
-    Setup JSON Schema Test Environment
-    ${scenario}=    Set Variable    ${product_list}
-    Ask For JSON With Schema
-    ...    ${scenario}[prompt]
-    ...    ${scenario}[schema]
-    ...    schema_name=${scenario}[name]
-    ...    min_score=${scenario}[min_score]
+    Validate Scenario    ${product_list}
 
 Configuration Object JSON Validation
-    [Documentation]    Ask for a configuration object and validate nested structure.
     [Tags]    nested    score:partial
-    Setup JSON Schema Test Environment
-    ${scenario}=    Set Variable    ${config_object}
-    Ask For JSON With Schema
-    ...    ${scenario}[prompt]
-    ...    ${scenario}[schema]
-    ...    schema_name=${scenario}[name]
-    ...    min_score=${scenario}[min_score]
+    Validate Scenario    ${config_object}
 
 JSON Validation With Retry Logic
-    [Documentation]    Test JSON schema validation with automatic retry on failure.
+    [Documentation]    Asks for JSON and retries with escalating prompts on failure.
     [Tags]    retry    score:partial
-    Setup JSON Schema Test Environment
-    ${scenario}=    Set Variable    ${basic_profile}
     ${score}    ${attempt}=    Ask For JSON With Retries
-    ...    ${scenario}[prompt]
-    ...    ${scenario}[schema]
-    ...    schema_name=${scenario}[name]
+    ...    ${basic_profile}[prompt]
+    ...    ${basic_profile}[schema]
+    ...    schema_name=${basic_profile}[name]
     ...    max_retries=5
     Log    Achieved score ${score} on attempt ${attempt}
 
 Batch Schema Validation
     [Documentation]    Validate all schema scenarios in sequence.
     [Tags]    batch    score:partial
-    Setup JSON Schema Test Environment
-    @{all_scenarios}=    Create List
-    ...    ${basic_profile}
-    ...    ${product_list}
-    ...    ${config_object}
+    @{all_scenarios}=    Create List    ${basic_profile}    ${product_list}    ${config_object}
     Test JSON Schema Across Scenarios    @{all_scenarios}
+
+*** Keywords ***
+Validate Scenario
+    [Arguments]    ${scenario}
+    Ask For JSON With Schema
+    ...    ${scenario}[prompt]
+    ...    ${scenario}[schema]
+    ...    schema_name=${scenario}[name]
+    ...    min_score=${scenario}[min_score]

--- a/robot/json_schema/tests/validation.robot
+++ b/robot/json_schema/tests/validation.robot
@@ -1,0 +1,67 @@
+*** Settings ***
+Documentation     JSON Schema Validation Tests
+...
+...               Tests LLM ability to generate JSON conforming to
+...               specified schemas. Tests include basic validation,
+...               retry logic, and optional model comparison.
+
+Resource          ../json_schema.resource
+
+Default Tags      json-schema    tier:2    verify:llm
+
+*** Test Cases ***
+
+Basic Profile JSON Validation
+    [Documentation]    Ask for a user profile in JSON and validate the schema.
+    [Tags]    basic    score:partial
+    Setup JSON Schema Test Environment
+    ${scenario}=    Set Variable    ${basic_profile}
+    Ask For JSON With Schema
+    ...    ${scenario}[prompt]
+    ...    ${scenario}[schema]
+    ...    schema_name=${scenario}[name]
+    ...    min_score=${scenario}[min_score]
+
+Product List JSON Validation
+    [Documentation]    Ask for a product list in JSON and validate schema.
+    [Tags]    array    score:partial
+    Setup JSON Schema Test Environment
+    ${scenario}=    Set Variable    ${product_list}
+    Ask For JSON With Schema
+    ...    ${scenario}[prompt]
+    ...    ${scenario}[schema]
+    ...    schema_name=${scenario}[name]
+    ...    min_score=${scenario}[min_score]
+
+Configuration Object JSON Validation
+    [Documentation]    Ask for a configuration object and validate nested structure.
+    [Tags]    nested    score:partial
+    Setup JSON Schema Test Environment
+    ${scenario}=    Set Variable    ${config_object}
+    Ask For JSON With Schema
+    ...    ${scenario}[prompt]
+    ...    ${scenario}[schema]
+    ...    schema_name=${scenario}[name]
+    ...    min_score=${scenario}[min_score]
+
+JSON Validation With Retry Logic
+    [Documentation]    Test JSON schema validation with automatic retry on failure.
+    [Tags]    retry    score:partial
+    Setup JSON Schema Test Environment
+    ${scenario}=    Set Variable    ${basic_profile}
+    ${score}    ${attempt}=    Ask For JSON With Retries
+    ...    ${scenario}[prompt]
+    ...    ${scenario}[schema]
+    ...    schema_name=${scenario}[name]
+    ...    max_retries=5
+    Log    Achieved score ${score} on attempt ${attempt}
+
+Batch Schema Validation
+    [Documentation]    Validate all schema scenarios in sequence.
+    [Tags]    batch    score:partial
+    Setup JSON Schema Test Environment
+    @{all_scenarios}=    Create List
+    ...    ${basic_profile}
+    ...    ${product_list}
+    ...    ${config_object}
+    Test JSON Schema Across Scenarios    @{all_scenarios}

--- a/robot/json_schema/variables/schema_scenarios.yaml
+++ b/robot/json_schema/variables/schema_scenarios.yaml
@@ -1,0 +1,57 @@
+---
+# Basic profile schema with required fields
+basic_profile:
+  name: "Basic Profile"
+  prompt: |
+    Generate a JSON object representing a user profile with the following fields:
+    - name (string): Full name of the person
+    - age (number): Age in years
+    - email (string): Email address
+    Make sure the JSON is valid and complete.
+  schema: |
+    {
+      "required": ["name", "age", "email"],
+      "types": {
+        "name": "string",
+        "age": "number",
+        "email": "string"
+      }
+    }
+  min_score: 0.5
+
+# Product listing with items array
+product_list:
+  name: "Product List"
+  prompt: |
+    Generate a JSON object containing a list of products. The response should have:
+    - status (string): "success" or "error"
+    - items (array): list of product objects
+    Each product should have id, name, and price fields.
+    Make sure the JSON is valid.
+  schema: |
+    {
+      "required": ["status", "items"],
+      "types": {
+        "status": "string",
+        "items": "array"
+      }
+    }
+  min_score: 0.5
+
+# Complex nested structure
+config_object:
+  name: "Configuration"
+  prompt: |
+    Generate a JSON object representing a system configuration with:
+    - database (object): containing host, port, name
+    - server (object): containing host, port, debug
+    Make sure all required fields are present and properly typed.
+  schema: |
+    {
+      "required": ["database", "server"],
+      "types": {
+        "database": "object",
+        "server": "object"
+      }
+    }
+  min_score: 0.5

--- a/src/rfc/browser_keywords.py
+++ b/src/rfc/browser_keywords.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 from robot.api.deco import keyword
 
 try:
-    from markdownify import markdownify as md
+    from markdownify import markdownify as md  # type: ignore[import-not-found]
 except ImportError:
     md = None  # type: ignore[assignment]
 
 try:
-    from bs4 import BeautifulSoup
+    from bs4 import BeautifulSoup  # type: ignore[import-not-found]
 except ImportError:
     BeautifulSoup = None  # type: ignore[assignment,misc]
 
@@ -45,7 +45,8 @@ class BrowserKeywords:
         """
         if md is None:
             raise RuntimeError(
-                "markdownify is not installed. Run: uv sync --extra playwright"
+                "markdownify is not installed. "
+                "Run: uv sync --extra playwright"
             )
 
         strip_tags = [t.strip() for t in strip.split(",") if t.strip()]

--- a/src/rfc/browser_keywords.py
+++ b/src/rfc/browser_keywords.py
@@ -15,7 +15,9 @@ except ImportError:
     md = None  # type: ignore[assignment]
 
 try:
-    from bs4 import BeautifulSoup  # type: ignore[import-not-found]
+    from bs4 import (  # type: ignore[import-not-found,import-untyped]
+        BeautifulSoup,
+    )
 except ImportError:
     BeautifulSoup = None  # type: ignore[assignment,misc]
 
@@ -45,8 +47,7 @@ class BrowserKeywords:
         """
         if md is None:
             raise RuntimeError(
-                "markdownify is not installed. "
-                "Run: uv sync --extra playwright"
+                "markdownify is not installed. Run: uv sync --extra playwright"
             )
 
         strip_tags = [t.strip() for t in strip.split(",") if t.strip()]

--- a/src/rfc/browser_keywords.py
+++ b/src/rfc/browser_keywords.py
@@ -45,8 +45,7 @@ class BrowserKeywords:
         """
         if md is None:
             raise RuntimeError(
-                "markdownify is not installed. "
-                "Run: uv sync --extra playwright"
+                "markdownify is not installed. Run: uv sync --extra playwright"
             )
 
         strip_tags = [t.strip() for t in strip.split(",") if t.strip()]

--- a/src/rfc/json_schema_keywords.py
+++ b/src/rfc/json_schema_keywords.py
@@ -160,6 +160,15 @@ class JSONSchemaKeywords:
             emit_rfc_data("schema_valid", "false")
             return 0.0
 
+        # Validate that all type specifiers are strings
+        for field, type_spec in schema_obj.get("types", {}).items():
+            if not isinstance(type_spec, str):
+                logger.error(
+                    f"Schema type for field '{field}' must be a string, not {type(type_spec).__name__}"
+                )
+                emit_rfc_data("schema_valid", "false")
+                return 0.0
+
         return _validate_parsed(response, schema_obj, schema_name)
 
     @keyword("Validate JSON With Retries")
@@ -199,6 +208,15 @@ class JSONSchemaKeywords:
             logger.error("Schema 'required' field must be a JSON array")
             emit_rfc_data("schema_valid", "false")
             return 0.0, 0
+
+        # Validate that all type specifiers are strings
+        for field, type_spec in schema_obj.get("types", {}).items():
+            if not isinstance(type_spec, str):
+                logger.error(
+                    f"Schema type for field '{field}' must be a string, not {type(type_spec).__name__}"
+                )
+                emit_rfc_data("schema_valid", "false")
+                return 0.0, 0
 
         client = self._get_configured_client()
         last_score = 0.0

--- a/src/rfc/json_schema_keywords.py
+++ b/src/rfc/json_schema_keywords.py
@@ -93,6 +93,7 @@ def _validate_parsed(
         logger.warn(f"Parse failed: {e}")
         emit_rfc_data("parse_valid", "false")
         emit_rfc_data("parse_error", str(e))
+        emit_rfc_data("score", "0.0000")
         return 0.0
 
     emit_rfc_data("parse_valid", "true")
@@ -161,22 +162,26 @@ class JSONSchemaKeywords:
         except (json.JSONDecodeError, ValueError) as e:
             logger.error(f"Invalid schema: {e}")
             emit_rfc_data("schema_valid", "false")
+            emit_rfc_data("score", "0.0000")
             return 0.0
 
         # Validate schema structure: both "required" and "types" must be dicts/lists
         if not isinstance(schema_obj, dict):
             logger.error("Schema must be a JSON object")
             emit_rfc_data("schema_valid", "false")
+            emit_rfc_data("score", "0.0000")
             return 0.0
 
         if "types" in schema_obj and not isinstance(schema_obj["types"], dict):
             logger.error("Schema 'types' field must be a JSON object, not a list")
             emit_rfc_data("schema_valid", "false")
+            emit_rfc_data("score", "0.0000")
             return 0.0
 
         if "required" in schema_obj and not isinstance(schema_obj["required"], list):
             logger.error("Schema 'required' field must be a JSON array")
             emit_rfc_data("schema_valid", "false")
+            emit_rfc_data("score", "0.0000")
             return 0.0
 
         # Validate that all type specifiers are strings
@@ -186,6 +191,7 @@ class JSONSchemaKeywords:
                     f"Schema type for field '{field}' must be a string, not {type(type_spec).__name__}"
                 )
                 emit_rfc_data("schema_valid", "false")
+                emit_rfc_data("score", "0.0000")
                 return 0.0
 
         return _validate_parsed(response, schema_obj, schema_name)
@@ -210,22 +216,26 @@ class JSONSchemaKeywords:
         except (json.JSONDecodeError, ValueError) as e:
             logger.error(f"Invalid schema: {e}")
             emit_rfc_data("schema_valid", "false")
+            emit_rfc_data("score", "0.0000")
             return 0.0, 0
 
         # Validate schema structure: both "required" and "types" must be dicts/lists
         if not isinstance(schema_obj, dict):
             logger.error("Schema must be a JSON object")
             emit_rfc_data("schema_valid", "false")
+            emit_rfc_data("score", "0.0000")
             return 0.0, 0
 
         if "types" in schema_obj and not isinstance(schema_obj["types"], dict):
             logger.error("Schema 'types' field must be a JSON object, not a list")
             emit_rfc_data("schema_valid", "false")
+            emit_rfc_data("score", "0.0000")
             return 0.0, 0
 
         if "required" in schema_obj and not isinstance(schema_obj["required"], list):
             logger.error("Schema 'required' field must be a JSON array")
             emit_rfc_data("schema_valid", "false")
+            emit_rfc_data("score", "0.0000")
             return 0.0, 0
 
         # Validate that all type specifiers are strings
@@ -235,6 +245,7 @@ class JSONSchemaKeywords:
                     f"Schema type for field '{field}' must be a string, not {type(type_spec).__name__}"
                 )
                 emit_rfc_data("schema_valid", "false")
+                emit_rfc_data("score", "0.0000")
                 return 0.0, 0
 
         client = self._get_configured_client()

--- a/src/rfc/json_schema_keywords.py
+++ b/src/rfc/json_schema_keywords.py
@@ -49,14 +49,24 @@ def _validate_against_schema(
         if field not in data:
             errors.append(f"Missing required field: {field}")
 
+    # Validate type specifiers first, before checking field presence
     for field, expected_type in schema.get("types", {}).items():
-        if field not in data:
-            continue
+        if not isinstance(expected_type, str):
+            return False, [
+                f"Schema type for field '{field}' must be a string, not {type(expected_type).__name__}"
+            ]
         check = _TYPE_CHECKS.get(expected_type)
         if check is None:
             return False, [
                 f"Unknown type specifier '{expected_type}' for field '{field}'"
             ]
+
+    # Now check field values for fields that are present
+    for field, expected_type in schema.get("types", {}).items():
+        if field not in data:
+            continue
+        check = _TYPE_CHECKS.get(expected_type)
+        assert check is not None  # Validated above in first loop
         py_type, label = check
         value = data[field]
         if not isinstance(value, py_type):

--- a/src/rfc/json_schema_keywords.py
+++ b/src/rfc/json_schema_keywords.py
@@ -236,19 +236,26 @@ class JSONSchemaKeywords:
 
         client = self._get_configured_client()
         last_score = 0.0
+        last_response = None
         for attempt in range(1, retries + 1):
             full_prompt = prompt + _RETRY_HINTS[min(attempt - 1, len(_RETRY_HINTS) - 1)]
             response = _generate_or_skip(client.generate, full_prompt, attempt)
             if response is None:
                 continue
 
+            last_response = response
             last_score = _validate_parsed(response, schema_obj, schema_name)
             emit_rfc_data("attempt_number", str(attempt))
             emit_rfc_data("final_score", f"{last_score:.4f}")
 
             if last_score == 1.0:
+                emit_rfc_data("actual_answer", response)
                 return last_score, attempt
 
+        # Emit score and final response even if all attempts were skipped or failed
+        emit_rfc_data("final_score", f"{last_score:.4f}")
+        if last_response is not None:
+            emit_rfc_data("actual_answer", last_response)
         return last_score, retries
 
 

--- a/src/rfc/json_schema_keywords.py
+++ b/src/rfc/json_schema_keywords.py
@@ -1,80 +1,94 @@
 """Robot Framework keywords for JSON schema validation.
 
-Provides keywords to validate JSON against schemas with retry logic
-and support for multiple schema types. Useful for testing LLM output
-compliance with expected structured formats.
+Validates LLM JSON output against a lightweight schema (required fields and
+field types) with retry-on-failure support for measuring parse failure rates.
 """
 
 from __future__ import annotations
 
 import json
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from robot.api import logger
 from robot.api.deco import keyword
 
 from .exceptions import EmptyLLMResponseError
+from .format_keywords import _strip_code_fences
 from .llm_client import create_provider, resolve_timeout
 from .rfc_data import emit_rfc_data
 
+_TYPE_CHECKS: dict[str, tuple[type | tuple[type, ...], str]] = {
+    "string": (str, "string"),
+    "number": ((int, float), "number"),
+    "boolean": (bool, "boolean"),
+    "array": (list, "array"),
+    "object": (dict, "object"),
+}
 
-def _strip_code_fences(text: str) -> str:
-    """Extract JSON from markdown code fences if present."""
-    text = text.strip()
-    if text.startswith("```"):
-        lines = text.split("\n")
-        if len(lines) >= 3:
-            return "\n".join(lines[1:-1]).strip()
-    return text
+_RETRY_HINTS = [
+    "",
+    "\n\nPlease provide valid JSON that strictly follows this schema.",
+    "\n\nEnsure the JSON is valid and complete. Double-check all required fields.",
+    "\n\nThis is your final attempt. Provide valid JSON matching the schema exactly.",
+]
 
 
 def _validate_against_schema(
     data: Any, schema: dict[str, Any]
 ) -> tuple[bool, list[str]]:
-    """Validate data against a simple schema.
-
-    Schema format: {"required": ["field1", "field2"], "types": {"field1": "string"}}
-
-    Returns (is_valid, error_messages).
-    """
-    errors = []
-
+    """Validate data against a simple {"required": [...], "types": {...}} schema."""
     if not isinstance(data, dict):
-        errors.append(f"Expected dict, got {type(data).__name__}")
-        return False, errors
+        return False, [f"Expected dict, got {type(data).__name__}"]
 
-    required_fields = schema.get("required", [])
-    for field in required_fields:
+    errors: list[str] = []
+    for field in schema.get("required", []):
         if field not in data:
             errors.append(f"Missing required field: {field}")
 
-    type_specs = schema.get("types", {})
-    for field, expected_type in type_specs.items():
+    for field, expected_type in schema.get("types", {}).items():
         if field not in data:
             continue
-        value = data[field]
-        if expected_type == "string" and not isinstance(value, str):
+        check = _TYPE_CHECKS.get(expected_type)
+        if check is None:
+            continue
+        py_type, label = check
+        if not isinstance(data[field], py_type):
             errors.append(
-                f"Field '{field}' should be string, got {type(value).__name__}"
-            )
-        elif expected_type == "number" and not isinstance(value, (int, float)):
-            errors.append(
-                f"Field '{field}' should be number, got {type(value).__name__}"
-            )
-        elif expected_type == "boolean" and not isinstance(value, bool):
-            errors.append(
-                f"Field '{field}' should be boolean, got {type(value).__name__}"
-            )
-        elif expected_type == "array" and not isinstance(value, list):
-            errors.append(
-                f"Field '{field}' should be array, got {type(value).__name__}"
-            )
-        elif expected_type == "object" and not isinstance(value, dict):
-            errors.append(
-                f"Field '{field}' should be object, got {type(value).__name__}"
+                f"Field '{field}' should be {label}, got {type(data[field]).__name__}"
             )
 
-    return len(errors) == 0, errors
+    return not errors, errors
+
+
+def _validate_parsed(
+    response: str, schema_obj: dict[str, Any], schema_name: str
+) -> float:
+    """Parse `response` and validate against an already-parsed schema object."""
+    emit_rfc_data("schema_valid", "true")
+    emit_rfc_data("schema_name", schema_name)
+
+    text = _strip_code_fences(response)
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, ValueError) as e:
+        logger.warn(f"Parse failed: {e}")
+        emit_rfc_data("parse_valid", "false")
+        emit_rfc_data("parse_error", str(e))
+        return 0.0
+
+    emit_rfc_data("parse_valid", "true")
+    is_valid, errors = _validate_against_schema(parsed, schema_obj)
+
+    if is_valid:
+        score = 1.0
+        emit_rfc_data("validation_valid", "true")
+    else:
+        score = 0.5
+        emit_rfc_data("validation_valid", "false")
+        emit_rfc_data("validation_errors", ";".join(errors))
+
+    emit_rfc_data("score", f"{score:.4f}")
+    return score
 
 
 class JSONSchemaKeywords:
@@ -100,18 +114,10 @@ class JSONSchemaKeywords:
         schema: str,
         schema_name: str = "custom",
     ) -> float:
-        """Validate JSON response against a schema with retry logic.
+        """Parse `response` as JSON and validate against `schema`.
 
-        Attempts to parse JSON and validate against schema. If parsing fails,
-        retries with escalating prompts up to max_retries times.
-
-        Args:
-            response: Raw LLM response containing JSON.
-            schema: JSON string defining the schema with required fields and types.
-            schema_name: Name of the schema for logging.
-
-        Returns:
-            Score from 0.0 to 1.0. Factors: parse success (0.5), validation (0.5).
+        Returns 1.0 for full pass, 0.5 for valid parse with schema errors,
+        and 0.0 for parse failure or invalid schema.
         """
         try:
             schema_obj = json.loads(schema)
@@ -120,32 +126,7 @@ class JSONSchemaKeywords:
             emit_rfc_data("schema_valid", "false")
             return 0.0
 
-        emit_rfc_data("schema_valid", "true")
-        emit_rfc_data("schema_name", schema_name)
-
-        text = _strip_code_fences(response)
-
-        try:
-            parsed = json.loads(text)
-            emit_rfc_data("parse_valid", "true")
-        except (json.JSONDecodeError, ValueError) as e:
-            logger.warn(f"Parse failed: {e}")
-            emit_rfc_data("parse_valid", "false")
-            emit_rfc_data("parse_error", str(e))
-            return 0.0
-
-        is_valid, errors = _validate_against_schema(parsed, schema_obj)
-
-        if is_valid:
-            score = 1.0
-            emit_rfc_data("validation_valid", "true")
-        else:
-            score = 0.5
-            emit_rfc_data("validation_valid", "false")
-            emit_rfc_data("validation_errors", ";".join(errors))
-
-        emit_rfc_data("score", f"{score:.4f}")
-        return score
+        return _validate_parsed(response, schema_obj, schema_name)
 
     @keyword("Validate JSON With Retries")
     def validate_json_with_retries(
@@ -155,55 +136,46 @@ class JSONSchemaKeywords:
         schema_name: str = "custom",
         max_retries: Optional[int] = None,
     ) -> tuple[float, int]:
-        """Ask LLM for JSON and validate against schema with retries.
+        """Ask the LLM for JSON and validate it, retrying on failure.
 
-        Asks LLM to generate JSON matching the schema. If parsing or validation
-        fails, retries with escalating prompts.
-
-        Args:
-            prompt: Base prompt asking for JSON response.
-            schema: JSON string defining the schema.
-            schema_name: Name of the schema for logging.
-            max_retries: Override default max retries.
-
-        Returns:
-            Tuple of (final_score, attempt_number).
+        Returns (final_score, attempt_number). Stops early on a perfect score.
         """
-        max_retries = int(max_retries) if max_retries is not None else self.max_retries
+        retries = int(max_retries) if max_retries is not None else self.max_retries
 
-        retry_hints = [
-            "",
-            "\n\nPlease provide valid JSON that strictly follows this schema.",
-            "\n\nEnsure the JSON is valid and complete. Double-check all required fields.",
-            "\n\nThis is your final attempt. Provide valid JSON matching the schema exactly.",
-        ]
+        try:
+            schema_obj = json.loads(schema)
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.error(f"Invalid schema: {e}")
+            emit_rfc_data("schema_valid", "false")
+            return 0.0, 0
 
         last_score = 0.0
-        last_attempt = max_retries
-
-        for attempt in range(max_retries):
-            hint = retry_hints[min(attempt, len(retry_hints) - 1)]
-            full_prompt = prompt + hint
-
-            try:
-                response = self.client.generate(full_prompt)
-                if not response or not response.strip():
-                    logger.warn(f"Attempt {attempt + 1}: Empty response")
-                    last_attempt = attempt + 1
-                    continue
-            except EmptyLLMResponseError:
-                logger.warn(f"Attempt {attempt + 1}: Empty LLM response")
-                last_attempt = attempt + 1
+        for attempt in range(1, retries + 1):
+            full_prompt = prompt + _RETRY_HINTS[min(attempt - 1, len(_RETRY_HINTS) - 1)]
+            response = _generate_or_skip(self.client.generate, full_prompt, attempt)
+            if response is None:
                 continue
 
-            score = self.validate_json_with_schema(response, schema, schema_name)
-            last_score = score
-            last_attempt = attempt + 1
+            last_score = _validate_parsed(response, schema_obj, schema_name)
+            emit_rfc_data("attempt_number", str(attempt))
+            emit_rfc_data("final_score", f"{last_score:.4f}")
 
-            emit_rfc_data("attempt_number", str(attempt + 1))
-            emit_rfc_data("final_score", f"{score:.4f}")
+            if last_score == 1.0:
+                return last_score, attempt
 
-            if score == 1.0:
-                return score, attempt + 1
+        return last_score, retries
 
-        return last_score, last_attempt
+
+def _generate_or_skip(
+    generate: Callable[[str], str], prompt: str, attempt: int
+) -> Optional[str]:
+    """Call `generate`; return None and log if response is empty or LLM raises."""
+    try:
+        response = generate(prompt)
+    except EmptyLLMResponseError:
+        logger.warn(f"Attempt {attempt}: Empty LLM response")
+        return None
+    if not response or not response.strip():
+        logger.warn(f"Attempt {attempt}: Empty response")
+        return None
+    return response

--- a/src/rfc/json_schema_keywords.py
+++ b/src/rfc/json_schema_keywords.py
@@ -13,9 +13,9 @@ from robot.api import logger
 from robot.api.deco import keyword
 
 from .exceptions import EmptyLLMResponseError
-from .format_keywords import _strip_code_fences
 from .llm_client import create_provider, resolve_timeout
 from .rfc_data import emit_rfc_data
+from .thinking import extract_json
 
 _TYPE_CHECKS: dict[str, tuple[type | tuple[type, ...], str]] = {
     "string": (str, "string"),
@@ -52,10 +52,13 @@ def _validate_against_schema(
         if check is None:
             continue
         py_type, label = check
-        if not isinstance(data[field], py_type):
+        value = data[field]
+        if not isinstance(value, py_type):
             errors.append(
-                f"Field '{field}' should be {label}, got {type(data[field]).__name__}"
+                f"Field '{field}' should be {label}, got {type(value).__name__}"
             )
+        elif expected_type == "number" and isinstance(value, bool):
+            errors.append(f"Field '{field}' should be {label}, got boolean")
 
     return not errors, errors
 
@@ -67,7 +70,7 @@ def _validate_parsed(
     emit_rfc_data("schema_valid", "true")
     emit_rfc_data("schema_name", schema_name)
 
-    text = _strip_code_fences(response)
+    text = extract_json(response)
     try:
         parsed = json.loads(text)
     except (json.JSONDecodeError, ValueError) as e:
@@ -107,6 +110,21 @@ class JSONSchemaKeywords:
         )
         self.max_retries = int(max_retries)
 
+    def _get_configured_client(self) -> Any:
+        """Get the currently configured LLM client from LLMKeywords, or fall back to self.client.
+
+        In Robot Framework suite execution, this returns the LLMKeywords instance's
+        client, which respects LLM.Set LLM Parameters() configuration. In unit tests
+        or non-Robot contexts, falls back to self.client.
+        """
+        try:
+            from robot.libraries.BuiltIn import BuiltIn  # type: ignore[import-not-found]
+
+            llm_library = BuiltIn().get_library_instance("LLM")
+            return llm_library.client  # type: ignore[attr-defined]
+        except Exception:
+            return self.client
+
     @keyword("Validate JSON With Schema")
     def validate_json_with_schema(
         self,
@@ -139,6 +157,7 @@ class JSONSchemaKeywords:
         """Ask the LLM for JSON and validate it, retrying on failure.
 
         Returns (final_score, attempt_number). Stops early on a perfect score.
+        Uses the configured LLM client from LLMKeywords if available.
         """
         retries = int(max_retries) if max_retries is not None else self.max_retries
 
@@ -149,10 +168,11 @@ class JSONSchemaKeywords:
             emit_rfc_data("schema_valid", "false")
             return 0.0, 0
 
+        client = self._get_configured_client()
         last_score = 0.0
         for attempt in range(1, retries + 1):
             full_prompt = prompt + _RETRY_HINTS[min(attempt - 1, len(_RETRY_HINTS) - 1)]
-            response = _generate_or_skip(self.client.generate, full_prompt, attempt)
+            response = _generate_or_skip(client.generate, full_prompt, attempt)
             if response is None:
                 continue
 

--- a/src/rfc/json_schema_keywords.py
+++ b/src/rfc/json_schema_keywords.py
@@ -120,10 +120,12 @@ class JSONSchemaKeywords:
         self,
         timeout: Optional[int] = None,
         max_retries: int = 5,
+        llm_library_alias: str = "LLM",
     ) -> None:
         self.timeout = resolve_timeout(timeout)
         self.client: Any = None
         self.max_retries = int(max_retries)
+        self.llm_library_alias = llm_library_alias
 
     def _get_configured_client(self) -> Any:
         """Get the currently configured LLM client from LLMKeywords, or lazily create one.
@@ -135,7 +137,7 @@ class JSONSchemaKeywords:
         try:
             from robot.libraries.BuiltIn import BuiltIn  # type: ignore[import-not-found]
 
-            llm_library = BuiltIn().get_library_instance("LLM")
+            llm_library = BuiltIn().get_library_instance(self.llm_library_alias)
             return llm_library.client  # type: ignore[attr-defined]
         except Exception:
             # Lazy initialization: create provider only when needed
@@ -251,8 +253,10 @@ class JSONSchemaKeywords:
         client = self._get_configured_client()
         last_score = 0.0
         last_response = None
+        schema_context = f"\n\nRequired schema (JSON):\n{schema}"
         for attempt in range(1, retries + 1):
-            full_prompt = prompt + _RETRY_HINTS[min(attempt - 1, len(_RETRY_HINTS) - 1)]
+            hint = _RETRY_HINTS[min(attempt - 1, len(_RETRY_HINTS) - 1)]
+            full_prompt = prompt + schema_context + hint
             response = _generate_or_skip(client.generate, full_prompt, attempt)
             if response is None:
                 continue

--- a/src/rfc/json_schema_keywords.py
+++ b/src/rfc/json_schema_keywords.py
@@ -120,18 +120,16 @@ class JSONSchemaKeywords:
         timeout: Optional[int] = None,
         max_retries: int = 5,
     ) -> None:
-        timeout = resolve_timeout(timeout)
-        self.client: Any = create_provider(
-            timeout=timeout, max_retries=int(max_retries)
-        )
+        self.timeout = resolve_timeout(timeout)
+        self.client: Any = None
         self.max_retries = int(max_retries)
 
     def _get_configured_client(self) -> Any:
-        """Get the currently configured LLM client from LLMKeywords, or fall back to self.client.
+        """Get the currently configured LLM client from LLMKeywords, or lazily create one.
 
         In Robot Framework suite execution, this returns the LLMKeywords instance's
         client, which respects LLM.Set LLM Parameters() configuration. In unit tests
-        or non-Robot contexts, falls back to self.client.
+        or non-Robot contexts, creates a provider on-demand (lazy initialization).
         """
         try:
             from robot.libraries.BuiltIn import BuiltIn  # type: ignore[import-not-found]
@@ -139,6 +137,11 @@ class JSONSchemaKeywords:
             llm_library = BuiltIn().get_library_instance("LLM")
             return llm_library.client  # type: ignore[attr-defined]
         except Exception:
+            # Lazy initialization: create provider only when needed
+            if self.client is None:
+                self.client = create_provider(
+                    timeout=self.timeout, max_retries=self.max_retries
+                )
             return self.client
 
     @keyword("Validate JSON With Schema")

--- a/src/rfc/json_schema_keywords.py
+++ b/src/rfc/json_schema_keywords.py
@@ -28,7 +28,9 @@ def _strip_code_fences(text: str) -> str:
     return text
 
 
-def _validate_against_schema(data: Any, schema: dict[str, Any]) -> tuple[bool, list[str]]:
+def _validate_against_schema(
+    data: Any, schema: dict[str, Any]
+) -> tuple[bool, list[str]]:
     """Validate data against a simple schema.
 
     Schema format: {"required": ["field1", "field2"], "types": {"field1": "string"}}
@@ -52,15 +54,25 @@ def _validate_against_schema(data: Any, schema: dict[str, Any]) -> tuple[bool, l
             continue
         value = data[field]
         if expected_type == "string" and not isinstance(value, str):
-            errors.append(f"Field '{field}' should be string, got {type(value).__name__}")
+            errors.append(
+                f"Field '{field}' should be string, got {type(value).__name__}"
+            )
         elif expected_type == "number" and not isinstance(value, (int, float)):
-            errors.append(f"Field '{field}' should be number, got {type(value).__name__}")
+            errors.append(
+                f"Field '{field}' should be number, got {type(value).__name__}"
+            )
         elif expected_type == "boolean" and not isinstance(value, bool):
-            errors.append(f"Field '{field}' should be boolean, got {type(value).__name__}")
+            errors.append(
+                f"Field '{field}' should be boolean, got {type(value).__name__}"
+            )
         elif expected_type == "array" and not isinstance(value, list):
-            errors.append(f"Field '{field}' should be array, got {type(value).__name__}")
+            errors.append(
+                f"Field '{field}' should be array, got {type(value).__name__}"
+            )
         elif expected_type == "object" and not isinstance(value, dict):
-            errors.append(f"Field '{field}' should be object, got {type(value).__name__}")
+            errors.append(
+                f"Field '{field}' should be object, got {type(value).__name__}"
+            )
 
     return len(errors) == 0, errors
 

--- a/src/rfc/json_schema_keywords.py
+++ b/src/rfc/json_schema_keywords.py
@@ -144,6 +144,22 @@ class JSONSchemaKeywords:
             emit_rfc_data("schema_valid", "false")
             return 0.0
 
+        # Validate schema structure: both "required" and "types" must be dicts/lists
+        if not isinstance(schema_obj, dict):
+            logger.error("Schema must be a JSON object")
+            emit_rfc_data("schema_valid", "false")
+            return 0.0
+
+        if "types" in schema_obj and not isinstance(schema_obj["types"], dict):
+            logger.error("Schema 'types' field must be a JSON object, not a list")
+            emit_rfc_data("schema_valid", "false")
+            return 0.0
+
+        if "required" in schema_obj and not isinstance(schema_obj["required"], list):
+            logger.error("Schema 'required' field must be a JSON array")
+            emit_rfc_data("schema_valid", "false")
+            return 0.0
+
         return _validate_parsed(response, schema_obj, schema_name)
 
     @keyword("Validate JSON With Retries")
@@ -165,6 +181,22 @@ class JSONSchemaKeywords:
             schema_obj = json.loads(schema)
         except (json.JSONDecodeError, ValueError) as e:
             logger.error(f"Invalid schema: {e}")
+            emit_rfc_data("schema_valid", "false")
+            return 0.0, 0
+
+        # Validate schema structure: both "required" and "types" must be dicts/lists
+        if not isinstance(schema_obj, dict):
+            logger.error("Schema must be a JSON object")
+            emit_rfc_data("schema_valid", "false")
+            return 0.0, 0
+
+        if "types" in schema_obj and not isinstance(schema_obj["types"], dict):
+            logger.error("Schema 'types' field must be a JSON object, not a list")
+            emit_rfc_data("schema_valid", "false")
+            return 0.0, 0
+
+        if "required" in schema_obj and not isinstance(schema_obj["required"], list):
+            logger.error("Schema 'required' field must be a JSON array")
             emit_rfc_data("schema_valid", "false")
             return 0.0, 0
 

--- a/src/rfc/json_schema_keywords.py
+++ b/src/rfc/json_schema_keywords.py
@@ -42,6 +42,10 @@ def _validate_against_schema(
 
     errors: list[str] = []
     for field in schema.get("required", []):
+        if not isinstance(field, str):
+            return False, [
+                f"Required field must be a string, not {type(field).__name__}"
+            ]
         if field not in data:
             errors.append(f"Missing required field: {field}")
 
@@ -50,7 +54,9 @@ def _validate_against_schema(
             continue
         check = _TYPE_CHECKS.get(expected_type)
         if check is None:
-            continue
+            return False, [
+                f"Unknown type specifier '{expected_type}' for field '{field}'"
+            ]
         py_type, label = check
         value = data[field]
         if not isinstance(value, py_type):

--- a/src/rfc/json_schema_keywords.py
+++ b/src/rfc/json_schema_keywords.py
@@ -1,0 +1,197 @@
+"""Robot Framework keywords for JSON schema validation.
+
+Provides keywords to validate JSON against schemas with retry logic
+and support for multiple schema types. Useful for testing LLM output
+compliance with expected structured formats.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from robot.api import logger
+from robot.api.deco import keyword
+
+from .exceptions import EmptyLLMResponseError
+from .llm_client import create_provider, resolve_timeout
+from .rfc_data import emit_rfc_data
+
+
+def _strip_code_fences(text: str) -> str:
+    """Extract JSON from markdown code fences if present."""
+    text = text.strip()
+    if text.startswith("```"):
+        lines = text.split("\n")
+        if len(lines) >= 3:
+            return "\n".join(lines[1:-1]).strip()
+    return text
+
+
+def _validate_against_schema(data: Any, schema: dict[str, Any]) -> tuple[bool, list[str]]:
+    """Validate data against a simple schema.
+
+    Schema format: {"required": ["field1", "field2"], "types": {"field1": "string"}}
+
+    Returns (is_valid, error_messages).
+    """
+    errors = []
+
+    if not isinstance(data, dict):
+        errors.append(f"Expected dict, got {type(data).__name__}")
+        return False, errors
+
+    required_fields = schema.get("required", [])
+    for field in required_fields:
+        if field not in data:
+            errors.append(f"Missing required field: {field}")
+
+    type_specs = schema.get("types", {})
+    for field, expected_type in type_specs.items():
+        if field not in data:
+            continue
+        value = data[field]
+        if expected_type == "string" and not isinstance(value, str):
+            errors.append(f"Field '{field}' should be string, got {type(value).__name__}")
+        elif expected_type == "number" and not isinstance(value, (int, float)):
+            errors.append(f"Field '{field}' should be number, got {type(value).__name__}")
+        elif expected_type == "boolean" and not isinstance(value, bool):
+            errors.append(f"Field '{field}' should be boolean, got {type(value).__name__}")
+        elif expected_type == "array" and not isinstance(value, list):
+            errors.append(f"Field '{field}' should be array, got {type(value).__name__}")
+        elif expected_type == "object" and not isinstance(value, dict):
+            errors.append(f"Field '{field}' should be object, got {type(value).__name__}")
+
+    return len(errors) == 0, errors
+
+
+class JSONSchemaKeywords:
+    """Robot Framework keywords for JSON schema validation."""
+
+    ROBOT_LIBRARY_SCOPE = "SUITE"
+
+    def __init__(
+        self,
+        timeout: Optional[int] = None,
+        max_retries: int = 5,
+    ) -> None:
+        timeout = resolve_timeout(timeout)
+        self.client: Any = create_provider(
+            timeout=timeout, max_retries=int(max_retries)
+        )
+        self.max_retries = int(max_retries)
+
+    @keyword("Validate JSON With Schema")
+    def validate_json_with_schema(
+        self,
+        response: str,
+        schema: str,
+        schema_name: str = "custom",
+    ) -> float:
+        """Validate JSON response against a schema with retry logic.
+
+        Attempts to parse JSON and validate against schema. If parsing fails,
+        retries with escalating prompts up to max_retries times.
+
+        Args:
+            response: Raw LLM response containing JSON.
+            schema: JSON string defining the schema with required fields and types.
+            schema_name: Name of the schema for logging.
+
+        Returns:
+            Score from 0.0 to 1.0. Factors: parse success (0.5), validation (0.5).
+        """
+        try:
+            schema_obj = json.loads(schema)
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.error(f"Invalid schema: {e}")
+            emit_rfc_data("schema_valid", "false")
+            return 0.0
+
+        emit_rfc_data("schema_valid", "true")
+        emit_rfc_data("schema_name", schema_name)
+
+        text = _strip_code_fences(response)
+
+        try:
+            parsed = json.loads(text)
+            emit_rfc_data("parse_valid", "true")
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.warn(f"Parse failed: {e}")
+            emit_rfc_data("parse_valid", "false")
+            emit_rfc_data("parse_error", str(e))
+            return 0.0
+
+        is_valid, errors = _validate_against_schema(parsed, schema_obj)
+
+        if is_valid:
+            score = 1.0
+            emit_rfc_data("validation_valid", "true")
+        else:
+            score = 0.5
+            emit_rfc_data("validation_valid", "false")
+            emit_rfc_data("validation_errors", ";".join(errors))
+
+        emit_rfc_data("score", f"{score:.4f}")
+        return score
+
+    @keyword("Validate JSON With Retries")
+    def validate_json_with_retries(
+        self,
+        prompt: str,
+        schema: str,
+        schema_name: str = "custom",
+        max_retries: Optional[int] = None,
+    ) -> tuple[float, int]:
+        """Ask LLM for JSON and validate against schema with retries.
+
+        Asks LLM to generate JSON matching the schema. If parsing or validation
+        fails, retries with escalating prompts.
+
+        Args:
+            prompt: Base prompt asking for JSON response.
+            schema: JSON string defining the schema.
+            schema_name: Name of the schema for logging.
+            max_retries: Override default max retries.
+
+        Returns:
+            Tuple of (final_score, attempt_number).
+        """
+        max_retries = int(max_retries) if max_retries is not None else self.max_retries
+
+        retry_hints = [
+            "",
+            "\n\nPlease provide valid JSON that strictly follows this schema.",
+            "\n\nEnsure the JSON is valid and complete. Double-check all required fields.",
+            "\n\nThis is your final attempt. Provide valid JSON matching the schema exactly.",
+        ]
+
+        last_score = 0.0
+        last_attempt = max_retries
+
+        for attempt in range(max_retries):
+            hint = retry_hints[min(attempt, len(retry_hints) - 1)]
+            full_prompt = prompt + hint
+
+            try:
+                response = self.client.generate(full_prompt)
+                if not response or not response.strip():
+                    logger.warn(f"Attempt {attempt + 1}: Empty response")
+                    last_attempt = attempt + 1
+                    continue
+            except EmptyLLMResponseError:
+                logger.warn(f"Attempt {attempt + 1}: Empty LLM response")
+                last_attempt = attempt + 1
+                continue
+
+            score = self.validate_json_with_schema(response, schema, schema_name)
+            last_score = score
+            last_attempt = attempt + 1
+
+            emit_rfc_data("attempt_number", str(attempt + 1))
+            emit_rfc_data("final_score", f"{score:.4f}")
+
+            if score == 1.0:
+                return score, attempt + 1
+
+        return last_score, last_attempt

--- a/tests/test_json_schema_keywords.py
+++ b/tests/test_json_schema_keywords.py
@@ -1,50 +1,12 @@
 """Tests for rfc.json_schema_keywords.JSONSchemaKeywords."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-from rfc.json_schema_keywords import (
-    JSONSchemaKeywords,
-    _strip_code_fences,
-    _validate_against_schema,
-)
-
-
-class TestStripCodeFences:
-    def test_strips_json_code_fence(self) -> None:
-        """Code fence with json type is stripped."""
-        text = '```json\n{"key": "value"}\n```'
-        result = _strip_code_fences(text)
-        assert result == '{"key": "value"}'
-
-    def test_strips_unmarked_code_fence(self) -> None:
-        """Code fence without type is stripped."""
-        text = '```\n{"key": "value"}\n```'
-        result = _strip_code_fences(text)
-        assert result == '{"key": "value"}'
-
-    def test_no_code_fence_returns_original(self) -> None:
-        """Text without code fence is returned unchanged."""
-        text = '{"key": "value"}'
-        result = _strip_code_fences(text)
-        assert result == '{"key": "value"}'
-
-    def test_preserves_newlines_in_json(self) -> None:
-        """Newlines within JSON are preserved."""
-        text = '```json\n{"key": "value",\n"other": "data"}\n```'
-        result = _strip_code_fences(text)
-        assert '{"key": "value",' in result
-        assert '"other": "data"}' in result
-
-    def test_strips_leading_trailing_whitespace(self) -> None:
-        """Leading and trailing whitespace is removed."""
-        text = '  ```json\n  {"key": "value"}  \n```  '
-        result = _strip_code_fences(text)
-        assert result == '{"key": "value"}'
+from rfc.json_schema_keywords import JSONSchemaKeywords, _validate_against_schema
 
 
 class TestValidateAgainstSchema:
     def test_validates_required_fields_present(self) -> None:
-        """Data with all required fields passes."""
         schema = {"required": ["name", "age"]}
         data = {"name": "Alice", "age": 30}
         is_valid, errors = _validate_against_schema(data, schema)
@@ -52,7 +14,6 @@ class TestValidateAgainstSchema:
         assert errors == []
 
     def test_rejects_missing_required_fields(self) -> None:
-        """Data missing required fields fails."""
         schema = {"required": ["name", "age"]}
         data = {"name": "Alice"}
         is_valid, errors = _validate_against_schema(data, schema)
@@ -60,7 +21,6 @@ class TestValidateAgainstSchema:
         assert "Missing required field: age" in errors
 
     def test_validates_field_types(self) -> None:
-        """Field types are validated correctly."""
         schema = {
             "required": ["name", "age"],
             "types": {"name": "string", "age": "number"},
@@ -71,7 +31,6 @@ class TestValidateAgainstSchema:
         assert errors == []
 
     def test_rejects_wrong_field_type(self) -> None:
-        """Wrong field type causes validation to fail."""
         schema = {"types": {"age": "string"}}
         data = {"age": 30}
         is_valid, errors = _validate_against_schema(data, schema)
@@ -79,58 +38,41 @@ class TestValidateAgainstSchema:
         assert any("should be string" in e for e in errors)
 
     def test_rejects_non_dict(self) -> None:
-        """Non-dict data fails validation."""
         schema = {"required": ["name"]}
-        data = ["Alice"]
-        is_valid, errors = _validate_against_schema(data, schema)
+        is_valid, errors = _validate_against_schema(["Alice"], schema)
         assert not is_valid
         assert "Expected dict" in errors[0]
 
     def test_allows_extra_fields(self) -> None:
-        """Extra fields beyond schema don't cause failure."""
         schema = {"required": ["name"]}
         data = {"name": "Alice", "age": 30, "email": "alice@example.com"}
-        is_valid, errors = _validate_against_schema(data, schema)
+        is_valid, _ = _validate_against_schema(data, schema)
         assert is_valid
 
     def test_type_validation_for_boolean(self) -> None:
-        """Boolean type is correctly validated."""
         schema = {"types": {"active": "boolean"}}
-        data = {"active": True}
-        is_valid, errors = _validate_against_schema(data, schema)
+        is_valid, _ = _validate_against_schema({"active": True}, schema)
         assert is_valid
-
-        data = {"active": "true"}
-        is_valid, errors = _validate_against_schema(data, schema)
+        is_valid, _ = _validate_against_schema({"active": "true"}, schema)
         assert not is_valid
 
     def test_type_validation_for_array(self) -> None:
-        """Array type is correctly validated."""
         schema = {"types": {"items": "array"}}
-        data = {"items": [1, 2, 3]}
-        is_valid, errors = _validate_against_schema(data, schema)
+        is_valid, _ = _validate_against_schema({"items": [1, 2, 3]}, schema)
         assert is_valid
-
-        data = {"items": "not an array"}
-        is_valid, errors = _validate_against_schema(data, schema)
+        is_valid, _ = _validate_against_schema({"items": "not an array"}, schema)
         assert not is_valid
 
     def test_type_validation_for_object(self) -> None:
-        """Object type is correctly validated."""
         schema = {"types": {"metadata": "object"}}
-        data = {"metadata": {"key": "value"}}
-        is_valid, errors = _validate_against_schema(data, schema)
+        is_valid, _ = _validate_against_schema({"metadata": {"k": "v"}}, schema)
         assert is_valid
-
-        data = {"metadata": ["not", "an", "object"]}
-        is_valid, errors = _validate_against_schema(data, schema)
+        is_valid, _ = _validate_against_schema({"metadata": ["x"]}, schema)
         assert not is_valid
 
     def test_ignores_missing_optional_fields(self) -> None:
-        """Missing optional fields don't trigger type validation."""
         schema = {"types": {"optional_field": "string"}}
-        data = {"other": "value"}
-        is_valid, errors = _validate_against_schema(data, schema)
+        is_valid, _ = _validate_against_schema({"other": "value"}, schema)
         assert is_valid
 
 
@@ -139,191 +81,188 @@ class TestValidateJsonWithSchema:
         self.jk = JSONSchemaKeywords()
 
     def test_invalid_schema_returns_zero(self) -> None:
-        """Invalid schema JSON returns 0.0."""
         with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
-            schema = "not valid json"
-            response = '{"name": "Alice"}'
-            score = self.jk.validate_json_with_schema(response, schema)
+            score = self.jk.validate_json_with_schema('{"name": "Alice"}', "not json")
             assert score == 0.0
             mock_emit.assert_any_call("schema_valid", "false")
 
     def test_valid_schema_recorded(self) -> None:
-        """Valid schema is recorded."""
         with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
-            schema = '{"required": ["name"]}'
-            response = '{"name": "Alice"}'
-            self.jk.validate_json_with_schema(response, schema)
+            self.jk.validate_json_with_schema(
+                '{"name": "Alice"}', '{"required": ["name"]}'
+            )
             mock_emit.assert_any_call("schema_valid", "true")
 
     def test_parse_failure_returns_zero(self) -> None:
-        """Unparseable JSON returns 0.0."""
         with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
-            schema = '{"required": []}'
-            response = "not json"
-            score = self.jk.validate_json_with_schema(response, schema)
+            score = self.jk.validate_json_with_schema("not json", '{"required": []}')
             assert score == 0.0
             mock_emit.assert_any_call("parse_valid", "false")
 
     def test_parse_success_recorded(self) -> None:
-        """Successful parse is recorded."""
         with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
-            schema = '{"required": []}'
-            response = '{"name": "Alice"}'
-            self.jk.validate_json_with_schema(response, schema)
+            self.jk.validate_json_with_schema('{"name": "Alice"}', '{"required": []}')
             mock_emit.assert_any_call("parse_valid", "true")
 
     def test_valid_json_valid_schema_scores_1_0(self) -> None:
-        """Valid JSON matching schema scores 1.0."""
         with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
-            schema = '{"required": ["name", "age"], "types": {"name": "string", "age": "number"}}'
-            response = '{"name": "Alice", "age": 30}'
-            score = self.jk.validate_json_with_schema(response, schema)
+            schema = (
+                '{"required": ["name", "age"], '
+                '"types": {"name": "string", "age": "number"}}'
+            )
+            score = self.jk.validate_json_with_schema(
+                '{"name": "Alice", "age": 30}', schema
+            )
             assert score == 1.0
             mock_emit.assert_any_call("validation_valid", "true")
 
     def test_valid_json_invalid_schema_scores_0_5(self) -> None:
-        """Valid JSON but missing required fields scores 0.5."""
         with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
-            schema = '{"required": ["name", "age"]}'
-            response = '{"name": "Alice"}'
-            score = self.jk.validate_json_with_schema(response, schema)
+            score = self.jk.validate_json_with_schema(
+                '{"name": "Alice"}', '{"required": ["name", "age"]}'
+            )
             assert score == 0.5
             mock_emit.assert_any_call("validation_valid", "false")
 
     def test_json_in_code_fence_is_extracted(self) -> None:
-        """JSON wrapped in code fence is extracted."""
         with patch("rfc.json_schema_keywords.emit_rfc_data"):
-            schema = '{"required": ["name"]}'
-            response = '```json\n{"name": "Alice"}\n```'
-            score = self.jk.validate_json_with_schema(response, schema)
+            score = self.jk.validate_json_with_schema(
+                '```json\n{"name": "Alice"}\n```', '{"required": ["name"]}'
+            )
             assert score == 1.0
 
     def test_schema_name_recorded(self) -> None:
-        """Schema name is recorded in RFC data."""
         with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
-            schema = '{"required": []}'
-            response = "{}"
             self.jk.validate_json_with_schema(
-                response, schema, schema_name="test_schema"
+                "{}", '{"required": []}', schema_name="test_schema"
             )
             mock_emit.assert_any_call("schema_name", "test_schema")
 
     def test_validation_errors_recorded(self) -> None:
-        """Validation errors are recorded."""
         with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
-            schema = '{"required": ["name", "age"]}'
-            response = '{"name": "Alice"}'
-            self.jk.validate_json_with_schema(response, schema)
-            calls = [
-                call
-                for call in mock_emit.call_args_list
-                if call[0][0] == "validation_errors"
+            self.jk.validate_json_with_schema(
+                '{"name": "Alice"}', '{"required": ["name", "age"]}'
+            )
+            errors_calls = [
+                c.args[1]
+                for c in mock_emit.call_args_list
+                if c.args[0] == "validation_errors"
             ]
-            assert len(calls) > 0
-            assert "Missing required field: age" in calls[0][0][1]
+            assert errors_calls
+            assert "Missing required field: age" in errors_calls[0]
 
     def test_score_formatted_correctly(self) -> None:
-        """Score is formatted to 4 decimal places."""
         with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
-            schema = '{"required": []}'
-            response = "{}"
-            score = self.jk.validate_json_with_schema(response, schema)
-            calls = [call for call in mock_emit.call_args_list if call[0][0] == "score"]
-            assert len(calls) > 0
-            assert calls[-1][0][1] == f"{score:.4f}"
+            score = self.jk.validate_json_with_schema("{}", '{"required": []}')
+            score_calls = [
+                c.args[1] for c in mock_emit.call_args_list if c.args[0] == "score"
+            ]
+            assert score_calls and score_calls[-1] == f"{score:.4f}"
 
 
 class TestValidateJsonWithRetries:
     def setup_method(self) -> None:
         self.jk = JSONSchemaKeywords(max_retries=3)
 
-    @patch("rfc.json_schema_keywords.JSONSchemaKeywords.validate_json_with_schema")
-    def test_returns_on_first_success(self, mock_validate: MagicMock) -> None:
-        """Returns immediately on first attempt success."""
-        mock_validate.return_value = 1.0
-        with patch.object(self.jk.client, "generate", return_value='{"data": "value"}'):
-            with patch("rfc.json_schema_keywords.emit_rfc_data"):
-                schema = '{"required": []}'
-                score, attempt = self.jk.validate_json_with_retries(
-                    "Generate JSON", schema
-                )
-                assert score == 1.0
-                assert attempt == 1
+    def _patched(self, validate_return: float | list[float]) -> patch:
+        kwarg = (
+            {"side_effect": validate_return}
+            if isinstance(validate_return, list)
+            else {"return_value": validate_return}
+        )
+        return patch("rfc.json_schema_keywords._validate_parsed", **kwarg)
 
-    @patch("rfc.json_schema_keywords.JSONSchemaKeywords.validate_json_with_schema")
-    def test_retries_on_failure(self, mock_validate: MagicMock) -> None:
-        """Retries when validation fails."""
-        mock_validate.side_effect = [0.5, 0.5, 1.0]
-        with patch.object(self.jk.client, "generate", return_value='{"data": "value"}'):
-            with patch("rfc.json_schema_keywords.emit_rfc_data"):
-                schema = '{"required": []}'
-                score, attempt = self.jk.validate_json_with_retries(
-                    "Generate JSON", schema
-                )
-                assert score == 1.0
-                assert attempt == 3
+    def test_returns_on_first_success(self) -> None:
+        with (
+            self._patched(1.0) as mock_validate,
+            patch.object(self.jk.client, "generate", return_value="{}"),
+            patch("rfc.json_schema_keywords.emit_rfc_data"),
+        ):
+            score, attempt = self.jk.validate_json_with_retries(
+                "Generate JSON", '{"required": []}'
+            )
+            assert (score, attempt) == (1.0, 1)
+            assert mock_validate.call_count == 1
 
-    @patch("rfc.json_schema_keywords.JSONSchemaKeywords.validate_json_with_schema")
-    def test_respects_max_retries(self, mock_validate: MagicMock) -> None:
-        """Stops retrying after max_retries attempts."""
-        mock_validate.return_value = 0.5
-        with patch.object(self.jk.client, "generate", return_value='{"data": "value"}'):
-            with patch("rfc.json_schema_keywords.emit_rfc_data"):
-                schema = '{"required": []}'
-                score, attempt = self.jk.validate_json_with_retries(
-                    "Generate JSON", schema, max_retries=2
-                )
-                assert attempt == 2
-                assert mock_validate.call_count == 2
+    def test_retries_on_failure(self) -> None:
+        with (
+            self._patched([0.5, 0.5, 1.0]),
+            patch.object(self.jk.client, "generate", return_value="{}"),
+            patch("rfc.json_schema_keywords.emit_rfc_data"),
+        ):
+            score, attempt = self.jk.validate_json_with_retries(
+                "Generate JSON", '{"required": []}'
+            )
+            assert (score, attempt) == (1.0, 3)
 
-    @patch("rfc.json_schema_keywords.JSONSchemaKeywords.validate_json_with_schema")
-    def test_empty_response_skips_retry(self, mock_validate: MagicMock) -> None:
-        """Empty LLM response is skipped without validation."""
-        with patch.object(self.jk.client, "generate", return_value=""):
-            with patch("rfc.json_schema_keywords.emit_rfc_data"):
-                schema = '{"required": []}'
-                score, attempt = self.jk.validate_json_with_retries(
-                    "Generate JSON", schema
-                )
-                assert mock_validate.call_count == 0
+    def test_respects_max_retries(self) -> None:
+        with (
+            self._patched(0.5) as mock_validate,
+            patch.object(self.jk.client, "generate", return_value="{}"),
+            patch("rfc.json_schema_keywords.emit_rfc_data"),
+        ):
+            _, attempt = self.jk.validate_json_with_retries(
+                "Generate JSON", '{"required": []}', max_retries=2
+            )
+            assert attempt == 2
+            assert mock_validate.call_count == 2
 
-    def test_respects_custom_max_retries_parameter(self) -> None:
-        """Custom max_retries parameter overrides default."""
+    def test_empty_response_skips_validation(self) -> None:
+        with (
+            self._patched(1.0) as mock_validate,
+            patch.object(self.jk.client, "generate", return_value=""),
+            patch("rfc.json_schema_keywords.emit_rfc_data"),
+        ):
+            self.jk.validate_json_with_retries("Generate JSON", '{"required": []}')
+            assert mock_validate.call_count == 0
+
+    def test_empty_llm_response_exception_skips_validation(self) -> None:
         from rfc.exceptions import EmptyLLMResponseError
 
-        with patch.object(
-            self.jk.client, "generate", side_effect=EmptyLLMResponseError("test-model")
+        with (
+            patch.object(
+                self.jk.client,
+                "generate",
+                side_effect=EmptyLLMResponseError("test-model"),
+            ),
+            patch("rfc.json_schema_keywords.emit_rfc_data"),
         ):
-            with patch("rfc.json_schema_keywords.emit_rfc_data"):
-                schema = '{"required": []}'
-                score, attempt = self.jk.validate_json_with_retries(
-                    "Generate JSON", schema, max_retries=2
-                )
-                assert attempt == 2
+            _, attempt = self.jk.validate_json_with_retries(
+                "Generate JSON", '{"required": []}', max_retries=2
+            )
+            assert attempt == 2
 
     def test_emits_attempt_number(self) -> None:
-        """Attempt number is recorded in RFC data."""
-        with patch(
-            "rfc.json_schema_keywords.JSONSchemaKeywords.validate_json_with_schema",
-            return_value=1.0,
+        with (
+            self._patched(1.0),
+            patch.object(self.jk.client, "generate", return_value="{}"),
+            patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit,
         ):
-            with patch.object(self.jk.client, "generate", return_value="{}"):
-                with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
-                    schema = '{"required": []}'
-                    self.jk.validate_json_with_retries("Generate JSON", schema)
-                    mock_emit.assert_any_call("attempt_number", "1")
+            self.jk.validate_json_with_retries("Generate JSON", '{"required": []}')
+            mock_emit.assert_any_call("attempt_number", "1")
 
     def test_emits_final_score(self) -> None:
-        """Final score is recorded in RFC data."""
-        with patch.object(self.jk, "validate_json_with_schema", return_value=0.75):
-            with patch.object(self.jk.client, "generate", return_value="{}"):
-                with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
-                    schema = '{"required": []}'
-                    self.jk.validate_json_with_retries("Generate JSON", schema)
-                    calls = [
-                        call
-                        for call in mock_emit.call_args_list
-                        if call[0][0] == "final_score"
-                    ]
-                    assert len(calls) > 0
-                    assert calls[-1][0][1] == "0.7500"
+        with (
+            self._patched(0.75),
+            patch.object(self.jk.client, "generate", return_value="{}"),
+            patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit,
+        ):
+            self.jk.validate_json_with_retries("Generate JSON", '{"required": []}')
+            final_calls = [
+                c.args[1]
+                for c in mock_emit.call_args_list
+                if c.args[0] == "final_score"
+            ]
+            assert final_calls and final_calls[-1] == "0.7500"
+
+    def test_invalid_schema_short_circuits(self) -> None:
+        """An unparseable schema returns immediately without calling the LLM."""
+        with (
+            patch.object(self.jk.client, "generate") as mock_gen,
+            patch("rfc.json_schema_keywords.emit_rfc_data"),
+        ):
+            score, attempt = self.jk.validate_json_with_retries(
+                "Generate JSON", "not valid schema"
+            )
+            assert (score, attempt) == (0.0, 0)
+            assert mock_gen.call_count == 0

--- a/tests/test_json_schema_keywords.py
+++ b/tests/test_json_schema_keywords.py
@@ -1,0 +1,317 @@
+"""Tests for rfc.json_schema_keywords.JSONSchemaKeywords."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from rfc.json_schema_keywords import (
+    JSONSchemaKeywords,
+    _strip_code_fences,
+    _validate_against_schema,
+)
+
+
+class TestStripCodeFences:
+    def test_strips_json_code_fence(self) -> None:
+        """Code fence with json type is stripped."""
+        text = '```json\n{"key": "value"}\n```'
+        result = _strip_code_fences(text)
+        assert result == '{"key": "value"}'
+
+    def test_strips_unmarked_code_fence(self) -> None:
+        """Code fence without type is stripped."""
+        text = '```\n{"key": "value"}\n```'
+        result = _strip_code_fences(text)
+        assert result == '{"key": "value"}'
+
+    def test_no_code_fence_returns_original(self) -> None:
+        """Text without code fence is returned unchanged."""
+        text = '{"key": "value"}'
+        result = _strip_code_fences(text)
+        assert result == '{"key": "value"}'
+
+    def test_preserves_newlines_in_json(self) -> None:
+        """Newlines within JSON are preserved."""
+        text = '```json\n{"key": "value",\n"other": "data"}\n```'
+        result = _strip_code_fences(text)
+        assert '{"key": "value",' in result
+        assert '"other": "data"}' in result
+
+    def test_strips_leading_trailing_whitespace(self) -> None:
+        """Leading and trailing whitespace is removed."""
+        text = '  ```json\n  {"key": "value"}  \n```  '
+        result = _strip_code_fences(text)
+        assert result == '{"key": "value"}'
+
+
+class TestValidateAgainstSchema:
+    def test_validates_required_fields_present(self) -> None:
+        """Data with all required fields passes."""
+        schema = {"required": ["name", "age"]}
+        data = {"name": "Alice", "age": 30}
+        is_valid, errors = _validate_against_schema(data, schema)
+        assert is_valid
+        assert errors == []
+
+    def test_rejects_missing_required_fields(self) -> None:
+        """Data missing required fields fails."""
+        schema = {"required": ["name", "age"]}
+        data = {"name": "Alice"}
+        is_valid, errors = _validate_against_schema(data, schema)
+        assert not is_valid
+        assert "Missing required field: age" in errors
+
+    def test_validates_field_types(self) -> None:
+        """Field types are validated correctly."""
+        schema = {
+            "required": ["name", "age"],
+            "types": {"name": "string", "age": "number"},
+        }
+        data = {"name": "Alice", "age": 30}
+        is_valid, errors = _validate_against_schema(data, schema)
+        assert is_valid
+        assert errors == []
+
+    def test_rejects_wrong_field_type(self) -> None:
+        """Wrong field type causes validation to fail."""
+        schema = {"types": {"age": "string"}}
+        data = {"age": 30}
+        is_valid, errors = _validate_against_schema(data, schema)
+        assert not is_valid
+        assert any("should be string" in e for e in errors)
+
+    def test_rejects_non_dict(self) -> None:
+        """Non-dict data fails validation."""
+        schema = {"required": ["name"]}
+        data = ["Alice"]
+        is_valid, errors = _validate_against_schema(data, schema)
+        assert not is_valid
+        assert "Expected dict" in errors[0]
+
+    def test_allows_extra_fields(self) -> None:
+        """Extra fields beyond schema don't cause failure."""
+        schema = {"required": ["name"]}
+        data = {"name": "Alice", "age": 30, "email": "alice@example.com"}
+        is_valid, errors = _validate_against_schema(data, schema)
+        assert is_valid
+
+    def test_type_validation_for_boolean(self) -> None:
+        """Boolean type is correctly validated."""
+        schema = {"types": {"active": "boolean"}}
+        data = {"active": True}
+        is_valid, errors = _validate_against_schema(data, schema)
+        assert is_valid
+
+        data = {"active": "true"}
+        is_valid, errors = _validate_against_schema(data, schema)
+        assert not is_valid
+
+    def test_type_validation_for_array(self) -> None:
+        """Array type is correctly validated."""
+        schema = {"types": {"items": "array"}}
+        data = {"items": [1, 2, 3]}
+        is_valid, errors = _validate_against_schema(data, schema)
+        assert is_valid
+
+        data = {"items": "not an array"}
+        is_valid, errors = _validate_against_schema(data, schema)
+        assert not is_valid
+
+    def test_type_validation_for_object(self) -> None:
+        """Object type is correctly validated."""
+        schema = {"types": {"metadata": "object"}}
+        data = {"metadata": {"key": "value"}}
+        is_valid, errors = _validate_against_schema(data, schema)
+        assert is_valid
+
+        data = {"metadata": ["not", "an", "object"]}
+        is_valid, errors = _validate_against_schema(data, schema)
+        assert not is_valid
+
+    def test_ignores_missing_optional_fields(self) -> None:
+        """Missing optional fields don't trigger type validation."""
+        schema = {"types": {"optional_field": "string"}}
+        data = {"other": "value"}
+        is_valid, errors = _validate_against_schema(data, schema)
+        assert is_valid
+
+
+class TestValidateJsonWithSchema:
+    def setup_method(self) -> None:
+        self.jk = JSONSchemaKeywords()
+
+    def test_invalid_schema_returns_zero(self) -> None:
+        """Invalid schema JSON returns 0.0."""
+        with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
+            schema = "not valid json"
+            response = '{"name": "Alice"}'
+            score = self.jk.validate_json_with_schema(response, schema)
+            assert score == 0.0
+            mock_emit.assert_any_call("schema_valid", "false")
+
+    def test_valid_schema_recorded(self) -> None:
+        """Valid schema is recorded."""
+        with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
+            schema = '{"required": ["name"]}'
+            response = '{"name": "Alice"}'
+            self.jk.validate_json_with_schema(response, schema)
+            mock_emit.assert_any_call("schema_valid", "true")
+
+    def test_parse_failure_returns_zero(self) -> None:
+        """Unparseable JSON returns 0.0."""
+        with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
+            schema = '{"required": []}'
+            response = "not json"
+            score = self.jk.validate_json_with_schema(response, schema)
+            assert score == 0.0
+            mock_emit.assert_any_call("parse_valid", "false")
+
+    def test_parse_success_recorded(self) -> None:
+        """Successful parse is recorded."""
+        with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
+            schema = '{"required": []}'
+            response = '{"name": "Alice"}'
+            self.jk.validate_json_with_schema(response, schema)
+            mock_emit.assert_any_call("parse_valid", "true")
+
+    def test_valid_json_valid_schema_scores_1_0(self) -> None:
+        """Valid JSON matching schema scores 1.0."""
+        with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
+            schema = '{"required": ["name", "age"], "types": {"name": "string", "age": "number"}}'
+            response = '{"name": "Alice", "age": 30}'
+            score = self.jk.validate_json_with_schema(response, schema)
+            assert score == 1.0
+            mock_emit.assert_any_call("validation_valid", "true")
+
+    def test_valid_json_invalid_schema_scores_0_5(self) -> None:
+        """Valid JSON but missing required fields scores 0.5."""
+        with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
+            schema = '{"required": ["name", "age"]}'
+            response = '{"name": "Alice"}'
+            score = self.jk.validate_json_with_schema(response, schema)
+            assert score == 0.5
+            mock_emit.assert_any_call("validation_valid", "false")
+
+    def test_json_in_code_fence_is_extracted(self) -> None:
+        """JSON wrapped in code fence is extracted."""
+        with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
+            schema = '{"required": ["name"]}'
+            response = '```json\n{"name": "Alice"}\n```'
+            score = self.jk.validate_json_with_schema(response, schema)
+            assert score == 1.0
+
+    def test_schema_name_recorded(self) -> None:
+        """Schema name is recorded in RFC data."""
+        with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
+            schema = '{"required": []}'
+            response = '{}'
+            self.jk.validate_json_with_schema(response, schema, schema_name="test_schema")
+            mock_emit.assert_any_call("schema_name", "test_schema")
+
+    def test_validation_errors_recorded(self) -> None:
+        """Validation errors are recorded."""
+        with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
+            schema = '{"required": ["name", "age"]}'
+            response = '{"name": "Alice"}'
+            self.jk.validate_json_with_schema(response, schema)
+            calls = [call for call in mock_emit.call_args_list
+                     if call[0][0] == "validation_errors"]
+            assert len(calls) > 0
+            assert "Missing required field: age" in calls[0][0][1]
+
+    def test_score_formatted_correctly(self) -> None:
+        """Score is formatted to 4 decimal places."""
+        with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
+            schema = '{"required": []}'
+            response = '{}'
+            score = self.jk.validate_json_with_schema(response, schema)
+            calls = [call for call in mock_emit.call_args_list
+                     if call[0][0] == "score"]
+            assert len(calls) > 0
+            assert calls[-1][0][1] == f"{score:.4f}"
+
+
+class TestValidateJsonWithRetries:
+    def setup_method(self) -> None:
+        self.jk = JSONSchemaKeywords(max_retries=3)
+
+    @patch("rfc.json_schema_keywords.JSONSchemaKeywords.validate_json_with_schema")
+    def test_returns_on_first_success(self, mock_validate: MagicMock) -> None:
+        """Returns immediately on first attempt success."""
+        mock_validate.return_value = 1.0
+        with patch.object(self.jk.client, "generate", return_value='{"data": "value"}'):
+            with patch("rfc.json_schema_keywords.emit_rfc_data"):
+                schema = '{"required": []}'
+                score, attempt = self.jk.validate_json_with_retries(
+                    "Generate JSON", schema
+                )
+                assert score == 1.0
+                assert attempt == 1
+
+    @patch("rfc.json_schema_keywords.JSONSchemaKeywords.validate_json_with_schema")
+    def test_retries_on_failure(self, mock_validate: MagicMock) -> None:
+        """Retries when validation fails."""
+        mock_validate.side_effect = [0.5, 0.5, 1.0]
+        with patch.object(self.jk.client, "generate", return_value='{"data": "value"}'):
+            with patch("rfc.json_schema_keywords.emit_rfc_data"):
+                schema = '{"required": []}'
+                score, attempt = self.jk.validate_json_with_retries(
+                    "Generate JSON", schema
+                )
+                assert score == 1.0
+                assert attempt == 3
+
+    @patch("rfc.json_schema_keywords.JSONSchemaKeywords.validate_json_with_schema")
+    def test_respects_max_retries(self, mock_validate: MagicMock) -> None:
+        """Stops retrying after max_retries attempts."""
+        mock_validate.return_value = 0.5
+        with patch.object(self.jk.client, "generate", return_value='{"data": "value"}'):
+            with patch("rfc.json_schema_keywords.emit_rfc_data"):
+                schema = '{"required": []}'
+                score, attempt = self.jk.validate_json_with_retries(
+                    "Generate JSON", schema, max_retries=2
+                )
+                assert attempt == 2
+                assert mock_validate.call_count == 2
+
+    @patch("rfc.json_schema_keywords.JSONSchemaKeywords.validate_json_with_schema")
+    def test_empty_response_skips_retry(self, mock_validate: MagicMock) -> None:
+        """Empty LLM response is skipped without validation."""
+        with patch.object(self.jk.client, "generate", return_value=""):
+            with patch("rfc.json_schema_keywords.emit_rfc_data"):
+                schema = '{"required": []}'
+                score, attempt = self.jk.validate_json_with_retries(
+                    "Generate JSON", schema
+                )
+                assert mock_validate.call_count == 0
+
+    def test_respects_custom_max_retries_parameter(self) -> None:
+        """Custom max_retries parameter overrides default."""
+        from rfc.exceptions import EmptyLLMResponseError
+        with patch.object(self.jk.client, "generate", side_effect=EmptyLLMResponseError("test-model")):
+            with patch("rfc.json_schema_keywords.emit_rfc_data"):
+                schema = '{"required": []}'
+                score, attempt = self.jk.validate_json_with_retries(
+                    "Generate JSON", schema, max_retries=2
+                )
+                assert attempt == 2
+
+    def test_emits_attempt_number(self) -> None:
+        """Attempt number is recorded in RFC data."""
+        with patch("rfc.json_schema_keywords.JSONSchemaKeywords.validate_json_with_schema", return_value=1.0):
+            with patch.object(self.jk.client, "generate", return_value='{}'):
+                with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
+                    schema = '{"required": []}'
+                    self.jk.validate_json_with_retries("Generate JSON", schema)
+                    mock_emit.assert_any_call("attempt_number", "1")
+
+    def test_emits_final_score(self) -> None:
+        """Final score is recorded in RFC data."""
+        with patch.object(self.jk, "validate_json_with_schema", return_value=0.75):
+            with patch.object(self.jk.client, "generate", return_value='{}'):
+                with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
+                    schema = '{"required": []}'
+                    self.jk.validate_json_with_retries("Generate JSON", schema)
+                    calls = [call for call in mock_emit.call_args_list
+                             if call[0][0] == "final_score"]
+                    assert len(calls) > 0
+                    assert calls[-1][0][1] == "0.7500"

--- a/tests/test_json_schema_keywords.py
+++ b/tests/test_json_schema_keywords.py
@@ -1,6 +1,5 @@
 """Tests for rfc.json_schema_keywords.JSONSchemaKeywords."""
 
-import json
 from unittest.mock import MagicMock, patch
 
 from rfc.json_schema_keywords import (
@@ -193,7 +192,7 @@ class TestValidateJsonWithSchema:
 
     def test_json_in_code_fence_is_extracted(self) -> None:
         """JSON wrapped in code fence is extracted."""
-        with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
+        with patch("rfc.json_schema_keywords.emit_rfc_data"):
             schema = '{"required": ["name"]}'
             response = '```json\n{"name": "Alice"}\n```'
             score = self.jk.validate_json_with_schema(response, schema)
@@ -203,8 +202,10 @@ class TestValidateJsonWithSchema:
         """Schema name is recorded in RFC data."""
         with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
             schema = '{"required": []}'
-            response = '{}'
-            self.jk.validate_json_with_schema(response, schema, schema_name="test_schema")
+            response = "{}"
+            self.jk.validate_json_with_schema(
+                response, schema, schema_name="test_schema"
+            )
             mock_emit.assert_any_call("schema_name", "test_schema")
 
     def test_validation_errors_recorded(self) -> None:
@@ -213,8 +214,11 @@ class TestValidateJsonWithSchema:
             schema = '{"required": ["name", "age"]}'
             response = '{"name": "Alice"}'
             self.jk.validate_json_with_schema(response, schema)
-            calls = [call for call in mock_emit.call_args_list
-                     if call[0][0] == "validation_errors"]
+            calls = [
+                call
+                for call in mock_emit.call_args_list
+                if call[0][0] == "validation_errors"
+            ]
             assert len(calls) > 0
             assert "Missing required field: age" in calls[0][0][1]
 
@@ -222,10 +226,9 @@ class TestValidateJsonWithSchema:
         """Score is formatted to 4 decimal places."""
         with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
             schema = '{"required": []}'
-            response = '{}'
+            response = "{}"
             score = self.jk.validate_json_with_schema(response, schema)
-            calls = [call for call in mock_emit.call_args_list
-                     if call[0][0] == "score"]
+            calls = [call for call in mock_emit.call_args_list if call[0][0] == "score"]
             assert len(calls) > 0
             assert calls[-1][0][1] == f"{score:.4f}"
 
@@ -287,7 +290,10 @@ class TestValidateJsonWithRetries:
     def test_respects_custom_max_retries_parameter(self) -> None:
         """Custom max_retries parameter overrides default."""
         from rfc.exceptions import EmptyLLMResponseError
-        with patch.object(self.jk.client, "generate", side_effect=EmptyLLMResponseError("test-model")):
+
+        with patch.object(
+            self.jk.client, "generate", side_effect=EmptyLLMResponseError("test-model")
+        ):
             with patch("rfc.json_schema_keywords.emit_rfc_data"):
                 schema = '{"required": []}'
                 score, attempt = self.jk.validate_json_with_retries(
@@ -297,8 +303,11 @@ class TestValidateJsonWithRetries:
 
     def test_emits_attempt_number(self) -> None:
         """Attempt number is recorded in RFC data."""
-        with patch("rfc.json_schema_keywords.JSONSchemaKeywords.validate_json_with_schema", return_value=1.0):
-            with patch.object(self.jk.client, "generate", return_value='{}'):
+        with patch(
+            "rfc.json_schema_keywords.JSONSchemaKeywords.validate_json_with_schema",
+            return_value=1.0,
+        ):
+            with patch.object(self.jk.client, "generate", return_value="{}"):
                 with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
                     schema = '{"required": []}'
                     self.jk.validate_json_with_retries("Generate JSON", schema)
@@ -307,11 +316,14 @@ class TestValidateJsonWithRetries:
     def test_emits_final_score(self) -> None:
         """Final score is recorded in RFC data."""
         with patch.object(self.jk, "validate_json_with_schema", return_value=0.75):
-            with patch.object(self.jk.client, "generate", return_value='{}'):
+            with patch.object(self.jk.client, "generate", return_value="{}"):
                 with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
                     schema = '{"required": []}'
                     self.jk.validate_json_with_retries("Generate JSON", schema)
-                    calls = [call for call in mock_emit.call_args_list
-                             if call[0][0] == "final_score"]
+                    calls = [
+                        call
+                        for call in mock_emit.call_args_list
+                        if call[0][0] == "final_score"
+                    ]
                     assert len(calls) > 0
                     assert calls[-1][0][1] == "0.7500"

--- a/tests/test_json_schema_keywords.py
+++ b/tests/test_json_schema_keywords.py
@@ -114,6 +114,14 @@ class TestValidateJsonWithSchema:
             assert score == 0.0
             mock_emit.assert_any_call("schema_valid", "false")
 
+    def test_schema_with_non_string_type_specifier_returns_zero(self) -> None:
+        with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
+            score = self.jk.validate_json_with_schema(
+                '{"name": "Alice"}', '{"types": {"age": []}}'
+            )
+            assert score == 0.0
+            mock_emit.assert_any_call("schema_valid", "false")
+
     def test_valid_schema_recorded(self) -> None:
         with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
             self.jk.validate_json_with_schema(
@@ -303,6 +311,18 @@ class TestValidateJsonWithRetries:
         ):
             score, attempt = self.jk.validate_json_with_retries(
                 "Generate JSON", '{"types": []}'
+            )
+            assert (score, attempt) == (0.0, 0)
+            assert mock_gen.call_count == 0
+
+    def test_schema_with_non_string_type_specifier_short_circuits(self) -> None:
+        """Non-string type specifiers short-circuit without LLM call."""
+        with (
+            patch.object(self.jk.client, "generate") as mock_gen,
+            patch("rfc.json_schema_keywords.emit_rfc_data"),
+        ):
+            score, attempt = self.jk.validate_json_with_retries(
+                "Generate JSON", '{"types": {"age": []}}'
             )
             assert (score, attempt) == (0.0, 0)
             assert mock_gen.call_count == 0

--- a/tests/test_json_schema_keywords.py
+++ b/tests/test_json_schema_keywords.py
@@ -309,6 +309,56 @@ class TestValidateJsonWithRetries:
             ]
             assert final_calls and final_calls[-1] == "0.7500"
 
+    def test_emits_score_when_all_attempts_skipped(self) -> None:
+        """Score is emitted even when all attempts return empty responses."""
+        with (
+            patch.object(self.jk.client, "generate", return_value=""),
+            patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit,
+        ):
+            score, attempt = self.jk.validate_json_with_retries(
+                "Generate JSON", '{"required": []}', max_retries=2
+            )
+            assert score == 0.0
+            # Verify final_score is emitted
+            final_calls = [
+                c.args[1]
+                for c in mock_emit.call_args_list
+                if c.args[0] == "final_score"
+            ]
+            assert final_calls and final_calls[-1] == "0.0000"
+
+    def test_emits_actual_answer_for_successful_attempt(self) -> None:
+        """Actual response is emitted for successful validation."""
+        with (
+            self._patched(1.0),
+            patch.object(self.jk.client, "generate", return_value='{"data": "test"}'),
+            patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit,
+        ):
+            self.jk.validate_json_with_retries("Generate JSON", '{"required": []}')
+            actual_calls = [
+                c.args[1]
+                for c in mock_emit.call_args_list
+                if c.args[0] == "actual_answer"
+            ]
+            assert actual_calls and '{"data": "test"}' in actual_calls
+
+    def test_emits_actual_answer_for_final_failed_attempt(self) -> None:
+        """Actual response is emitted even for failed validation."""
+        with (
+            self._patched(0.5),
+            patch.object(self.jk.client, "generate", return_value='{"name": "Alice"}'),
+            patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit,
+        ):
+            self.jk.validate_json_with_retries(
+                "Generate JSON", '{"required": []}', max_retries=1
+            )
+            actual_calls = [
+                c.args[1]
+                for c in mock_emit.call_args_list
+                if c.args[0] == "actual_answer"
+            ]
+            assert actual_calls and '{"name": "Alice"}' in actual_calls
+
     def test_invalid_schema_short_circuits(self) -> None:
         """An unparseable schema returns immediately without calling the LLM."""
         with (

--- a/tests/test_json_schema_keywords.py
+++ b/tests/test_json_schema_keywords.py
@@ -93,6 +93,12 @@ class TestValidateAgainstSchema:
         assert not is_valid
         assert any("unknown" in e.lower() and "integer" in e.lower() for e in errors)
 
+    def test_rejects_unknown_type_even_when_field_missing(self) -> None:
+        schema = {"types": {"age": "integer"}}
+        is_valid, errors = _validate_against_schema({}, schema)
+        assert not is_valid
+        assert any("unknown" in e.lower() and "integer" in e.lower() for e in errors)
+
 
 class TestValidateJsonWithSchema:
     def setup_method(self) -> None:

--- a/tests/test_json_schema_keywords.py
+++ b/tests/test_json_schema_keywords.py
@@ -92,6 +92,28 @@ class TestValidateJsonWithSchema:
             assert score == 0.0
             mock_emit.assert_any_call("schema_valid", "false")
 
+    def test_schema_with_types_as_list_returns_zero(self) -> None:
+        with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
+            score = self.jk.validate_json_with_schema(
+                '{"name": "Alice"}', '{"types": []}'
+            )
+            assert score == 0.0
+            mock_emit.assert_any_call("schema_valid", "false")
+
+    def test_schema_with_required_as_dict_returns_zero(self) -> None:
+        with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
+            score = self.jk.validate_json_with_schema(
+                '{"name": "Alice"}', '{"required": {}}'
+            )
+            assert score == 0.0
+            mock_emit.assert_any_call("schema_valid", "false")
+
+    def test_schema_as_array_returns_zero(self) -> None:
+        with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
+            score = self.jk.validate_json_with_schema('{"name": "Alice"}', "[]")
+            assert score == 0.0
+            mock_emit.assert_any_call("schema_valid", "false")
+
     def test_valid_schema_recorded(self) -> None:
         with patch("rfc.json_schema_keywords.emit_rfc_data") as mock_emit:
             self.jk.validate_json_with_schema(
@@ -269,6 +291,18 @@ class TestValidateJsonWithRetries:
         ):
             score, attempt = self.jk.validate_json_with_retries(
                 "Generate JSON", "not valid schema"
+            )
+            assert (score, attempt) == (0.0, 0)
+            assert mock_gen.call_count == 0
+
+    def test_schema_with_types_as_list_short_circuits(self) -> None:
+        """Structurally invalid schema (types as list) short-circuits without LLM call."""
+        with (
+            patch.object(self.jk.client, "generate") as mock_gen,
+            patch("rfc.json_schema_keywords.emit_rfc_data"),
+        ):
+            score, attempt = self.jk.validate_json_with_retries(
+                "Generate JSON", '{"types": []}'
             )
             assert (score, attempt) == (0.0, 0)
             assert mock_gen.call_count == 0

--- a/tests/test_json_schema_keywords.py
+++ b/tests/test_json_schema_keywords.py
@@ -81,6 +81,18 @@ class TestValidateAgainstSchema:
         is_valid, _ = _validate_against_schema({"other": "value"}, schema)
         assert is_valid
 
+    def test_rejects_non_string_required_field(self) -> None:
+        schema = {"required": [[]]}
+        is_valid, errors = _validate_against_schema({"x": 1}, schema)
+        assert not is_valid
+        assert any("required" in e.lower() and "string" in e.lower() for e in errors)
+
+    def test_rejects_unknown_type_specifier(self) -> None:
+        schema = {"types": {"age": "integer"}}
+        is_valid, errors = _validate_against_schema({"age": 30}, schema)
+        assert not is_valid
+        assert any("unknown" in e.lower() and "integer" in e.lower() for e in errors)
+
 
 class TestValidateJsonWithSchema:
     def setup_method(self) -> None:

--- a/tests/test_json_schema_keywords.py
+++ b/tests/test_json_schema_keywords.py
@@ -56,6 +56,12 @@ class TestValidateAgainstSchema:
         is_valid, _ = _validate_against_schema({"active": "true"}, schema)
         assert not is_valid
 
+    def test_rejects_boolean_for_number_field(self) -> None:
+        schema = {"types": {"age": "number"}}
+        is_valid, errors = _validate_against_schema({"age": True}, schema)
+        assert not is_valid
+        assert any("should be number" in e and "boolean" in e for e in errors)
+
     def test_type_validation_for_array(self) -> None:
         schema = {"types": {"items": "array"}}
         is_valid, _ = _validate_against_schema({"items": [1, 2, 3]}, schema)

--- a/tests/test_json_schema_keywords.py
+++ b/tests/test_json_schema_keywords.py
@@ -217,6 +217,10 @@ class TestValidateJsonWithSchema:
 class TestValidateJsonWithRetries:
     def setup_method(self) -> None:
         self.jk = JSONSchemaKeywords(max_retries=3)
+        # Create a mock client for testing (lazy initialization)
+        from unittest.mock import Mock
+
+        self.jk.client = Mock()
 
     def _patched(self, validate_return: float | list[float]) -> patch:
         kwarg = (


### PR DESCRIPTION
## Summary

Adds a new `JSONSchemaKeywords` Robot Framework library for validating LLM-generated JSON against lightweight schemas (required fields and field types). Includes retry-on-failure support with escalating prompts to measure parse failure rates and recovery. Complements existing LLM testing infrastructure with structured output validation.

## How to review

**Start here:** `src/rfc/json_schema_keywords.py` — the core validation logic and Robot Framework keywords.

**Key changes:**
- `src/rfc/json_schema_keywords.py`: New library with `validate_json_with_schema()` and `validate_json_with_retries()` keywords; lightweight schema validation supporting required fields and type checking
- `tests/test_json_schema_keywords.py`: Comprehensive unit tests covering schema validation, parsing, retry logic, and error handling
- `robot/json_schema/`: New test suite with 5 test cases validating JSON generation across basic profiles, arrays, nested objects, and retry scenarios
- `config/local_models.yaml` and `config/test_suites.yaml`: Registration of new test suite

**What to ignore:** Type hint additions to `browser_keywords.py` are unrelated linting fixes.

## Evidence of testing

Unit tests cover:
- Schema validation (required fields, type checking for string/number/boolean/array/object)
- JSON parsing with code fence extraction
- Retry logic with max_retries enforcement
- Early exit on invalid schema (no LLM calls)
- Empty response handling
- Metric emission (attempt number, final score, validation errors)

Robot tests validate:
- Basic profile generation (name, age, email)
- Array handling (product lists)
- Nested objects (database/server config)
- Retry escalation with 5 attempts
- Batch scenario testing

## Critical changes

None. This is a new feature addition with no impact to existing APIs or configurations.

## Checklist

- [ ] All pytest tests pass
- [ ] pre-commit passes
- [ ] code-quality-check passes (ruff + mypy)
- [ ] robot-dryrun passes
- [ ] Self-reviewed diff — no scope creep, no debug prints
- [ ] Changes comply with `ai/agents.md` contract
- [ ] Changes comply with `ai/testing.md` tier rules
- [ ] New Robot tests have `tier:*` and `verify:*` tags
- [ ] No unresolved `TODO`/`FIXME` in changed files
- [ ] Type hints on all new Python code
- [ ] Commit history is atomic and bisectable
- [ ] Version bump confirmed with user (`pyproject.toml` + `src/rfc/__init__.py`)

https://claude.ai/code/session_01SQXmj8Mv8f1hFvCAyUpyUM