### PR TITLE
fix: supply model= to OllamaClient in tests broken by silent-fallback removal

### DIFF
--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -12,7 +12,7 @@ from rfc.ollama import OllamaClient
 class TestLLMProviderProtocol:
     def test_ollama_client_satisfies_protocol(self):
         """OllamaClient structurally satisfies LLMProvider."""
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         assert isinstance(client, LLMProvider)
 
     def test_protocol_requires_generate(self):
@@ -43,12 +43,12 @@ class TestCreateProvider:
         env = os.environ.copy()
         env.pop("LLM_PROVIDER", None)
         with patch.dict(os.environ, env, clear=True):
-            client = create_provider()
+            client = create_provider(model="test-model")
             assert isinstance(client, OllamaClient)
 
     @patch.dict(os.environ, {"LLM_PROVIDER": "ollama"})
     def test_explicit_ollama(self):
-        client = create_provider()
+        client = create_provider(model="test-model")
         assert isinstance(client, OllamaClient)
 
     @patch.dict(
@@ -79,11 +79,11 @@ class TestCreateProvider:
 
     def test_explicit_provider_arg_overrides_env(self):
         with patch.dict(os.environ, {"LLM_PROVIDER": "openai"}):
-            client = create_provider(provider="ollama")
+            client = create_provider(provider="ollama", model="test-model")
             assert isinstance(client, OllamaClient)
 
     def test_kwargs_forwarded_to_ollama(self):
-        client = create_provider(provider="ollama", timeout=60, max_retries=5)
+        client = create_provider(provider="ollama", model="test-model", timeout=60, max_retries=5)
         assert isinstance(client, OllamaClient)
         assert client.timeout == 60
         assert client.max_retries == 5

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -31,26 +31,26 @@ class TestOllamaClientInit:
 
     @patch.dict(os.environ, {"OLLAMA_ENDPOINT": "http://gpu1:11434"})
     def test_default_base_url_from_env(self):
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         assert client.base_url == "http://gpu1:11434"
 
     @patch.dict(os.environ, {"OLLAMA_ENDPOINT": "http://gpu1:11434"})
     def test_explicit_base_url_overrides_env(self):
-        client = OllamaClient(base_url="http://myhost:1234")
+        client = OllamaClient(model="test-model", base_url="http://myhost:1234")
         assert client.base_url == "http://myhost:1234"
 
     @patch.dict(os.environ, {"OLLAMA_TIMEOUT": "300"})
     def test_default_timeout_from_env(self):
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         assert client.timeout == 300
 
     @patch.dict(os.environ, {"OLLAMA_TIMEOUT": "300"})
     def test_explicit_timeout_overrides_env(self):
-        client = OllamaClient(timeout=60)
+        client = OllamaClient(model="test-model", timeout=60)
         assert client.timeout == 60
 
     def test_strips_trailing_slash(self):
-        client = OllamaClient(base_url="http://example.com/")
+        client = OllamaClient(model="test-model", base_url="http://example.com/")
         assert client.base_url == "http://example.com"
 
     @patch.dict(os.environ, {"DEFAULT_MODEL": "llama3"})
@@ -65,45 +65,45 @@ class TestOllamaClientInit:
 
     def test_negative_temperature(self):
         with pytest.raises(ValueError, match="temperature must be >= 0"):
-            OllamaClient(temperature=-0.1)
+            OllamaClient(model="test-model", temperature=-0.1)
 
     def test_zero_max_tokens(self):
         with pytest.raises(ValueError, match="max_tokens must be >= 1"):
-            OllamaClient(max_tokens=0)
+            OllamaClient(model="test-model", max_tokens=0)
 
     def test_custom_timeout(self):
-        client = OllamaClient(timeout=300)
+        client = OllamaClient(model="test-model", timeout=300)
         assert client.timeout == 300
 
     def test_custom_max_retries(self):
-        client = OllamaClient(max_retries=5)
+        client = OllamaClient(model="test-model", max_retries=5)
         assert client.max_retries == 5
 
     def test_zero_timeout_rejected(self):
         with pytest.raises(ValueError, match="timeout must be >= 1"):
-            OllamaClient(timeout=0)
+            OllamaClient(model="test-model", timeout=0)
 
     def test_negative_max_retries_rejected(self):
         with pytest.raises(ValueError, match="max_retries must be >= 0"):
-            OllamaClient(max_retries=-1)
+            OllamaClient(model="test-model", max_retries=-1)
 
     def test_zero_max_retries_allowed(self):
-        client = OllamaClient(max_retries=0)
+        client = OllamaClient(model="test-model", max_retries=0)
         assert client.max_retries == 0
 
 
 class TestEndpointProperty:
     def test_get_endpoint(self):
-        client = OllamaClient(base_url="http://myhost:1234")
+        client = OllamaClient(model="test-model", base_url="http://myhost:1234")
         assert client.endpoint == "http://myhost:1234/api/generate"
 
     def test_set_endpoint_full_url(self):
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         client.endpoint = "http://newhost:5678/api/generate"
         assert client.base_url == "http://newhost:5678"
 
     def test_set_endpoint_base_only(self):
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         client.endpoint = "http://newhost:5678"
         assert client.base_url == "http://newhost:5678"
 
@@ -117,17 +117,17 @@ class TestGenerate:
         mock_resp.raise_for_status = MagicMock()
         mock_post.return_value = mock_resp
 
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         result = client.generate("test prompt")
         assert result == "hello world"
 
     def test_empty_prompt_rejected(self):
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         with pytest.raises(ValueError, match="non-empty string"):
             client.generate("")
 
     def test_non_string_prompt_rejected(self):
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         with pytest.raises(TypeError, match="prompt must be a str"):
             client.generate(123)
 
@@ -136,7 +136,7 @@ class TestGenerate:
     def test_http_error(self, mock_post, mock_logger):
         mock_post.side_effect = req_lib.HTTPError("500 Server Error")
 
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         with pytest.raises(req_lib.HTTPError):
             client.generate("prompt")
 
@@ -155,7 +155,7 @@ class TestGenerateRetry:
             mock_resp,
         ]
 
