### PR TITLE
feat: dialog recording schema + in-test recorder (#354)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 COMPOSE = $(if $(_COMPOSE_CACHED),,$(eval _COMPOSE_CACHED := 1)$(eval _COMPOSE_VAL := $(shell docker compose version >/dev/null 2>&1 && echo "docker compose" || { echo "Error: Docker Compose V2 is required. Install it with: https://docs.docker.com/compose/install/" >&2; echo "false"; })))$(_COMPOSE_VAL)
 ROBOT    := uv run robot
 VERSION  := $(shell uv run python -c "from rfc import __version__; print(__version__)")
-LISTENER := --listener rfc.db_listener.DbListener --listener rfc.git_metadata_listener.GitMetaData --listener rfc.ollama_timestamp_listener.OllamaTimestampListener --listener rfc.chat_log_listener.ChatLogListener
+LISTENER := --listener rfc.db_listener.DbListener --listener rfc.git_metadata_listener.GitMetaData --listener rfc.ollama_timestamp_listener.OllamaTimestampListener --listener rfc.chat_log_listener.ChatLogListener --listener rfc.dialog_listener.DialogListener
 DRYRUN_LISTENER := --listener rfc.dry_run_listener.DryRunListener
 
 # Load .env if present

--- a/config/local_models.yaml
+++ b/config/local_models.yaml
@@ -248,6 +248,7 @@ execution:
     - "rfc.git_metadata_listener.GitMetaData"
     - "rfc.ollama_timestamp_listener.OllamaTimestampListener"
     - "rfc.agent_workflow_listener.AgentWorkflowListener"
+    - "rfc.dialog_listener.DialogListener"
   # Continue to next model even if a suite fails
   continue_on_failure: true
   # Maximum parallel model runs (1 = sequential)

--- a/config/test_suites.yaml
+++ b/config/test_suites.yaml
@@ -337,6 +337,7 @@ ci:
     - "rfc.ollama_timestamp_listener.OllamaTimestampListener"
     - "rfc.chat_log_listener.ChatLogListener"
     - "rfc.agent_workflow_listener.AgentWorkflowListener"
+    - "rfc.dialog_listener.DialogListener"
 
   # Job groups: combine multiple atomic suites into a single CI job.
   # Suites not listed here run as individual jobs.

--- a/src/rfc/dialog_listener.py
+++ b/src/rfc/dialog_listener.py
@@ -70,7 +70,10 @@ class DialogListener(BaseListener):
 
     def on_test_end(self, data: Any, result: Any) -> None:
         events = (
-            [(RECORDING_DATA_KEY, p) for p in self.get_rfc_data_history(RECORDING_DATA_KEY)]
+            [
+                (RECORDING_DATA_KEY, p)
+                for p in self.get_rfc_data_history(RECORDING_DATA_KEY)
+            ]
             + [(TURN_DATA_KEY, p) for p in self.get_rfc_data_history(TURN_DATA_KEY)]
             + [
                 (RECORDING_END_DATA_KEY, p)
@@ -134,6 +137,4 @@ class DialogListener(BaseListener):
             )
             self._persisted_turn_count += 1
         elif key == RECORDING_END_DATA_KEY:
-            db.end_recording(
-                str(payload["recording_id"]), str(payload["ended_at"])
-            )
+            db.end_recording(str(payload["recording_id"]), str(payload["ended_at"]))

--- a/src/rfc/dialog_listener.py
+++ b/src/rfc/dialog_listener.py
@@ -1,0 +1,139 @@
+"""Robot Framework listener persisting dialog recordings and turns (#354).
+
+Consumes the ``dialog_recording`` / ``dialog_turn`` /
+``dialog_recording_end`` RFC_DATA events emitted by
+:mod:`rfc.dialog_recorder` and ``Ask LLM``, and writes them through
+:class:`rfc.harness_db.HarnessDatabase` at end-of-test. Turn numbers
+are assigned in arrival order per recording and continue across tests
+within a run (UNIQUE(recording_id, turn_number)).
+
+Usage::
+
+    robot --listener rfc.dialog_listener.DialogListener tests/
+    robot --listener rfc.dialog_listener.DialogListener:database_url=<URL> tests/
+
+Environment:
+    DIALOG_DATABASE_URL  Preferred — isolates dialog rows.
+    DATABASE_URL         Fallback if DIALOG_DATABASE_URL is unset.
+
+Missing DB configuration or write failures are skip-and-log per
+CLAUDE.md; the test outcome is never affected.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, Optional
+
+from .base_listener import BaseListener
+from .harness_db import HarnessDatabase
+from .harness_models import DialogRecording, DialogTurn
+
+logger = logging.getLogger(__name__)
+
+RECORDING_DATA_KEY = "dialog_recording"
+TURN_DATA_KEY = "dialog_turn"
+RECORDING_END_DATA_KEY = "dialog_recording_end"
+
+
+class DialogListener(BaseListener):
+    """Persist dialog recordings captured via RFC_DATA at end-of-test."""
+
+    def __init__(self, database_url: Optional[str] = None) -> None:
+        super().__init__()
+        self._database_url = (
+            database_url
+            or os.getenv("DIALOG_DATABASE_URL")
+            or os.getenv("DATABASE_URL")
+        )
+        self._db: Optional[HarnessDatabase] = None
+        self._turn_counters: Dict[str, int] = {}
+        self._persisted_turn_count = 0
+
+    @property
+    def persisted_turn_count(self) -> int:
+        return self._persisted_turn_count
+
+    def _get_db(self) -> Optional[HarnessDatabase]:
+        if self._db is not None:
+            return self._db
+        if not self._database_url:
+            return None
+        try:
+            self._db = HarnessDatabase(database_url=self._database_url)
+        except Exception as exc:
+            logger.warning("HarnessDatabase init failed: %s", exc)
+            return None
+        return self._db
+
+    def on_test_end(self, data: Any, result: Any) -> None:
+        events = (
+            [(RECORDING_DATA_KEY, p) for p in self.get_rfc_data_history(RECORDING_DATA_KEY)]
+            + [(TURN_DATA_KEY, p) for p in self.get_rfc_data_history(TURN_DATA_KEY)]
+            + [
+                (RECORDING_END_DATA_KEY, p)
+                for p in self.get_rfc_data_history(RECORDING_END_DATA_KEY)
+            ]
+        )
+        if not events:
+            return
+        db = self._get_db()
+        if db is None:
+            logger.info(
+                "DialogListener: no DIALOG_DATABASE_URL/DATABASE_URL configured, "
+                "skipping persist"
+            )
+            return
+        for key, payload in events:
+            try:
+                parsed = json.loads(payload)
+            except json.JSONDecodeError as exc:
+                logger.warning("DialogListener: bad %s payload skipped: %s", key, exc)
+                continue
+            try:
+                self._dispatch(db, key, parsed)
+            except Exception as exc:  # skip-and-log: never fail the test
+                logger.warning("DialogListener: %s persist failed: %s", key, exc)
+
+    def _dispatch(self, db: HarnessDatabase, key: str, payload: Dict[str, Any]) -> None:
+        if key == RECORDING_DATA_KEY:
+            db.save_recording(
+                DialogRecording(
+                    id=str(payload["id"]),
+                    source_type=str(payload.get("source_type", "live")),
+                    started_at=str(payload["started_at"]),
+                    session_id=str(payload.get("session_id", "")),
+                    tool_name=str(payload.get("tool_name", "")),
+                    tool_version=str(payload.get("tool_version", "")),
+                    model_id=str(payload.get("model_id", "")),
+                    metadata_json=str(payload.get("metadata_json", "")),
+                )
+            )
+            self._turn_counters.setdefault(str(payload["id"]), 0)
+        elif key == TURN_DATA_KEY:
+            recording_id = str(payload["recording_id"])
+            turn_number = self._turn_counters.get(recording_id, 0) + 1
+            self._turn_counters[recording_id] = turn_number
+            db.save_turns(
+                [
+                    DialogTurn(
+                        recording_id=recording_id,
+                        turn_number=turn_number,
+                        role=str(payload["role"]),
+                        timestamp=str(payload["timestamp"]),
+                        content=str(payload.get("content", "")),
+                        tool_calls_json=str(payload.get("tool_calls_json", "")),
+                        tool_results_json=str(payload.get("tool_results_json", "")),
+                        prompt_tokens=int(payload.get("prompt_tokens", -1)),
+                        completion_tokens=int(payload.get("completion_tokens", -1)),
+                        latency_ms=float(payload.get("latency_ms", -1.0)),
+                    )
+                ]
+            )
+            self._persisted_turn_count += 1
+        elif key == RECORDING_END_DATA_KEY:
+            db.end_recording(
+                str(payload["recording_id"]), str(payload["ended_at"])
+            )

--- a/src/rfc/dialog_recorder.py
+++ b/src/rfc/dialog_recorder.py
@@ -1,0 +1,93 @@
+"""Dialog Recorder — Robot keyword library for the dialog bracket (#354).
+
+``Start Dialog Recording`` opens a recording bracket: it generates the
+recording id, exposes it via the ``RFC_DIALOG_RECORDING_ID`` env flag
+(read by ``Ask LLM`` to decide whether to emit ``dialog_turn`` events),
+and emits a ``dialog_recording`` RFC_DATA payload for the
+DialogListener to persist. ``End Dialog Recording`` closes the bracket.
+
+If an ``rfc harness`` session is active in this worktree (sidecar at
+``.git/rfc-harness-session.json``, see Issue #351), the recording is
+attached to it; otherwise ``session_id`` stays empty and the recording
+is written unattached.
+"""
+
+import json
+import os
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+from robot.api.deco import keyword
+
+from .git_metadata import _git_command
+from .rfc_data import emit_rfc_data
+
+RECORDING_ENV_VAR = "RFC_DIALOG_RECORDING_ID"
+_SIDECAR_NAME = "rfc-harness-session.json"
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(tzinfo=None).isoformat() + "Z"
+
+
+def _active_session_id() -> str:
+    """Read the active harness session from the per-worktree sidecar."""
+    git_dir = _git_command("rev-parse", "--absolute-git-dir")
+    if not git_dir:
+        return ""
+    sidecar = Path(git_dir) / _SIDECAR_NAME
+    if not sidecar.is_file():
+        return ""
+    try:
+        return str(json.loads(sidecar.read_text()).get("session_id", ""))
+    except (json.JSONDecodeError, OSError):
+        return ""
+
+
+class DialogRecorder:
+    """Robot Framework keywords bracketing a dialog recording."""
+
+    ROBOT_LIBRARY_SCOPE = "SUITE"
+
+    def __init__(self) -> None:
+        self._recording_id: str = ""
+
+    @keyword("Start Dialog Recording")
+    def start_dialog_recording(
+        self,
+        source_type: str = "live",
+        agent_id: str = "",
+        model_id: str = "",
+    ) -> str:
+        """Open a recording bracket and return the new recording id."""
+        recording_id = uuid.uuid4().hex
+        payload = {
+            "id": recording_id,
+            "session_id": _active_session_id(),
+            "source_type": source_type,
+            "tool_name": agent_id,
+            "model_id": model_id or os.environ.get("DEFAULT_MODEL", ""),
+            "started_at": _utc_now(),
+        }
+        emit_rfc_data("dialog_recording", json.dumps(payload))
+        os.environ[RECORDING_ENV_VAR] = recording_id
+        self._recording_id = recording_id
+        return recording_id
+
+    @keyword("End Dialog Recording")
+    def end_dialog_recording(self) -> str:
+        """Close the active recording bracket and return its id."""
+        recording_id = os.environ.get(RECORDING_ENV_VAR, "") or self._recording_id
+        if not recording_id:
+            raise RuntimeError(
+                "End Dialog Recording called without an active recording "
+                "(missing Start Dialog Recording bracket)."
+            )
+        emit_rfc_data(
+            "dialog_recording_end",
+            json.dumps({"recording_id": recording_id, "ended_at": _utc_now()}),
+        )
+        os.environ.pop(RECORDING_ENV_VAR, None)
+        self._recording_id = ""
+        return recording_id

--- a/src/rfc/harness_db.py
+++ b/src/rfc/harness_db.py
@@ -9,6 +9,7 @@ file even if the superset extra is not installed.
 from __future__ import annotations
 
 import abc
+import dataclasses
 import logging
 import os
 import sqlite3
@@ -1216,6 +1217,22 @@ class HarnessDatabase:
         return self._backend.get_metrics(session_id, metric_key=metric_key)
 
     def save_recording(self, recording: DialogRecording) -> str:
+        """Persist a recording, dropping a dangling ``session_id``.
+
+        With an isolated DIALOG_DATABASE_URL the parent agentic_harnesses
+        row lives in the main DB, so the FK target is absent here. Keep
+        the recording (skip-and-log per CLAUDE.md) rather than letting
+        the FK reject it and lose the dialog.
+        """
+        if recording.session_id and self.get_harness(recording.session_id) is None:
+            logger.warning(
+                "save_recording: session_id %r has no agentic_harnesses row "
+                "in this database (isolated dialog DB?); saving recording %s "
+                "without a session link.",
+                recording.session_id,
+                recording.id,
+            )
+            recording = dataclasses.replace(recording, session_id="")
         return self._backend.save_recording(recording)
 
     def end_recording(self, recording_id: str, ended_at: str) -> None:

--- a/src/rfc/harness_db.py
+++ b/src/rfc/harness_db.py
@@ -13,13 +13,15 @@ import logging
 import os
 import sqlite3
 import uuid
-from typing import Optional
+from typing import Any, Optional, Sequence
 
 from .harness_models import (
     AgenticHarness,
     AgenticMetric,
     AgenticPlugin,
     AgenticSkill,
+    DialogRecording,
+    DialogTurn,
 )
 
 logger = logging.getLogger(__name__)
@@ -92,9 +94,77 @@ CREATE TABLE IF NOT EXISTS agentic_metrics (
 CREATE INDEX IF NOT EXISTS idx_metrics_session ON agentic_metrics(session_id);
 CREATE INDEX IF NOT EXISTS idx_metrics_key     ON agentic_metrics(metric_key);
 CREATE INDEX IF NOT EXISTS idx_metrics_run     ON agentic_metrics(test_run_id);
+
+CREATE TABLE IF NOT EXISTS dialog_recordings (
+    id              TEXT PRIMARY KEY,
+    session_id      TEXT,
+    source_type     TEXT NOT NULL,
+    tool_name       TEXT,
+    tool_version    TEXT,
+    model_id        TEXT,
+    started_at      TEXT NOT NULL,
+    ended_at        TEXT,
+    metadata_json   TEXT,
+    FOREIGN KEY (session_id) REFERENCES agentic_harnesses(session_id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS dialog_turns (
+    id                  TEXT PRIMARY KEY,
+    recording_id        TEXT NOT NULL,
+    turn_number         INTEGER NOT NULL,
+    role                TEXT NOT NULL,
+    content             TEXT,
+    tool_calls_json     TEXT,
+    tool_results_json   TEXT,
+    timestamp           TEXT NOT NULL,
+    prompt_tokens       INTEGER,
+    completion_tokens   INTEGER,
+    latency_ms          REAL,
+    FOREIGN KEY (recording_id) REFERENCES dialog_recordings(id) ON DELETE CASCADE,
+    UNIQUE (recording_id, turn_number)
+);
+CREATE INDEX IF NOT EXISTS idx_dialog_turns_recording ON dialog_turns(recording_id);
 """
 
 _SQLITE_MIGRATIONS: list[str] = []  # placeholder for future column adds
+
+
+def _recording_from_row(row: "Sequence[Any]") -> DialogRecording:
+    """Map a positional (id, session_id, source_type, tool_name, tool_version,
+    model_id, started_at, ended_at, metadata_json) row to a dataclass.
+
+    Works for both sqlite3 tuples and SQLAlchemy Row objects (index-able).
+    """
+    return DialogRecording(
+        id=row[0],
+        session_id=row[1] or "",
+        source_type=row[2],
+        tool_name=row[3] or "",
+        tool_version=row[4] or "",
+        model_id=row[5] or "",
+        started_at=row[6],
+        ended_at=row[7] or "",
+        metadata_json=row[8] or "",
+    )
+
+
+def _turn_from_row(row: "Sequence[Any]") -> DialogTurn:
+    """Map a positional (id, recording_id, turn_number, role, content,
+    tool_calls_json, tool_results_json, timestamp, prompt_tokens,
+    completion_tokens, latency_ms) row to a dataclass."""
+    return DialogTurn(
+        recording_id=row[1],
+        turn_number=int(row[2]),
+        role=row[3],
+        content=row[4] or "",
+        tool_calls_json=row[5] or "",
+        tool_results_json=row[6] or "",
+        timestamp=row[7],
+        prompt_tokens=int(row[8]) if row[8] is not None else -1,
+        completion_tokens=int(row[9]) if row[9] is not None else -1,
+        latency_ms=float(row[10]) if row[10] is not None else -1.0,
+        id=row[0],
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +211,21 @@ class _HarnessBackend(abc.ABC):
     def get_metrics(
         self, session_id: str, *, metric_key: str = ""
     ) -> list[AgenticMetric]: ...
+
+    @abc.abstractmethod
+    def save_recording(self, recording: DialogRecording) -> str: ...
+
+    @abc.abstractmethod
+    def end_recording(self, recording_id: str, ended_at: str) -> None: ...
+
+    @abc.abstractmethod
+    def get_recording(self, recording_id: str) -> Optional[DialogRecording]: ...
+
+    @abc.abstractmethod
+    def save_turns(self, turns: list[DialogTurn]) -> list[str]: ...
+
+    @abc.abstractmethod
+    def get_turns(self, recording_id: str) -> list[DialogTurn]: ...
 
     @abc.abstractmethod
     def get_version(self) -> str: ...
@@ -406,6 +491,97 @@ class _SQLiteHarnessBackend(_HarnessBackend):
             for r in rows
         ]
 
+    def save_recording(self, recording: DialogRecording) -> str:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("PRAGMA foreign_keys = ON")
+            conn.execute(
+                """
+                INSERT INTO dialog_recordings
+                (id, session_id, source_type, tool_name, tool_version,
+                 model_id, started_at, ended_at, metadata_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    recording.id,
+                    recording.session_id or None,
+                    recording.source_type,
+                    recording.tool_name or None,
+                    recording.tool_version or None,
+                    recording.model_id or None,
+                    recording.started_at,
+                    recording.ended_at or None,
+                    recording.metadata_json or None,
+                ),
+            )
+        return recording.id
+
+    def end_recording(self, recording_id: str, ended_at: str) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                "UPDATE dialog_recordings SET ended_at = ? WHERE id = ?",
+                (ended_at, recording_id),
+            )
+            if cursor.rowcount == 0:
+                raise LookupError(f"no recording with id={recording_id!r}")
+
+    def get_recording(self, recording_id: str) -> Optional[DialogRecording]:
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                """
+                SELECT id, session_id, source_type, tool_name, tool_version,
+                       model_id, started_at, ended_at, metadata_json
+                FROM dialog_recordings WHERE id = ?
+                """,
+                (recording_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return _recording_from_row(row)
+
+    def save_turns(self, turns: list[DialogTurn]) -> list[str]:
+        ids: list[str] = []
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("PRAGMA foreign_keys = ON")
+            for t in turns:
+                row_id = t.id or uuid.uuid4().hex
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO dialog_turns
+                    (id, recording_id, turn_number, role, content,
+                     tool_calls_json, tool_results_json, timestamp,
+                     prompt_tokens, completion_tokens, latency_ms)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        row_id,
+                        t.recording_id,
+                        t.turn_number,
+                        t.role,
+                        t.content or None,
+                        t.tool_calls_json or None,
+                        t.tool_results_json or None,
+                        t.timestamp,
+                        t.prompt_tokens if t.prompt_tokens >= 0 else None,
+                        t.completion_tokens if t.completion_tokens >= 0 else None,
+                        t.latency_ms if t.latency_ms >= 0 else None,
+                    ),
+                )
+                ids.append(row_id)
+        return ids
+
+    def get_turns(self, recording_id: str) -> list[DialogTurn]:
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute(
+                """
+                SELECT id, recording_id, turn_number, role, content,
+                       tool_calls_json, tool_results_json, timestamp,
+                       prompt_tokens, completion_tokens, latency_ms
+                FROM dialog_turns WHERE recording_id = ? ORDER BY turn_number
+                """,
+                (recording_id,),
+            ).fetchall()
+        return [_turn_from_row(r) for r in rows]
+
     def get_version(self) -> str:
         with sqlite3.connect(self.db_path) as conn:
             return str(conn.execute("SELECT sqlite_version()").fetchone()[0])
@@ -417,6 +593,8 @@ class _SQLiteHarnessBackend(_HarnessBackend):
             "agentic_plugins",
             "agentic_skills",
             "agentic_metrics",
+            "dialog_recordings",
+            "dialog_turns",
         }:
             raise ValueError(f"unknown harness table: {table_name}")
         with sqlite3.connect(self.db_path) as conn:
@@ -533,6 +711,47 @@ class _SQLAlchemyHarnessBackend(_HarnessBackend):
             Column("metric_key", String, nullable=False),
             Column("metric_value", Float),
             Column("recorded_at", String, nullable=False),
+        )
+        self._recordings = Table(
+            "dialog_recordings",
+            self.metadata,
+            Column("id", String, primary_key=True),
+            Column(
+                "session_id",
+                String,
+                ForeignKey("agentic_harnesses.session_id", ondelete="SET NULL"),
+            ),
+            Column("source_type", String, nullable=False),
+            Column("tool_name", String),
+            Column("tool_version", String),
+            Column("model_id", String),
+            Column("started_at", String, nullable=False),
+            Column("ended_at", String),
+            Column("metadata_json", String),
+        )
+        self._turns = Table(
+            "dialog_turns",
+            self.metadata,
+            Column("id", String, primary_key=True),
+            Column(
+                "recording_id",
+                String,
+                ForeignKey("dialog_recordings.id", ondelete="CASCADE"),
+                nullable=False,
+                index=True,
+            ),
+            Column("turn_number", Integer, nullable=False),
+            Column("role", String, nullable=False),
+            Column("content", String),
+            Column("tool_calls_json", String),
+            Column("tool_results_json", String),
+            Column("timestamp", String, nullable=False),
+            Column("prompt_tokens", Integer),
+            Column("completion_tokens", Integer),
+            Column("latency_ms", Float),
+            UniqueConstraint(
+                "recording_id", "turn_number", name="uq_turns_recording_number"
+            ),
         )
         # SQLite ignores FK constraints unless PRAGMA foreign_keys=ON is set
         # on every connection. Postgres enforces FKs unconditionally.
@@ -775,6 +994,110 @@ class _SQLAlchemyHarnessBackend(_HarnessBackend):
             for r in rows
         ]
 
+    def save_recording(self, recording: DialogRecording) -> str:
+        with self.engine.begin() as conn:
+            conn.execute(
+                self._recordings.insert(),
+                {
+                    "id": recording.id,
+                    "session_id": recording.session_id or None,
+                    "source_type": recording.source_type,
+                    "tool_name": recording.tool_name or None,
+                    "tool_version": recording.tool_version or None,
+                    "model_id": recording.model_id or None,
+                    "started_at": recording.started_at,
+                    "ended_at": recording.ended_at or None,
+                    "metadata_json": recording.metadata_json or None,
+                },
+            )
+        return recording.id
+
+    def end_recording(self, recording_id: str, ended_at: str) -> None:
+        with self.engine.begin() as conn:
+            result = conn.execute(
+                self._recordings.update()
+                .where(self._recordings.c.id == recording_id)
+                .values(ended_at=ended_at)
+            )
+            if result.rowcount == 0:
+                raise LookupError(f"no recording with id={recording_id!r}")
+
+    def get_recording(self, recording_id: str) -> Optional[DialogRecording]:
+        cols = self._recordings.c
+        stmt = self._select(
+            cols.id,
+            cols.session_id,
+            cols.source_type,
+            cols.tool_name,
+            cols.tool_version,
+            cols.model_id,
+            cols.started_at,
+            cols.ended_at,
+            cols.metadata_json,
+        ).where(cols.id == recording_id)
+        with self.engine.connect() as conn:
+            row = conn.execute(stmt).fetchone()
+        if row is None:
+            return None
+        return _recording_from_row(row)
+
+    def save_turns(self, turns: list[DialogTurn]) -> list[str]:
+        ids: list[str] = []
+        with self.engine.begin() as conn:
+            for t in turns:
+                row_id = t.id or uuid.uuid4().hex
+                conn.execute(
+                    self._turns.delete().where(
+                        (self._turns.c.recording_id == t.recording_id)
+                        & (self._turns.c.turn_number == t.turn_number)
+                    )
+                )
+                conn.execute(
+                    self._turns.insert(),
+                    {
+                        "id": row_id,
+                        "recording_id": t.recording_id,
+                        "turn_number": t.turn_number,
+                        "role": t.role,
+                        "content": t.content or None,
+                        "tool_calls_json": t.tool_calls_json or None,
+                        "tool_results_json": t.tool_results_json or None,
+                        "timestamp": t.timestamp,
+                        "prompt_tokens": t.prompt_tokens
+                        if t.prompt_tokens >= 0
+                        else None,
+                        "completion_tokens": (
+                            t.completion_tokens if t.completion_tokens >= 0 else None
+                        ),
+                        "latency_ms": t.latency_ms if t.latency_ms >= 0 else None,
+                    },
+                )
+                ids.append(row_id)
+        return ids
+
+    def get_turns(self, recording_id: str) -> list[DialogTurn]:
+        cols = self._turns.c
+        stmt = (
+            self._select(
+                cols.id,
+                cols.recording_id,
+                cols.turn_number,
+                cols.role,
+                cols.content,
+                cols.tool_calls_json,
+                cols.tool_results_json,
+                cols.timestamp,
+                cols.prompt_tokens,
+                cols.completion_tokens,
+                cols.latency_ms,
+            )
+            .where(cols.recording_id == recording_id)
+            .order_by(cols.turn_number)
+        )
+        with self.engine.connect() as conn:
+            rows = conn.execute(stmt).fetchall()
+        return [_turn_from_row(r) for r in rows]
+
     def get_version(self) -> str:
         return self.engine.dialect.name
 
@@ -784,6 +1107,8 @@ class _SQLAlchemyHarnessBackend(_HarnessBackend):
             "agentic_plugins",
             "agentic_skills",
             "agentic_metrics",
+            "dialog_recordings",
+            "dialog_turns",
         }:
             raise ValueError(f"unknown harness table: {table_name}")
         table_map = {
@@ -791,6 +1116,8 @@ class _SQLAlchemyHarnessBackend(_HarnessBackend):
             "agentic_plugins": self._plugins,
             "agentic_skills": self._skills,
             "agentic_metrics": self._metrics,
+            "dialog_recordings": self._recordings,
+            "dialog_turns": self._turns,
         }
         with self.engine.connect() as conn:
             return int(
@@ -887,6 +1214,21 @@ class HarnessDatabase:
         self, session_id: str, *, metric_key: str = ""
     ) -> list[AgenticMetric]:
         return self._backend.get_metrics(session_id, metric_key=metric_key)
+
+    def save_recording(self, recording: DialogRecording) -> str:
+        return self._backend.save_recording(recording)
+
+    def end_recording(self, recording_id: str, ended_at: str) -> None:
+        self._backend.end_recording(recording_id, ended_at)
+
+    def get_recording(self, recording_id: str) -> Optional[DialogRecording]:
+        return self._backend.get_recording(recording_id)
+
+    def save_turns(self, turns: list[DialogTurn]) -> list[str]:
+        return self._backend.save_turns(turns)
+
+    def get_turns(self, recording_id: str) -> list[DialogTurn]:
+        return self._backend.get_turns(recording_id)
 
     def get_version(self) -> str:
         return self._backend.get_version()

--- a/src/rfc/harness_models.py
+++ b/src/rfc/harness_models.py
@@ -67,3 +67,35 @@ class AgenticMetric:
     test_run_id: int = -1  # -1 sentinel matches TestRun.id convention
     test_result_id: int = -1
     id: str = ""
+
+
+@dataclass
+class DialogRecording:
+    """One recorded agent dialog (Phase 2). session_id "" = unattached."""
+
+    id: str
+    source_type: str  # 'live' | 'imported'
+    started_at: str
+    session_id: str = ""  # nullable in DB: imported recordings may pre-date a session
+    tool_name: str = ""
+    tool_version: str = ""
+    model_id: str = ""
+    ended_at: str = ""
+    metadata_json: str = ""
+
+
+@dataclass
+class DialogTurn:
+    """One turn of a recording. UNIQUE(recording_id, turn_number)."""
+
+    recording_id: str
+    turn_number: int
+    role: str  # 'user' | 'assistant' | 'tool'
+    timestamp: str
+    content: str = ""
+    tool_calls_json: str = ""
+    tool_results_json: str = ""
+    prompt_tokens: int = -1  # -1 sentinel = unknown (NULL in DB)
+    completion_tokens: int = -1
+    latency_ms: float = -1.0
+    id: str = ""

--- a/src/rfc/keywords.py
+++ b/src/rfc/keywords.py
@@ -1,4 +1,6 @@
 import json
+import os
+from datetime import UTC, datetime
 from typing import Any, Dict, List, Optional, Tuple
 
 from robot.api import logger
@@ -99,7 +101,44 @@ class LLMKeywords:
                 self.client.last_metrics["num_ctx"] = self.client.num_ctx
             self.client.last_metrics["num_predict"] = self.client.max_tokens
             emit_rfc_data("llm_metrics", json.dumps(self.client.last_metrics))
+        self._emit_dialog_turns(prompt, clean_answer)
         return clean_answer
+
+    # Env flag set by rfc.dialog_recorder.DialogRecorder (kept as a literal
+    # here to avoid importing the recorder into every LLMKeywords user).
+    _DIALOG_RECORDING_ENV_VAR = "RFC_DIALOG_RECORDING_ID"
+
+    def _emit_dialog_turns(self, prompt: str, answer: str) -> None:
+        """Emit dialog_turn events when a recording bracket is active (#354)."""
+        recording_id = os.environ.get(self._DIALOG_RECORDING_ENV_VAR, "")
+        if not recording_id:
+            return
+        timestamp = datetime.now(UTC).replace(tzinfo=None).isoformat() + "Z"
+        emit_rfc_data(
+            "dialog_turn",
+            json.dumps(
+                {
+                    "recording_id": recording_id,
+                    "role": "user",
+                    "content": prompt,
+                    "timestamp": timestamp,
+                }
+            ),
+        )
+        assistant_turn: Dict[str, Any] = {
+            "recording_id": recording_id,
+            "role": "assistant",
+            "content": answer,
+            "timestamp": timestamp,
+        }
+        metrics = self.client.last_metrics or {}
+        if "prompt_eval_count" in metrics:
+            assistant_turn["prompt_tokens"] = int(metrics["prompt_eval_count"])
+        if "eval_count" in metrics:
+            assistant_turn["completion_tokens"] = int(metrics["eval_count"])
+        if "total_duration_ns" in metrics:
+            assistant_turn["latency_ms"] = float(metrics["total_duration_ns"]) / 1e6
+        emit_rfc_data("dialog_turn", json.dumps(assistant_turn))
 
     @keyword("Unload Model")
     def unload_model(self, model: Optional[str] = None) -> bool:

--- a/tasks.py
+++ b/tasks.py
@@ -32,6 +32,8 @@ LISTENERS = [
     "rfc.ollama_timestamp_listener.OllamaTimestampListener",
     "--listener",
     "rfc.chat_log_listener.ChatLogListener",
+    "--listener",
+    "rfc.dialog_listener.DialogListener",
 ]
 
 DRYRUN_LISTENER = ["--listener", "rfc.dry_run_listener.DryRunListener"]

--- a/tests/test_dialog_recorder.py
+++ b/tests/test_dialog_recorder.py
@@ -80,6 +80,45 @@ class TestDialogRecordingCrud:
     def test_get_missing_recording_returns_none(self, db):
         assert db.get_recording("nope") is None
 
+    def test_unknown_session_id_is_dropped_not_rejected(self, db, caplog):
+        """Isolated DIALOG_DATABASE_URL: the harness row lives in the main
+        DB, so the FK target is absent here — the recording must still be
+        saved (with the dangling session_id dropped), not silently lost."""
+        with caplog.at_level("WARNING"):
+            db.save_recording(_recording(session_id="no-such-harness"))
+        rec = db.get_recording("rec-1")
+        assert rec is not None
+        assert rec.session_id == ""
+        assert any("no-such-harness" in m for m in caplog.messages)
+
+
+class TestListenerRegistration:
+    """DialogListener must be wired into the runners actually in use,
+    not just the retired ci.listeners section (#409 review P1)."""
+
+    REPO_ROOT = __import__("pathlib").Path(__file__).resolve().parent.parent
+    LISTENER = "rfc.dialog_listener.DialogListener"
+
+    def test_registered_in_local_models_config(self):
+        import yaml
+
+        config = yaml.safe_load(
+            (self.REPO_ROOT / "config" / "local_models.yaml").read_text()
+        )
+        assert self.LISTENER in config["execution"]["listeners"]
+
+    def test_registered_in_makefile_listener_var(self):
+        makefile = (self.REPO_ROOT / "Makefile").read_text()
+        listener_line = next(
+            line for line in makefile.splitlines() if line.startswith("LISTENER ")
+        )
+        assert self.LISTENER in listener_line
+
+    def test_registered_in_tasks_listeners(self):
+        import tasks
+
+        assert self.LISTENER in tasks.LISTENERS
+
 
 class TestDialogTurnCrud:
     def test_turns_round_trip_in_order(self, db):
@@ -107,9 +146,7 @@ class TestDialogTurnCrud:
 
     def test_tool_call_payloads_round_trip(self, db):
         db.save_recording(_recording())
-        db.save_turns(
-            [_turn(1, role="tool", tool_calls_json='[{"name": "x"}]')]
-        )
+        db.save_turns([_turn(1, role="tool", tool_calls_json='[{"name": "x"}]')])
         assert db.get_turns("rec-1")[0].tool_calls_json == '[{"name": "x"}]'
 
 
@@ -143,9 +180,7 @@ class TestDialogRecorderKeywords:
         assert data["started_at"]
 
     @patch("rfc.dialog_recorder.emit_rfc_data")
-    def test_start_picks_up_active_harness_session(
-        self, mock_emit, recorder, tmp_path
-    ):
+    def test_start_picks_up_active_harness_session(self, mock_emit, recorder, tmp_path):
         sidecar = tmp_path / ".git" / "rfc-harness-session.json"
         sidecar.write_text(json.dumps({"session_id": "sess-9"}))
         recorder.start_dialog_recording(source_type="live", agent_id="claude-code")
@@ -251,8 +286,24 @@ class TestDialogListener:
                         "started_at": T0,
                     },
                 ),
-                ("dialog_turn", {"recording_id": "rec-1", "role": "user", "content": "q", "timestamp": T0}),
-                ("dialog_turn", {"recording_id": "rec-1", "role": "assistant", "content": "a", "timestamp": T1}),
+                (
+                    "dialog_turn",
+                    {
+                        "recording_id": "rec-1",
+                        "role": "user",
+                        "content": "q",
+                        "timestamp": T0,
+                    },
+                ),
+                (
+                    "dialog_turn",
+                    {
+                        "recording_id": "rec-1",
+                        "role": "assistant",
+                        "content": "a",
+                        "timestamp": T1,
+                    },
+                ),
                 ("dialog_recording_end", {"recording_id": "rec-1", "ended_at": T1}),
             ],
         )
@@ -261,7 +312,10 @@ class TestDialogListener:
         assert rec is not None
         assert rec.ended_at == T1
         turns = db.get_turns("rec-1")
-        assert [(t.turn_number, t.role) for t in turns] == [(1, "user"), (2, "assistant")]
+        assert [(t.turn_number, t.role) for t in turns] == [
+            (1, "user"),
+            (2, "assistant"),
+        ]
 
     def test_turn_numbering_continues_across_tests(self, tmp_path):
         url = f"sqlite:///{tmp_path / 'h.db'}"
@@ -271,14 +325,39 @@ class TestDialogListener:
             [
                 (
                     "dialog_recording",
-                    {"id": "rec-1", "session_id": "", "source_type": "live", "tool_name": "t", "model_id": "", "started_at": T0},
+                    {
+                        "id": "rec-1",
+                        "session_id": "",
+                        "source_type": "live",
+                        "tool_name": "t",
+                        "model_id": "",
+                        "started_at": T0,
+                    },
                 ),
-                ("dialog_turn", {"recording_id": "rec-1", "role": "user", "content": "q1", "timestamp": T0}),
+                (
+                    "dialog_turn",
+                    {
+                        "recording_id": "rec-1",
+                        "role": "user",
+                        "content": "q1",
+                        "timestamp": T0,
+                    },
+                ),
             ],
         )
         self._run_test_cycle(
             listener,
-            [("dialog_turn", {"recording_id": "rec-1", "role": "assistant", "content": "a1", "timestamp": T1})],
+            [
+                (
+                    "dialog_turn",
+                    {
+                        "recording_id": "rec-1",
+                        "role": "assistant",
+                        "content": "a1",
+                        "timestamp": T1,
+                    },
+                )
+            ],
         )
         db = HarnessDatabase(database_url=url)
         assert [t.turn_number for t in db.get_turns("rec-1")] == [1, 2]
@@ -289,7 +368,17 @@ class TestDialogListener:
         listener = DialogListener()
         self._run_test_cycle(
             listener,
-            [("dialog_turn", {"recording_id": "rec-1", "role": "user", "content": "q", "timestamp": T0})],
+            [
+                (
+                    "dialog_turn",
+                    {
+                        "recording_id": "rec-1",
+                        "role": "user",
+                        "content": "q",
+                        "timestamp": T0,
+                    },
+                )
+            ],
         )
         assert listener.persisted_turn_count == 0
 

--- a/tests/test_dialog_recorder.py
+++ b/tests/test_dialog_recorder.py
@@ -1,0 +1,302 @@
+"""Tests for the dialog recording stack (#354).
+
+Covers the dialog_recordings/dialog_turns schema in HarnessDatabase,
+the DialogRecorder keyword library, the RFC_DATA emission from
+``Ask LLM`` when a recording bracket is active, and the DialogListener
+that persists captured turns.
+"""
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rfc.dialog_listener import DialogListener
+from rfc.dialog_recorder import RECORDING_ENV_VAR, DialogRecorder
+from rfc.harness_db import HarnessDatabase
+from rfc.harness_models import AgenticHarness, DialogRecording, DialogTurn
+from rfc.keywords import LLMKeywords
+
+T0 = "2026-06-11T00:00:00Z"
+T1 = "2026-06-11T00:01:00Z"
+
+
+@pytest.fixture()
+def db(tmp_path):
+    return HarnessDatabase(database_url=f"sqlite:///{tmp_path / 'h.db'}")
+
+
+def _recording(**overrides) -> DialogRecording:
+    base = dict(
+        id="rec-1",
+        source_type="live",
+        started_at=T0,
+        session_id="",
+        tool_name="claude-code",
+        model_id="llama3:latest",
+    )
+    base.update(overrides)
+    return DialogRecording(**base)
+
+
+def _turn(n: int, **overrides) -> DialogTurn:
+    base = dict(
+        recording_id="rec-1",
+        turn_number=n,
+        role="user" if n % 2 else "assistant",
+        timestamp=T0,
+        content=f"turn {n}",
+    )
+    base.update(overrides)
+    return DialogTurn(**base)
+
+
+class TestDialogRecordingCrud:
+    def test_save_and_get_recording(self, db):
+        db.save_recording(_recording())
+        rec = db.get_recording("rec-1")
+        assert rec is not None
+        assert rec.source_type == "live"
+        assert rec.tool_name == "claude-code"
+        assert rec.session_id == ""
+
+    def test_session_id_round_trips_when_harness_exists(self, db):
+        db.save_harness(
+            AgenticHarness(session_id="sess-1", tool_name="claude-code", started_at=T0)
+        )
+        db.save_recording(_recording(session_id="sess-1"))
+        rec = db.get_recording("rec-1")
+        assert rec is not None
+        assert rec.session_id == "sess-1"
+
+    def test_end_recording_sets_ended_at(self, db):
+        db.save_recording(_recording())
+        db.end_recording("rec-1", T1)
+        rec = db.get_recording("rec-1")
+        assert rec is not None
+        assert rec.ended_at == T1
+
+    def test_get_missing_recording_returns_none(self, db):
+        assert db.get_recording("nope") is None
+
+
+class TestDialogTurnCrud:
+    def test_turns_round_trip_in_order(self, db):
+        db.save_recording(_recording())
+        db.save_turns([_turn(2), _turn(1), _turn(3)])
+        turns = db.get_turns("rec-1")
+        assert [t.turn_number for t in turns] == [1, 2, 3]
+        assert turns[0].role == "user"
+        assert turns[0].content == "turn 1"
+
+    def test_token_and_latency_sentinels_round_trip(self, db):
+        db.save_recording(_recording())
+        db.save_turns(
+            [
+                _turn(1, prompt_tokens=12, completion_tokens=34, latency_ms=56.7),
+                _turn(2),  # sentinels: -1 / -1 / -1.0
+            ]
+        )
+        turns = db.get_turns("rec-1")
+        assert turns[0].prompt_tokens == 12
+        assert turns[0].completion_tokens == 34
+        assert turns[0].latency_ms == 56.7
+        assert turns[1].prompt_tokens == -1
+        assert turns[1].latency_ms == -1.0
+
+    def test_tool_call_payloads_round_trip(self, db):
+        db.save_recording(_recording())
+        db.save_turns(
+            [_turn(1, role="tool", tool_calls_json='[{"name": "x"}]')]
+        )
+        assert db.get_turns("rec-1")[0].tool_calls_json == '[{"name": "x"}]'
+
+
+def _init_repo(root) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+
+
+class TestDialogRecorderKeywords:
+    @pytest.fixture()
+    def recorder(self, tmp_path, monkeypatch):
+        _init_repo(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv(RECORDING_ENV_VAR, raising=False)
+        return DialogRecorder()
+
+    @patch("rfc.dialog_recorder.emit_rfc_data")
+    def test_start_sets_env_and_emits_payload(self, mock_emit, recorder, monkeypatch):
+        recording_id = recorder.start_dialog_recording(
+            source_type="live", agent_id="claude-code"
+        )
+        import os
+
+        assert os.environ[RECORDING_ENV_VAR] == recording_id
+        key, payload = mock_emit.call_args[0]
+        assert key == "dialog_recording"
+        data = json.loads(payload)
+        assert data["id"] == recording_id
+        assert data["source_type"] == "live"
+        assert data["tool_name"] == "claude-code"
+        assert data["session_id"] == ""
+        assert data["started_at"]
+
+    @patch("rfc.dialog_recorder.emit_rfc_data")
+    def test_start_picks_up_active_harness_session(
+        self, mock_emit, recorder, tmp_path
+    ):
+        sidecar = tmp_path / ".git" / "rfc-harness-session.json"
+        sidecar.write_text(json.dumps({"session_id": "sess-9"}))
+        recorder.start_dialog_recording(source_type="live", agent_id="claude-code")
+        data = json.loads(mock_emit.call_args[0][1])
+        assert data["session_id"] == "sess-9"
+
+    @patch("rfc.dialog_recorder.emit_rfc_data")
+    def test_end_clears_env_and_emits_end(self, mock_emit, recorder):
+        import os
+
+        recording_id = recorder.start_dialog_recording(
+            source_type="live", agent_id="claude-code"
+        )
+        recorder.end_dialog_recording()
+        assert RECORDING_ENV_VAR not in os.environ
+        key, payload = mock_emit.call_args[0]
+        assert key == "dialog_recording_end"
+        data = json.loads(payload)
+        assert data["recording_id"] == recording_id
+        assert data["ended_at"]
+
+    def test_end_without_active_recording_raises(self, recorder):
+        with pytest.raises(RuntimeError):
+            recorder.end_dialog_recording()
+
+
+class TestAskLlmEmission:
+    @patch("rfc.keywords.emit_rfc_data")
+    @patch("rfc.keywords.create_provider")
+    @patch("rfc.keywords.Grader")
+    def test_ask_llm_emits_turns_when_bracket_active(
+        self, MockGrader, mock_create, mock_emit, monkeypatch
+    ):
+        monkeypatch.setenv(RECORDING_ENV_VAR, "rec-7")
+        kw = LLMKeywords()
+        kw.client.generate.return_value = "42"
+        kw.client.num_ctx = None
+        kw.client.max_tokens = 256
+        kw.client.last_metrics = {
+            "prompt_eval_count": 10,
+            "eval_count": 5,
+            "total_duration_ns": 2_000_000_000,
+        }
+        kw.ask_llm("What is 6 * 7?")
+        dialog_payloads = [
+            json.loads(c.args[1])
+            for c in mock_emit.call_args_list
+            if c.args[0] == "dialog_turn"
+        ]
+        assert [p["role"] for p in dialog_payloads] == ["user", "assistant"]
+        user, assistant = dialog_payloads
+        assert user["recording_id"] == "rec-7"
+        assert user["content"] == "What is 6 * 7?"
+        assert assistant["content"] == "42"
+        assert assistant["prompt_tokens"] == 10
+        assert assistant["completion_tokens"] == 5
+        assert assistant["latency_ms"] == 2000.0
+
+    @patch("rfc.keywords.emit_rfc_data")
+    @patch("rfc.keywords.create_provider")
+    @patch("rfc.keywords.Grader")
+    def test_ask_llm_emits_no_turns_without_bracket(
+        self, MockGrader, mock_create, mock_emit, monkeypatch
+    ):
+        monkeypatch.delenv(RECORDING_ENV_VAR, raising=False)
+        kw = LLMKeywords()
+        kw.client.generate.return_value = "42"
+        kw.client.last_metrics = None
+        kw.ask_llm("What is 6 * 7?")
+        assert not [c for c in mock_emit.call_args_list if c.args[0] == "dialog_turn"]
+
+
+class _FakeMessage:
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+
+def _feed(listener: DialogListener, key: str, payload: dict) -> None:
+    listener.log_message(_FakeMessage(f"RFC_DATA:{key}:{json.dumps(payload)}"))
+
+
+class TestDialogListener:
+    def _run_test_cycle(self, listener: DialogListener, events) -> None:
+        listener.start_test(MagicMock(), MagicMock())
+        for key, payload in events:
+            _feed(listener, key, payload)
+        listener.end_test(MagicMock(), MagicMock())
+
+    def test_persists_recording_and_numbered_turns(self, tmp_path):
+        url = f"sqlite:///{tmp_path / 'h.db'}"
+        listener = DialogListener(database_url=url)
+        self._run_test_cycle(
+            listener,
+            [
+                (
+                    "dialog_recording",
+                    {
+                        "id": "rec-1",
+                        "session_id": "",
+                        "source_type": "live",
+                        "tool_name": "claude-code",
+                        "model_id": "llama3",
+                        "started_at": T0,
+                    },
+                ),
+                ("dialog_turn", {"recording_id": "rec-1", "role": "user", "content": "q", "timestamp": T0}),
+                ("dialog_turn", {"recording_id": "rec-1", "role": "assistant", "content": "a", "timestamp": T1}),
+                ("dialog_recording_end", {"recording_id": "rec-1", "ended_at": T1}),
+            ],
+        )
+        db = HarnessDatabase(database_url=url)
+        rec = db.get_recording("rec-1")
+        assert rec is not None
+        assert rec.ended_at == T1
+        turns = db.get_turns("rec-1")
+        assert [(t.turn_number, t.role) for t in turns] == [(1, "user"), (2, "assistant")]
+
+    def test_turn_numbering_continues_across_tests(self, tmp_path):
+        url = f"sqlite:///{tmp_path / 'h.db'}"
+        listener = DialogListener(database_url=url)
+        self._run_test_cycle(
+            listener,
+            [
+                (
+                    "dialog_recording",
+                    {"id": "rec-1", "session_id": "", "source_type": "live", "tool_name": "t", "model_id": "", "started_at": T0},
+                ),
+                ("dialog_turn", {"recording_id": "rec-1", "role": "user", "content": "q1", "timestamp": T0}),
+            ],
+        )
+        self._run_test_cycle(
+            listener,
+            [("dialog_turn", {"recording_id": "rec-1", "role": "assistant", "content": "a1", "timestamp": T1})],
+        )
+        db = HarnessDatabase(database_url=url)
+        assert [t.turn_number for t in db.get_turns("rec-1")] == [1, 2]
+
+    def test_no_database_url_skips_quietly(self, monkeypatch):
+        monkeypatch.delenv("DIALOG_DATABASE_URL", raising=False)
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        listener = DialogListener()
+        self._run_test_cycle(
+            listener,
+            [("dialog_turn", {"recording_id": "rec-1", "role": "user", "content": "q", "timestamp": T0})],
+        )
+        assert listener.persisted_turn_count == 0
+
+    def test_malformed_payload_is_skipped(self, tmp_path):
+        url = f"sqlite:///{tmp_path / 'h.db'}"
+        listener = DialogListener(database_url=url)
+        listener.start_test(MagicMock(), MagicMock())
+        listener.log_message(_FakeMessage("RFC_DATA:dialog_turn:{not json"))
+        listener.end_test(MagicMock(), MagicMock())
+        assert listener.persisted_turn_count == 0


### PR DESCRIPTION
## Summary

Implements Agentic Stack Tracker Issue 5 (#354): the `dialog_recordings`/`dialog_turns` schema in `HarnessDatabase`, the `Dialog Recorder` Robot keyword library (`Start Dialog Recording` / `End Dialog Recording`), `Ask LLM` emitting `RFC_DATA:dialog_turn:<json>` while a recording bracket is active, and a `DialogListener` that persists captured turns at end-of-test.

Closes #354.

## How to review

**Start here:** `src/rfc/dialog_listener.py` — the event consumption, per-recording turn numbering, and skip-and-log behaviour.

**Key changes:**
- `src/rfc/harness_db.py` + `src/rfc/harness_models.py` — the two tables exactly per the SQL in the issue body (nullable `session_id` with ON DELETE SET NULL, `UNIQUE(recording_id, turn_number)`, CASCADE on turns), in both SQLite and SQLAlchemy backends; `-1` sentinels for unknown tokens/latency per the no-Optional dataclass rule
- `src/rfc/dialog_recorder.py` — bracket keywords; the bracket is the `RFC_DIALOG_RECORDING_ID` env flag; attaches to the active `rfc harness` session via the `.git/rfc-harness-session.json` sidecar when present (graceful "" when not — works independently of PR #408)
- `src/rfc/keywords.py` — `Ask LLM` emits a user+assistant `dialog_turn` pair only when the bracket is active; tokens/latency mapped from `last_metrics` (`prompt_eval_count`/`eval_count`/`total_duration_ns`)
- `config/test_suites.yaml` — `DialogListener` registered in the CI listeners list
- `tests/test_dialog_recorder.py` — 17 tests written failing-first: CRUD round-trips, sentinel handling, bracket env semantics, sidecar session pickup, emission on/off, listener turn numbering across tests, no-DB skip, malformed-payload skip

**What to ignore:** the version bump commit is mechanical.

## Evidence of testing

<details>
<summary>pytest output</summary>

```
2985 passed, 1 skipped, 10 warnings in 9.16s
```
</details>

<details>
<summary>pre-commit output</summary>

```
all hooks Passed (check yaml/json, eol, whitespace, merge conflicts,
ruff, ruff format, mypy, Block FTP usage)
```
</details>

<details>
<summary>code-quality-check output</summary>

```
Success: no issues found in 105 source files
Required test coverage of 50.0% reached. Total coverage: 88.32%
2985 passed, 1 skipped, 406 warnings in 14.10s
```
</details>

<details>
<summary>robot-dryrun output</summary>

```
636 tests, 636 passed, 0 failed
```
</details>

## Critical changes

- **Database schema:** two new tables (`dialog_recordings`, `dialog_turns`) created via `CREATE TABLE IF NOT EXISTS` / `metadata.create_all` — additive, no migrations of existing tables.
- New public Robot keywords `Start Dialog Recording` / `End Dialog Recording`; new listener registered in CI config.
- Version bump 1.11.7 → 1.12.0 (minor). Sibling tracker PR #408 carries the same bump; whoever merges second rebases.

## Checklist

- [x] All pytest tests pass
- [x] pre-commit passes
- [x] code-quality-check passes (ruff + mypy)
- [x] robot-dryrun passes
- [x] Self-reviewed diff — no scope creep, no debug prints
- [x] Changes comply with `ai/agents.md` contract
- [x] Changes comply with `ai/testing.md` tier rules
- [x] New Robot tests have `tier:*` and `verify:*` tags (n/a — no new Robot suites; keywords only)
- [x] No unresolved `TODO`/`FIXME` in changed files
- [x] Type hints on all new Python code
- [x] Commit history is atomic and bisectable
- [ ] Version bump confirmed with user (`pyproject.toml` + `src/rfc/__init__.py`) — assumed minor per policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)