### PR TITLE
feat: llm-ignore failsafe + draft-PR babysitting policy

### DIFF
--- a/.claude/skills/triage-issues-prs/SKILL.md
+++ b/.claude/skills/triage-issues-prs/SKILL.md
@@ -27,6 +27,11 @@ The one policy every monitoring layer obeys. Repo: `tkarcheski/robotframework-ch
 These are absolute. If a situation seems to require one of these, **escalate to
 the owner instead** (see § Escalation).
 
+- **`llm-ignore` failsafe:** if an issue or PR carries the `llm-ignore` label,
+  **do not touch it in any way** — no comments, no labels, no assignment, no
+  draft PRs, no inclusion in stale nudges. List it in the report as
+  "skipped (llm-ignore)" and move on. Only a human may add or remove this label;
+  never add or remove it yourself.
 - **Never** close, merge, or reopen an issue or PR.
 - **Never** push, force-push, rebase, or delete a branch.
 - **Never** approve, request-changes, or dismiss a review on someone else's PR.
@@ -98,6 +103,35 @@ Engage when it adds real value; silence is fine. Good reasons to comment:
 
 Never comment just to look busy. A labelled, well-triaged issue with no comment
 is a perfectly good outcome.
+
+## Draft PRs — babysitting actionable issues
+
+When a sweep finds an open issue that is **clearly actionable** — unambiguous
+scope, no unanswered design questions, no `llm-ignore` label, and no open PR
+already referencing it — the agent may start the fix and open a **draft** PR:
+
+1. Branch `claude/issue-<n>-<short-desc>-<random5>` off `claude-code-staging`,
+   in an isolated worktree (never the shared checkout).
+2. Follow the normal CLAUDE.md workflow: TDD, full verification suite green,
+   atomic commits, PR template filled with real evidence.
+3. Create the PR with `--draft`, titled `<type>: <summary> (#<n>)`, body
+   linking the issue. **Never mark it ready for review and never merge it** —
+   promotion to ready is the owner's call.
+4. Comment on the issue (with the standard marker) linking the draft PR.
+5. Idempotency: one draft PR per issue, ever — if a previous draft was closed
+   without merging, treat that as the owner declining; escalate instead of
+   re-opening.
+
+Caps and limits:
+
+- At most **1 new draft PR per sweep** (the deepest action a sweep takes);
+  prefer the oldest actionable `needs-review` issue. Note deferrals in the
+  report.
+- If the fix attempt fails its own verification suite, push nothing: close the
+  loop by escalating on the issue instead (label `human-in-the-loop`, explain
+  what was tried in the report — not in a public comment).
+- Issues labelled `question`, `human-in-the-loop`, or `llm-ignore` are never
+  draft-PR candidates.
 
 ## Escalation — what goes to the owner
 

--- a/.github/workflows/claude-checkpoints.yml
+++ b/.github/workflows/claude-checkpoints.yml
@@ -53,6 +53,14 @@ jobs:
               return;
             }
 
+            // llm-ignore failsafe: automation must never touch labelled items.
+            const labels = (context.payload.issue?.labels ??
+              context.payload.pull_request?.labels ?? []).map(l => l.name);
+            if (labels.includes('llm-ignore')) {
+              core.info(`#${issue_number} is labelled llm-ignore; skipping.`);
+              return;
+            }
+
             // Idempotent: addLabels is a no-op if the label is already present.
             await github.rest.issues.addLabels({
               owner, repo, issue_number, labels: ['needs-review'],


### PR DESCRIPTION
## Summary

Activation hardening for the issue/PR monitoring system (PR #392): a repo-wide `llm-ignore` label failsafe (created on GitHub; black, "automation must never touch this") and an explicit draft-PR babysitting policy, per the owner's directive to babysit all open issues with draft PRs under a failsafe.

## How to review

**Start here:** `.claude/skills/triage-issues-prs/SKILL.md` — the new top safety rail (llm-ignore) and the new "Draft PRs — babysitting actionable issues" section.

**Key changes:**
1. SKILL.md hard rail: labelled items are untouchable by every layer; only humans set/remove the label.
2. SKILL.md draft-PR policy: ≤1 draft PR per sweep, isolated worktree, full verification suite, never ready/never merge, one-draft-per-issue idempotency.
3. `.github/workflows/claude-checkpoints.yml`: early-return when the event item carries `llm-ignore` (mirrors the skill rail at the workflow layer).

**What to ignore:** Nothing — the whole diff is 42 lines.

## Evidence of testing

<details>
<summary>pytest output</summary>

```
2963 passed, 1 skipped, 10 warnings in 6.53s
```
</details>

<details>
<summary>pre-commit output</summary>

```
All hooks passed (yaml, json, whitespace, merge-conflict, ruff, ruff-format, mypy, FTP block)
```
</details>

<details>
<summary>code-quality-check output</summary>

```
ruff: clean; mypy: passed
2963 passed, 1 skipped, 393 warnings in 8.35s
```
</details>

<details>
<summary>robot-dryrun output</summary>

```
DryRunListener: 636 tests, 636 passed, 0 failed
```
</details>

## Critical changes

- **CI behavior:** `claude-checkpoints.yml` now skips `llm-ignore` items before labelling.
- The `llm-ignore` label itself was created directly on the repo (label creation isn't versioned).
- Version bump skipped per policy: skill docs + CI workflow only, no installable code.

## Checklist

- [x] All pytest tests pass
- [x] pre-commit passes
- [x] code-quality-check passes (ruff + mypy)
- [x] robot-dryrun passes
- [x] Self-reviewed diff — no scope creep
- [x] Changes comply with `ai/agents.md` / `ai/testing.md` (n/a — no code)
- [x] No unresolved `TODO`/`FIXME`
- [x] Commit history is atomic
- [x] Version bump — skipped: docs/CI only

🤖 Generated with [Claude Code](https://claude.com/claude-code)