-        client = OllamaClient(max_retries=2)
+        client = OllamaClient(model="test-model", max_retries=2)
         result = client.generate("What is 6*7?")
         assert result == "42"
         assert mock_post.call_count == 2
@@ -174,7 +174,7 @@ class TestGenerateRetry:
             mock_resp,
         ]
 
-        client = OllamaClient(max_retries=2)
+        client = OllamaClient(model="test-model", max_retries=2)
         result = client.generate("test")
         assert result == "ok"
         assert mock_post.call_count == 2
@@ -185,7 +185,7 @@ class TestGenerateRetry:
     def test_exhausts_retries_then_raises(self, mock_post, mock_sleep, mock_logger):
         mock_post.side_effect = req_lib.exceptions.ReadTimeout("timed out")
 
-        client = OllamaClient(max_retries=2)
+        client = OllamaClient(model="test-model", max_retries=2)
         with pytest.raises(req_lib.exceptions.ReadTimeout):
             client.generate("test")
         # 1 initial + 2 retries = 3 total calls
@@ -197,7 +197,7 @@ class TestGenerateRetry:
     def test_no_retry_on_http_error(self, mock_post, mock_sleep, mock_logger):
         mock_post.side_effect = req_lib.exceptions.HTTPError("500 Server Error")
 
-        client = OllamaClient(max_retries=2)
+        client = OllamaClient(model="test-model", max_retries=2)
         with pytest.raises(req_lib.exceptions.HTTPError):
             client.generate("test")
         assert mock_post.call_count == 1
@@ -208,7 +208,7 @@ class TestGenerateRetry:
     def test_no_retry_when_max_retries_zero(self, mock_post, mock_logger):
         mock_post.side_effect = req_lib.exceptions.ReadTimeout("timed out")
 
-        client = OllamaClient(max_retries=0)
+        client = OllamaClient(model="test-model", max_retries=0)
         with pytest.raises(req_lib.exceptions.ReadTimeout):
             client.generate("test")
         assert mock_post.call_count == 1
@@ -219,7 +219,7 @@ class TestGenerateRetry:
     def test_exponential_backoff_timing(self, mock_post, mock_sleep, mock_logger):
         mock_post.side_effect = req_lib.exceptions.ReadTimeout("timed out")
 
-        client = OllamaClient(max_retries=2)
+        client = OllamaClient(model="test-model", max_retries=2)
         with pytest.raises(req_lib.exceptions.ReadTimeout):
             client.generate("test")
 
@@ -239,7 +239,7 @@ class TestListModels:
         mock_resp.raise_for_status = MagicMock()
         mock_get.return_value = mock_resp
 
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         models = client.list_models()
         assert "llama3" in models
         assert "mistral" in models
@@ -251,7 +251,7 @@ class TestListModels:
         mock_resp.raise_for_status = MagicMock()
         mock_get.return_value = mock_resp
 
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         assert client.list_models() == []
 
 
@@ -272,7 +272,7 @@ class TestListModelsDetailed:
         mock_resp.raise_for_status = MagicMock()
         mock_get.return_value = mock_resp
 
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         models = client.list_models_detailed()
         assert len(models) == 1
         assert models[0]["name"] == "llama3"
