### PR TITLE
fix: restrict robot-tests CI job to main branch pushes (#403)

### DIFF
--- a/.github/workflows/robot-tests.yml
+++ b/.github/workflows/robot-tests.yml
@@ -69,7 +69,7 @@ jobs:
     name: Robot Tests
     runs-on: self-hosted
     needs: [lint, robot-dryrun]
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     env:
       LISTENERS: >-
         --listener rfc.db_listener.DbListener


### PR DESCRIPTION
## Summary

- Fixes #403: the `robot-tests` job was running on every `push` event (including `claude-code-staging`), triggering live suite execution (math, safety, Docker suites + DB listener writes) on the self-hosted runner for staging commits.
- Root cause: the job-level `if:` only checked `event_name`, not `ref`. The workflow-level `on: push: branches: [main, claude-code-staging]` admits both branches, so staging pushes fell through.
- Fix: add `&& github.ref == 'refs/heads/main'` to the `push` arm of the condition. `workflow_dispatch` (manual runs) is preserved.

One-line change to `.github/workflows/robot-tests.yml`:

```diff
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
```

## How to review

Single change: line 72 of `.github/workflows/robot-tests.yml`. Nothing else changed.

After this lands, the `lint` and `robot-dryrun` jobs continue firing on `claude-code-staging` pushes (they have no branch condition), but `robot-tests` will only run on `main` pushes and manual dispatches.

## Evidence of testing

**pytest**
```
2855 passed, 22 skipped, 9 warnings in 17.03s
```

**pre-commit (uvx)**
```
check yaml...........Passed
check json...........Passed
fix end of files.....Passed
trim trailing whitespace...Passed
check for merge conflicts...Passed
ruff (legacy alias)..Passed
ruff format..........Passed
mypy.................Passed
Block FTP usage......Passed
```

**robot-dryrun**
```
636 tests, 636 passed, 0 failed
```

Note: `make code-quality-check` shows 15 pre-existing mypy errors in unchanged files — same count as the base branch; this change introduces zero new errors (it only touches a YAML file).

## Critical changes

None beyond the CI condition change. No Python, no Robot tests, no schema changes.

## Checklist

- [x] All pytest tests pass
- [x] pre-commit passes (all hooks)
- [x] robot-dryrun passes (636/636)
- [x] Self-reviewed diff — single line change, no scope creep
- [x] No new Python or Robot files
- [x] No unresolved TODO/FIXME
- [x] Commit is atomic and bisectable

---
🤖 Heartbeat sweep draft — promotion to ready-for-review is the owner's call.

https://claude.ai/code/session_01P9JgK3oqp5P1t6E8XLLBjD

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9JgK3oqp5P1t6E8XLLBjD)_