### PR TITLE
docs: add Claude Code guest-pass badge to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,9 @@
 # robotframework-chat
 
+[![Try Claude Code — free guest pass](https://img.shields.io/badge/Claude%20Code-free%20guest%20pass-D97757?logo=claude&logoColor=white)](https://claude.ai/referral/4Q8ajgGjHQ)
+
+> This repo is built with [Claude Code](https://claude.com/claude-code). Grab a guest pass above to try it yourself.
+
 A Robot Framework-based test harness for systematically testing Large Language Models (LLMs) using LLMs as both the system under test and as automated graders. Test results are archived to SQL and visualized in Apache Superset dashboards.
 
 ---


### PR DESCRIPTION
## Summary

Adds a guest-pass referral badge ("Try Claude Code — free guest pass") to the top of `readme.md`, linking to Tyler's referral link, plus a one-line blurb. Requested as an "ad for /passes".

## How to review

**Start here:** `readme.md` lines 1–7 — that's the entire diff (4 added lines: badge + blurb).

**Key changes:**
- shields.io badge linking to https://claude.ai/referral/4Q8ajgGjHQ

**What to ignore:** Nothing else changed.

## Evidence of testing

<details>
<summary>pre-commit (changed file)</summary>

```
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check for merge conflicts................................................Passed
```
</details>

Docs-only change at base f3477b9 (staging baseline verified green earlier today: 2963 pytest passed, 636 robot dry-run passed). No code touched.

## Critical changes

None. Version bump skipped per creating-prs policy (pure docs).

## Checklist

- [x] All pytest tests pass (baseline unchanged — docs-only)
- [x] pre-commit passes
- [x] code-quality-check passes (no code touched)
- [x] robot-dryrun passes (no robot files touched)
- [x] Self-reviewed diff — no scope creep
- [x] Changes comply with `ai/agents.md` / `ai/testing.md` (n/a)
- [x] No unresolved `TODO`/`FIXME`
- [x] Commit history is atomic
- [x] Version bump — skipped: pure docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)