@@ -289,7 +289,7 @@ class TestRunningModels:
         mock_resp.raise_for_status = MagicMock()
         mock_get.return_value = mock_resp
 
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         models = client.running_models()
         assert len(models) == 1
 
@@ -300,7 +300,7 @@ class TestRunningModels:
         mock_resp.raise_for_status = MagicMock()
         mock_get.return_value = mock_resp
 
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         assert client.running_models() == []
 
 
@@ -314,7 +314,7 @@ class TestIsBusy:
         mock_resp.raise_for_status = MagicMock()
         mock_get.return_value = mock_resp
 
-        assert OllamaClient().is_busy() is True
+        assert OllamaClient(model="test-model", ).is_busy() is True
 
     @patch("rfc.ollama.requests.get")
     def test_not_busy(self, mock_get):
@@ -323,12 +323,12 @@ class TestIsBusy:
         mock_resp.raise_for_status = MagicMock()
         mock_get.return_value = mock_resp
 
-        assert OllamaClient().is_busy() is False
+        assert OllamaClient(model="test-model", ).is_busy() is False
 
     @patch("rfc.ollama.requests.get")
     def test_error_returns_false(self, mock_get):
         mock_get.side_effect = Exception("connection error")
-        assert OllamaClient().is_busy() is False
+        assert OllamaClient(model="test-model", ).is_busy() is False
 
 
 class TestIsAvailable:
@@ -338,12 +338,12 @@ class TestIsAvailable:
         mock_resp.status_code = 200
         mock_get.return_value = mock_resp
 
-        assert OllamaClient().is_available() is True
+        assert OllamaClient(model="test-model", ).is_available() is True
 
     @patch("rfc.ollama.requests.get")
     def test_unavailable(self, mock_get):
         mock_get.side_effect = Exception("connection refused")
-        assert OllamaClient().is_available() is False
+        assert OllamaClient(model="test-model", ).is_available() is False
 
 
 class TestWaitUntilReady:
@@ -356,15 +356,15 @@ class TestWaitUntilReady:
         mock_resp.raise_for_status = MagicMock()
         mock_get.return_value = mock_resp
 
-        assert OllamaClient().wait_until_ready(timeout=5) is True
+        assert OllamaClient(model="test-model", ).wait_until_ready(timeout=5) is True
 
     def test_invalid_timeout(self):
         with pytest.raises(ValueError, match="timeout must be >= 1"):
-            OllamaClient().wait_until_ready(timeout=0)
+            OllamaClient(model="test-model", ).wait_until_ready(timeout=0)
 
     def test_invalid_poll_interval(self):
         with pytest.raises(ValueError, match="poll_interval must be >= 1"):
-            OllamaClient().wait_until_ready(poll_interval=0)
+            OllamaClient(model="test-model", ).wait_until_ready(poll_interval=0)
 
     @patch("rfc.ollama.logger")
     @patch("rfc.ollama.time.sleep")
@@ -451,7 +451,7 @@ class TestGenerateMetrics:
         mock_resp.raise_for_status = MagicMock()
         mock_post.return_value = mock_resp
 
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         client.generate("test prompt")
 
         assert client.last_metrics is not None
@@ -474,7 +474,7 @@ class TestGenerateMetrics:
         mock_resp.raise_for_status = MagicMock()
         mock_post.return_value = mock_resp
 
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         client.generate("test")
 
         assert client.last_metrics is not None
@@ -493,7 +493,7 @@ class TestGenerateMetrics:
         mock_resp.raise_for_status = MagicMock()
         mock_post.return_value = mock_resp
 
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         client.generate("test")
 
         assert client.last_metrics is not None
@@ -508,7 +508,7 @@ class TestGenerateMetrics:
         mock_resp.raise_for_status = MagicMock()
         mock_post.return_value = mock_resp
 
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         client.generate("test")
 
         assert client.last_metrics is not None
@@ -527,14 +527,14 @@ class TestGenerateMetrics:
         mock_resp.raise_for_status = MagicMock()
         mock_post.return_value = mock_resp
 
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         client.generate("test")
 
         assert client.last_metrics is not None
         assert client.last_metrics["eval_rate"] is None
 
     def test_last_metrics_none_initially(self):
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         assert client.last_metrics is None
 
     @patch("rfc.ollama.logger")
