### PR TITLE
chore: wire elons-algorithm skill in as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "results"]
 	path = results
 	url = git@github.com:tkarcheski/robotframework-chat-results.git
+[submodule ".claude/skills/elons-algorithm"]
+	path = .claude/skills/elons-algorithm
+	url = git@github.com:tkarcheski/elons-algorithm.git

--- a/tests/test_backup_push.py
+++ b/tests/test_backup_push.py
@@ -36,7 +36,9 @@ def _env(backups_dir: Path, repo_url: str) -> dict[str, str]:
     }
 
 
-def _run(backups_dir: Path, repo_url: str, msg: str) -> subprocess.CompletedProcess[str]:
+def _run(
+    backups_dir: Path, repo_url: str, msg: str
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["bash", str(SCRIPT), msg],
         env=_env(backups_dir, repo_url),
@@ -61,7 +63,10 @@ def _files_on_remote_main(remote: Path, tmp_path: Path) -> list[str]:
         capture_output=True,
     )
     out = subprocess.run(
-        ["git", "-C", str(verify), "ls-files"], check=True, capture_output=True, text=True
+        ["git", "-C", str(verify), "ls-files"],
+        check=True,
+        capture_output=True,
+        text=True,
     )
     return sorted(out.stdout.split())
 
@@ -78,7 +83,9 @@ def test_clones_bare_remote_and_pushes_artifact_to_main(tmp_path: Path) -> None:
     result = _run(backups, str(remote), "chore: backup 20260527_010203")
 
     assert result.returncode == 0, result.stderr
-    assert (backups / ".git").exists(), "script should have grafted a .git into backups/"
+    assert (backups / ".git").exists(), (
+        "script should have grafted a .git into backups/"
+    )
     assert _files_on_remote_main(remote, tmp_path) == ["db_20260527_010203.sql.gz"]
 
 
@@ -118,7 +125,9 @@ def test_idempotent_when_no_new_artifacts(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize("missing", ["BACKUPS_DIR", "BACKUPS_REPO_URL"])
-def test_defaults_when_env_unset(tmp_path: Path, missing: str, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_defaults_when_env_unset(
+    tmp_path: Path, missing: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
     # When the optional env vars aren't set, the script must fall back to its
     # documented defaults rather than expanding `set -u` undefined references.
     # We don't actually push here — just confirm the script reaches the clone


### PR DESCRIPTION
## Summary

Wires the [elons-algorithm](https://github.com/tkarcheski/elons-algorithm) skill repo in as a submodule at `.claude/skills/elons-algorithm/` so Claude Code discovers it. Also includes a one-file ruff-format fix for baseline drift introduced in PR #388.

## How to review

**Start here:** `.gitmodules` — the 3-line submodule entry is the whole change.

**Key changes:**
- `.gitmodules` + `.claude/skills/elons-algorithm` gitlink (pinned to `50ce1b6`, pushed on the skill repo's `main`)
- `tests/test_backup_push.py` — mechanical ruff-format pass, no logic change

**What to ignore:** The test file diff is formatting only (`ruff format` output verbatim).

## Evidence of testing

<details>
<summary>pytest output</summary>

```
2963 passed, 1 skipped, 10 warnings in 13.81s
```
</details>

<details>
<summary>pre-commit output</summary>

```
All hooks passed (yaml, json, whitespace, merge-conflict, ruff, ruff-format, mypy, FTP block)
```
</details>

<details>
<summary>code-quality-check output</summary>

```
ruff: clean; mypy: passed
Coverage HTML written to dir htmlcov
Required test coverage of 50.0% reached. Total coverage: 88.54%
2963 passed, 1 skipped, 394 warnings in 9.11s
```
</details>

<details>
<summary>robot-dryrun output</summary>

```
DryRunListener: 636 tests, 636 passed, 0 failed
```
</details>

## Critical changes

None. No installable code touched — version bump skipped per the creating-prs policy (submodule wiring + formatting only).

## Checklist

- [x] All pytest tests pass
- [x] pre-commit passes
- [x] code-quality-check passes (ruff + mypy)
- [x] robot-dryrun passes
- [x] Self-reviewed diff — no scope creep, no debug prints
- [x] Changes comply with `ai/agents.md` contract
- [x] Changes comply with `ai/testing.md` tier rules
- [x] New Robot tests have `tier:*` and `verify:*` tags (n/a — none added)
- [x] No unresolved `TODO`/`FIXME` in changed files
- [x] Type hints on all new Python code (n/a — no new Python)
- [x] Commit history is atomic and bisectable
- [x] Version bump confirmed with user (`pyproject.toml` + `src/rfc/__init__.py`) — skipped: no installable code

🤖 Generated with [Claude Code](https://claude.com/claude-code)