### PR TITLE
fix(arc-pilot-390): commit verification.log and resolvable harness commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ venv.bak/
 # (github.com/tkarcheski/robotframework-chat-results). output.xml is LFS-tracked
 # there; heavy HTML / logs are ignored by the submodule's own .gitignore.
 *.log
+!pilots/**/*.log
 log.html
 report.html
 ci_metadata.json

--- a/pilots/arc-issue-390/pytest-dev__pytest-11148/result.json
+++ b/pilots/arc-issue-390/pytest-dev__pytest-11148/result.json
@@ -7,7 +7,10 @@
     "model": "llama3:latest",
     "model_version_or_digest": "365c0bd3c000a25d28ddbf732fe1c6add414de7275464c4e4d1c3b5fcb5d8ad1",
     "harness": "robotframework-chat SWE-bench",
-    "harness_commit": "0f1ab719884ac15b1b0c7a5609362b1bf06eb2cd"
+    "harness_commit": "9ae631d",
+    "harness_commit_published": "9ae631d",
+    "harness_commit_run_time": "0f1ab719884ac15b1b0c7a5609362b1bf06eb2cd",
+    "harness_commit_note": "harness_commit_run_time was the local branch head when the pilot ran; it was never pushed (rebased away during PR prep) and is unresolvable on GitHub. harness_commit_published points to commit 9ae631d on branch claude/arc-pilot-390-m4q7x (PR #394), which contains the harness changes used for the run (Load SWEBench Instances dataset override + verbatim prompt template)."
   },
   "artifacts": {
     "instance": "instance.json",

--- a/pilots/arc-issue-390/pytest-dev__pytest-11148/result.json
+++ b/pilots/arc-issue-390/pytest-dev__pytest-11148/result.json
@@ -7,10 +7,10 @@
     "model": "llama3:latest",
     "model_version_or_digest": "365c0bd3c000a25d28ddbf732fe1c6add414de7275464c4e4d1c3b5fcb5d8ad1",
     "harness": "robotframework-chat SWE-bench",
-    "harness_commit": "9ae631d",
-    "harness_commit_published": "9ae631d",
+    "harness_commit": "9ae631d1ec350a8b9a0667c841fb4450c0e2964d",
+    "harness_commit_published": "9ae631d1ec350a8b9a0667c841fb4450c0e2964d",
     "harness_commit_run_time": "0f1ab719884ac15b1b0c7a5609362b1bf06eb2cd",
-    "harness_commit_note": "harness_commit_run_time was the local branch head when the pilot ran; it was never pushed (rebased away during PR prep) and is unresolvable on GitHub. harness_commit_published points to commit 9ae631d on branch claude/arc-pilot-390-m4q7x (PR #394), which contains the harness changes used for the run (Load SWEBench Instances dataset override + verbatim prompt template)."
+    "harness_commit_note": "harness_commit_run_time was the local branch head when the pilot ran; it was never pushed (rebased away during PR prep) and is unresolvable on GitHub. harness_commit_published points to commit 9ae631d1ec350a8b9a0667c841fb4450c0e2964d on branch claude/arc-pilot-390-m4q7x (PR #394), which contains the harness changes used for the run (Load SWEBench Instances dataset override + verbatim prompt template)."
   },
   "artifacts": {
     "instance": "instance.json",

--- a/pilots/arc-issue-390/pytest-dev__pytest-11148/verification.log
+++ b/pilots/arc-issue-390/pytest-dev__pytest-11148/verification.log
@@ -1,0 +1,16 @@
+=== arc-pilot-390 verification.log (regenerated 2026-06-11) ===
+=== Reproduces the harness PatchResult for pytest-dev__pytest-11148 ===
+=== Note: regenerated outside Docker (daemon unavailable in regeneration env). ===
+=== The decisive failure — `git apply` rejecting an out-of-tree path — is environment-independent. ===
+
++ git rev-parse HEAD
+2f7415cfbc4b6ca62f9013f1abd27136f46b9653
+
++ git apply --allow-empty /home/user/robotframework-chat/pilots/arc-issue-390/pytest-dev__pytest-11148/test_patch.diff
+  (test patch applied cleanly, exit 0)
+
++ git apply --allow-empty /home/user/robotframework-chat/pilots/arc-issue-390/pytest-dev__pytest-11148/generated.patch
+error: pmxbot/logging.py: No such file or directory
+  (generated patch rejected, exit 1)
+
+EXIT_CODE=1   (matches harness PatchResult.exit_code=1, PatchResult.passed=false)


### PR DESCRIPTION
## Summary

Stacked on top of #394. Closes the two actionable gaps in the ARC Trust Brief on issue #390 (see https://github.com/tkarcheski/robotframework-chat/issues/390#issuecomment-4680355686):

1. **Missing `verification.log`** — `result.json` references it, but the file was absent from the PR #394 branch. Root cause: the global `*.log` ignore in `.gitignore` was silently dropping it. Fixed by scoping the ignore (`!pilots/**/*.log` exception) and committing a regenerated log.
2. **Unresolvable `harness_commit`** — `result.json` cited `0f1ab71...`, a local-only SHA that was rebased away before push. Now points to `9ae631d` (the feat commit on PR #394's branch containing the harness changes used for the run), with `harness_commit_run_time` preserved for provenance and `harness_commit_note` explaining the gap.

The third ARC question (why did the model patch `pmxbot/logging.py` when scope is `src/_pytest/pathlib.py`) is informational and answered in the issue thread: `llama3:latest` confused the issue reporter's example project (`pmxbot`) with pytest's repo — a textbook scope violation that ARC's contract-versus-diff check is meant to catch. No code change required.

## How to review

**Start here:** `pilots/arc-issue-390/pytest-dev__pytest-11148/verification.log` — the regenerated log.

**Key changes (3 files, 2 commits):**
1. `2be0a8e chore:` — `.gitignore` gains `!pilots/**/*.log` exception so artifact logs stay committed.
2. `a1f359f fix:` — commits `verification.log` and updates `result.json` with the resolvable harness commit fields.

**Honest provenance:** the log was regenerated from a non-Docker equivalent of `verification.sh` (the Docker daemon was unavailable in this regeneration env). The harness verification reduces to `git clone pytest @ base_commit → git apply test_patch.diff → git apply generated.patch`, and the decisive failure (`error: pmxbot/logging.py: No such file or directory`, exit 1) is the same in both environments because it's pure `git apply` semantics, not pytest behaviour. This matches ARC's own independent reproduction (also exit 1) and the harness `PatchResult` (`passed: false, exit_code: 1`).

## Evidence of testing

<details>
<summary>pre-commit output</summary>

```
check yaml...............................................................Passed
check json...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check for merge conflicts................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
mypy.....................................................................Passed
Block FTP usage..........................................................Passed
```

</details>

<details>
<summary>pytest, code-quality-check, robot-dryrun</summary>

All three passed (exit 0). No source code touched — only artifact files and a one-line `.gitignore` change — so behaviour is unchanged from PR #394's verification run.

</details>

<details>
<summary>verification.log regeneration (raw)</summary>

```
=== arc-pilot-390 verification.log (regenerated 2026-06-11) ===
=== Reproduces the harness PatchResult for pytest-dev__pytest-11148 ===
=== Note: regenerated outside Docker (daemon unavailable in regeneration env). ===
=== The decisive failure — `git apply` rejecting an out-of-tree path — is environment-independent. ===

+ git rev-parse HEAD
2f7415cfbc4b6ca62f9013f1abd27136f46b9653

+ git apply --allow-empty .../test_patch.diff
  (test patch applied cleanly, exit 0)

+ git apply --allow-empty .../generated.patch
error: pmxbot/logging.py: No such file or directory
  (generated patch rejected, exit 1)

EXIT_CODE=1   (matches harness PatchResult.exit_code=1, PatchResult.passed=false)
```

</details>

## Critical changes

- `.gitignore` gains a narrow `!pilots/**/*.log` exception. Non-pilot `*.log` files remain ignored.
- `result.json` schema gains optional `harness_commit_published`, `harness_commit_run_time`, `harness_commit_note` fields. `harness_commit` itself is updated to a resolvable SHA. Existing consumers reading `harness_commit` see the resolvable value; new fields are additive.

## Checklist

- [x] pre-commit passes
- [x] pytest passes (no code touched)
- [x] code-quality-check passes
- [x] robot-dryrun passes
- [x] Self-reviewed diff — scope limited to the two ARC findings
- [x] No version bump (pure evidence/artifact fix, no functional change beyond what PR #394 already ships)
- [x] Base is `claude/arc-pilot-390-m4q7x` (PR #394); when that merges, this PR's diff reduces to the three changed files

Supports #390. Stacked on #394.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZHvYMyhfQQVJ9xiXWTfKq)_