@@ -554,7 +554,7 @@ class TestGenerateMetrics:
 
 class TestNewParameters:
     def test_defaults_none(self):
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         assert client.seed is None
         assert client.top_p is None
         assert client.top_k is None
@@ -562,7 +562,7 @@ class TestNewParameters:
         assert client.keep_alive is None
 
     def test_explicit_params(self):
-        client = OllamaClient(
+        client = OllamaClient(model="test-model", 
             seed=42, top_p=0.9, top_k=40, num_ctx=4096, keep_alive="5m"
         )
         assert client.seed == 42
@@ -579,7 +579,7 @@ class TestNewParameters:
         mock_resp.raise_for_status = MagicMock()
         mock_post.return_value = mock_resp
 
-        client = OllamaClient(
+        client = OllamaClient(model="test-model", 
             seed=42, top_p=0.9, top_k=40, num_ctx=4096, keep_alive="5m"
         )
         client.generate("test")
@@ -599,7 +599,7 @@ class TestNewParameters:
         mock_resp.raise_for_status = MagicMock()
         mock_post.return_value = mock_resp
 
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         client.generate("test")
 
         payload = mock_post.call_args[1]["json"]
@@ -646,7 +646,7 @@ class TestUnloadModel:
     def test_unload_failure_returns_false(self, mock_post, mock_logger):
         mock_post.side_effect = Exception("connection refused")
 
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         result = client.unload_model()
         assert result is False
 
@@ -702,7 +702,7 @@ class TestModelNotFoundError:
         mock_resp.raise_for_status.side_effect = req_lib.HTTPError("500 Server Error")
         mock_post.return_value = mock_resp
 
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         with pytest.raises(req_lib.HTTPError):
             client.generate("test")
 
@@ -786,7 +786,7 @@ class TestWaitUntilReadyUnavailable:
             65,  # loop 3: while check, elapsed — available + idle
         ]
 
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         result = client.wait_until_ready(timeout=120, poll_interval=2)
         assert result is True
 
@@ -813,7 +813,7 @@ class TestWaitUntilReadyUnavailable:
 
         mock_time.side_effect = [0, 0, 0]  # start, while check, elapsed
 
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         result = client.wait_until_ready(timeout=5, poll_interval=1)
         assert result is True
 
@@ -849,6 +849,6 @@ class TestWaitUntilReadyUnavailable:
             6,  # after while: elapsed for error message
         ]
 
-        client = OllamaClient()
+        client = OllamaClient(model="test-model")
         with pytest.raises(OllamaTimeoutError, match="still busy"):
             client.wait_until_ready(timeout=5, poll_interval=1)

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -314,7 +314,7 @@ class TestIsBusy:
         mock_resp.raise_for_status = MagicMock()
         mock_get.return_value = mock_resp
 
-        assert OllamaClient(model="test-model", ).is_busy() is True
+        assert OllamaClient(model="test-model").is_busy() is True
 
     @patch("rfc.ollama.requests.get")
     def test_not_busy(self, mock_get):
@@ -323,12 +323,12 @@ class TestIsBusy:
         mock_resp.raise_for_status = MagicMock()
         mock_get.return_value = mock_resp
 
-        assert OllamaClient(model="test-model", ).is_busy() is False
+        assert OllamaClient(model="test-model").is_busy() is False
 
     @patch("rfc.ollama.requests.get")
     def test_error_returns_false(self, mock_get):
         mock_get.side_effect = Exception("connection error")
-        assert OllamaClient(model="test-model", ).is_busy() is False
+        assert OllamaClient(model="test-model").is_busy() is False
 
 
 class TestIsAvailable:
@@ -338,12 +338,12 @@ class TestIsAvailable:
         mock_resp.status_code = 200
         mock_get.return_value = mock_resp
 
-        assert OllamaClient(model="test-model", ).is_available() is True
+        assert OllamaClient(model="test-model").is_available() is True
 
     @patch("rfc.ollama.requests.get")
     def test_unavailable(self, mock_get):
         mock_get.side_effect = Exception("connection refused")
-        assert OllamaClient(model="test-model", ).is_available() is False
+        assert OllamaClient(model="test-model").is_available() is False
 
 
 class TestWaitUntilReady:
@@ -356,15 +356,15 @@ class TestWaitUntilReady:
         mock_resp.raise_for_status = MagicMock()
         mock_get.return_value = mock_resp
 
-        assert OllamaClient(model="test-model", ).wait_until_ready(timeout=5) is True
+        assert OllamaClient(model="test-model").wait_until_ready(timeout=5) is True
 
     def test_invalid_timeout(self):
         with pytest.raises(ValueError, match="timeout must be >= 1"):
-            OllamaClient(model="test-model", ).wait_until_ready(timeout=0)
+            OllamaClient(model="test-model").wait_until_ready(timeout=0)
 
     def test_invalid_poll_interval(self):
         with pytest.raises(ValueError, match="poll_interval must be >= 1"):
-            OllamaClient(model="test-model", ).wait_until_ready(poll_interval=0)
+            OllamaClient(model="test-model").wait_until_ready(poll_interval=0)
 
     @patch("rfc.ollama.logger")
     @patch("rfc.ollama.time.sleep")

--- a/tests/test_pre_run_modifier.py
+++ b/tests/test_pre_run_modifier.py
@@ -50,7 +50,7 @@ class TestLoadModelConfig:
         config_file = tmp_path / "models.yaml"
         config_file.write_text(yaml.dump({"models": {"llama3": {"parameters": "8B"}}}))
 
-        mod = ModelAwarePreRunModifier(config_path=str(config_file))
+        mod = ModelAwarePreRunModifier(config_path=str(config_file), default_model="test-model")
         mod._load_model_config()
 
         assert "llama3" in mod.model_config
@@ -58,7 +58,7 @@ class TestLoadModelConfig:
 
     @patch("rfc.pre_run_modifier.OllamaClient")
     def test_load_missing_config(self, MockClient):
-        mod = ModelAwarePreRunModifier(config_path="/nonexistent/models.yaml")
+        mod = ModelAwarePreRunModifier(config_path="/nonexistent/models.yaml", default_model="test-model")
         mod._load_model_config()
         assert mod.model_config == {}
 
@@ -67,7 +67,7 @@ class TestLoadModelConfig:
         config_file = tmp_path / "bad.yaml"
         config_file.write_text(": invalid: yaml: [")
 
-        mod = ModelAwarePreRunModifier(config_path=str(config_file))
+        mod = ModelAwarePreRunModifier(config_path=str(config_file), default_model="test-model")
         mod._load_model_config()  # should not raise
 
 


### PR DESCRIPTION
## Summary

- The `f13678d` refactor removed the hardcoded `phi4:14b` fallback from `OllamaClient.__init__` and `ModelAwarePreRunModifier.__init__`, requiring an explicit model at construction time.
- That commit only partially updated the test suite — 61 tests across `test_ollama.py`, `test_pre_run_modifier.py`, and `test_llm_client.py` were left calling `OllamaClient()` without a `model=` arg, causing them to raise `ValueError: model must be a non-empty string` instead of exercising the behaviour they cover.
- This PR adds `model="test-model"` (or `default_model="test-model"`) to every affected call, leaving the deliberate error-path tests (`test_missing_model_raises`, `test_non_string_base_url_raises`) unchanged.

## How to review

**Start here:** The changes are purely mechanical — no logic changed. Scan for any `OllamaClient(` or `ModelAwarePreRunModifier(` call that should *not* have received `model="test-model"` (i.e., tests that intentionally test the missing-model error path).

**Key changes:**
1. `tests/test_ollama.py` — 53 call sites updated (critical: verify `test_missing_model_raises` at line 25 and `test_non_string_base_url_raises` at line 739 are untouched)
2. `tests/test_pre_run_modifier.py` — 3 call sites in `TestLoadModelConfig` updated
3. `tests/test_llm_client.py` — 5 call sites updated

**What to ignore:** The trailing-comma cleanup commit is purely cosmetic.

## Evidence of testing

<details>
<summary>uv run pytest</summary>

```
2371 passed, 1 skipped, 6 warnings in 6.97s
```

</details>

<details>
<summary>make code-quality-lint (ruff)</summary>

```
All checks passed!
```

</details>

<details>
<summary>make code-quality-typecheck (mypy)</summary>

14 pre-existing `import-untyped` errors (missing stubs for yaml, requests, docker) — unchanged from baseline before this PR.

</details>

<details>
<summary>make robot-dryrun</summary>

546 tests, 534 passed, 12 failed — same 12 pre-existing failures (browser keywords not installed in this environment), unchanged from baseline.

</details>

## Critical changes

None. Only test files modified; no production code, public APIs, or config formats changed.

## Checklist

- [x] Tests pass (`uv run pytest`)
- [x] Linter passes (`ruff check`)
- [x] No stray debug prints or commented-out code
- [x] No new files outside `tests/`
- [x] Error-path tests left intentionally untouched
- [x] Rebased onto `claude-code-staging`

https://claude.ai/code/session_01WhJwF2LCyD29Vtcb5UiwXG

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhJwF2LCyD29Vtcb5UiwXG)_