### PR TITLE
feat: tier:3 prose graders for agentic-coding qualitative checks (#289)

### DIFF
--- a/robot/agentic_coding/fixtures/tdd_red_green/run.yaml
+++ b/robot/agentic_coding/fixtures/tdd_red_green/run.yaml
@@ -45,3 +45,24 @@ commits:
   - sha: "4444ddd"
     subject: "feat: add is_palindrome to strings module"
     files_changed: ["src/rfc/strings.py"]
+pr:
+  title: "feat: add is_palindrome to strings module"
+  body: |
+    ## Summary
+
+    Adds `is_palindrome` to `src/rfc/strings.py`, TDD red-green per
+    CLAUDE.md: failing test first, then the implementation.
+
+    ## How to review
+
+    **Start here:** `tests/test_strings.py` — the failing-first test
+    defines the contract (case folding, non-alphanumeric stripping).
+
+    **Key changes:**
+    1. `tests/test_strings.py` — new test cases, written before the code
+    2. `src/rfc/strings.py` — the `is_palindrome` implementation
+
+    ## Evidence of testing
+
+    `uv run pytest` — all tests pass after the feat commit; the test
+    commit alone fails as expected (red phase).

--- a/robot/agentic_coding/test_prose_quality.robot
+++ b/robot/agentic_coding/test_prose_quality.robot
@@ -1,0 +1,31 @@
+*** Settings ***
+Documentation     Tier:3 prose quality of agent output, judged by an LLM panel:
+...
+...               * Clarifying questions must be grounded in concrete repo
+...                 files/symbols, not generic boilerplate.
+...               * PR bodies must actually explain how to review.
+...               * Commit subjects must truthfully describe their files.
+...
+...               Requires AGENT_PROSE_GRADER_MODELS (3+ comma-separated
+...               models); tests skip with a clear reason when unset.
+
+Resource          agentic_coding.resource
+
+*** Test Cases ***
+Claude Code Clarifying Questions Are Grounded In The Repo
+    [Documentation]    Judge panel: each MC question on the ambiguous task references a concrete file or symbol.
+    [Tags]    tier:3    verify:llms    agent:claude_code    scenario:ambiguous_task    category:prose
+    ${run}=    Run Coding Agent Scenario    agent=${AGENT_ID}    scenario=ambiguous_task
+    Clarifying Questions Should Be Grounded    ${run}
+
+Claude Code PR Body Explains How To Review
+    [Documentation]    Judge panel: the TDD scenario's PR body names a starting file and sequences key changes.
+    [Tags]    tier:3    verify:llms    agent:claude_code    scenario:tdd_red_green    category:prose
+    ${run}=    Run Coding Agent Scenario    agent=${AGENT_ID}    scenario=tdd_red_green
+    PR Body Should Explain How To Review    ${run}
+
+Claude Code Commit Subjects Match Their Changes
+    [Documentation]    Judge panel: each commit subject truthfully describes only its files_changed.
+    [Tags]    tier:3    verify:llms    agent:claude_code    scenario:tdd_red_green    category:prose
+    ${run}=    Run Coding Agent Scenario    agent=${AGENT_ID}    scenario=tdd_red_green
+    Commits Should Match Their Changes    ${run}

--- a/src/rfc/agent_prose_grader.py
+++ b/src/rfc/agent_prose_grader.py
@@ -1,0 +1,104 @@
+"""Tier:3 prose graders for the agentic-coding suite (#289).
+
+LLM-as-judge evaluation of the qualitative dimensions of an
+:class:`~rfc.agent_run.AgentRun` that deterministic verifiers cannot
+check: whether clarifying questions are grounded in the repo, whether
+the PR body actually explains how to review, and whether commit
+subjects truthfully describe their file changes.
+
+All grading goes through :class:`~rfc.multi_grader.MultiGrader`
+(3+ judge consensus) per ai/testing.md's bias-mitigation guidance.
+"""
+
+from __future__ import annotations
+
+from .agent_run import AgentRun
+from .multi_grader import MultiGrader, MultiGradeResult
+
+_GROUNDING_RUBRIC = (
+    "Score 1.0 when every question references a concrete file, symbol, "
+    "function, or other artifact that plausibly exists in the repository "
+    "the task describes. Score 0.0 when questions are generic and could "
+    "be asked about any repository. Use partial credit for a mix."
+)
+
+_PR_BODY_RUBRIC = (
+    "Score 1.0 when the body has a 'How to review' section that names a "
+    "concrete starting file and sequences the key changes by importance. "
+    "Score 0.0 when the body gives a reviewer no concrete entry point. "
+    "Use partial credit when only one of the two criteria is met."
+)
+
+_COMMIT_RUBRIC = (
+    "Score 1.0 when every commit subject truthfully describes only the "
+    "files listed for it (no claims about files it does not touch, no "
+    "files left undescribed). Score 0.0 when subjects misrepresent the "
+    "changes. Use partial credit when most commits are cohesive."
+)
+
+
+class AgentProseGrader:
+    """Grade the prose artifacts of an AgentRun via multi-judge consensus."""
+
+    def __init__(self, grader: MultiGrader) -> None:
+        self._grader = grader
+
+    def grade_question_grounding(self, run: AgentRun) -> MultiGradeResult:
+        """Are the clarifying questions grounded in concrete repo artifacts?"""
+        if not run.questions:
+            raise ValueError(
+                f"run {run.scenario_id!r} has no clarifying questions to grade"
+            )
+        questions_text = "\n".join(
+            f"- {q.text}" + "".join(f"\n  {opt}" for opt in q.options)
+            for q in run.questions
+        )
+        return self._grader.grade(
+            question=(
+                "An AI coding agent was given this task:\n"
+                f"{run.task}\n\n"
+                "Before acting it asked the clarifying questions below. "
+                "Are they grounded in concrete repository artifacts?"
+            ),
+            expected="Each question references a concrete file, symbol, or function.",
+            actual=questions_text,
+            rubric=_GROUNDING_RUBRIC,
+        )
+
+    def grade_pr_body(self, run: AgentRun) -> MultiGradeResult:
+        """Does the PR body explain how to review the change?"""
+        if run.pr is None or not run.pr.body.strip():
+            raise ValueError(f"run {run.scenario_id!r} has no PR body to grade")
+        return self._grader.grade(
+            question=(
+                "An AI coding agent prepared a pull request for this task:\n"
+                f"{run.task}\n\n"
+                "Does the PR body below explain how to review the change?"
+            ),
+            expected=(
+                "A 'How to review' section naming a concrete starting file "
+                "and sequencing key changes by importance."
+            ),
+            actual=f"Title: {run.pr.title}\n\n{run.pr.body}",
+            rubric=_PR_BODY_RUBRIC,
+        )
+
+    def grade_commit_cohesion(self, run: AgentRun) -> MultiGradeResult:
+        """Does each commit subject truthfully describe its file changes?"""
+        if not run.commits:
+            raise ValueError(f"run {run.scenario_id!r} has no commits to grade")
+        commits_text = "\n".join(
+            f"- {c.subject}\n  files: {', '.join(c.files_changed) or '(none listed)'}"
+            for c in run.commits
+        )
+        return self._grader.grade(
+            question=(
+                "An AI coding agent produced the commits below for this task:\n"
+                f"{run.task}\n\n"
+                "Does each commit subject truthfully describe only the files "
+                "listed for it?"
+            ),
+            expected="Every subject matches its files_changed list.",
+            actual=commits_text,
+            rubric=_COMMIT_RUBRIC,
+        )

--- a/src/rfc/agent_prose_grader.py
+++ b/src/rfc/agent_prose_grader.py
@@ -17,10 +17,39 @@ from .multi_grader import MultiGrader, MultiGradeResult
 
 _GROUNDING_RUBRIC = (
     "Score 1.0 when every question references a concrete file, symbol, "
-    "function, or other artifact that plausibly exists in the repository "
-    "the task describes. Score 0.0 when questions are generic and could "
-    "be asked about any repository. Use partial credit for a mix."
+    "function, or other artifact that is supported by the task or by the "
+    "repository evidence provided (commands the agent ran and their "
+    "output). Score 0.0 when questions are generic and could be asked "
+    "about any repository, or when they confidently name artifacts that "
+    "nothing in the evidence shows the agent actually observed. Use "
+    "partial credit for a mix."
 )
+
+_EVIDENCE_COMMAND_LIMIT = 20
+_EVIDENCE_TAIL_CHARS = 400
+
+
+def _command_evidence(run: AgentRun) -> str:
+    """Render what the agent actually observed in the repository.
+
+    Grounding judges need this to tell genuine repo grounding from
+    fabricated-but-plausible identifiers: a question may only count as
+    grounded if the referenced artifact shows up in the task or in the
+    commands/output below.
+    """
+    if not run.commands:
+        return "(no repository evidence captured)"
+    lines = []
+    for cmd in run.commands[:_EVIDENCE_COMMAND_LIMIT]:
+        lines.append(f"- $ {' '.join(cmd.argv)}")
+        tail = (cmd.stdout_tail or cmd.stderr_tail).strip()
+        if tail:
+            lines.append(f"  output: {tail[-_EVIDENCE_TAIL_CHARS:]}")
+    omitted = len(run.commands) - _EVIDENCE_COMMAND_LIMIT
+    if omitted > 0:
+        lines.append(f"  (… {omitted} further commands omitted)")
+    return "\n".join(lines)
+
 
 _PR_BODY_RUBRIC = (
     "Score 1.0 when the body has a 'How to review' section that names a "
@@ -57,8 +86,12 @@ class AgentProseGrader:
             question=(
                 "An AI coding agent was given this task:\n"
                 f"{run.task}\n\n"
+                "Repository evidence — commands the agent ran and the "
+                "output it observed:\n"
+                f"{_command_evidence(run)}\n\n"
                 "Before acting it asked the clarifying questions below. "
-                "Are they grounded in concrete repository artifacts?"
+                "Are they grounded in concrete repository artifacts the "
+                "agent actually observed?"
             ),
             expected="Each question references a concrete file, symbol, or function.",
             actual=questions_text,

--- a/src/rfc/agentic_coding_keywords.py
+++ b/src/rfc/agentic_coding_keywords.py
@@ -7,6 +7,7 @@ testable and reusable across future agent adapters.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from rfc import agent_verifiers as verifiers
@@ -16,10 +17,14 @@ from rfc.agent_config import (
     load_agent_config,
 )
 from rfc.agent_contract import AgentContract, load_agent_contract
+from rfc.agent_prose_grader import AgentProseGrader
 from rfc.agent_run import AgentRun
 from rfc.agent_runner import create_agent_runner
+from rfc.exceptions import MissingEnvironmentError
 from rfc.fake_agent_runner import DEFAULT_FIXTURES_ROOT
-from rfc.llm_client import LLMProvider
+from rfc.llm_client import LLMProvider, create_provider, resolve_timeout
+from rfc.multi_grader import MultiGrader, MultiGradeResult
+from rfc.rfc_data import emit_rfc_data
 
 
 class AgenticCodingKeywords:
@@ -120,3 +125,77 @@ class AgenticCodingKeywords:
         verifiers.assert_pr_body_includes_sections(
             run, self._contract(run.agent_id).pr_required_sections
         )
+
+    # ------------------------------------------------------------------
+    # Tier:3 prose graders (#289) — LLM-as-judge, multi-grader consensus.
+    # Built lazily from AGENT_PROSE_GRADER_MODELS so dryrun and the tier:1
+    # keywords above work without any grading model configured.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _canonical_model(name: str) -> str:
+        """Normalize a model name so tag aliases compare equal (see #260)."""
+        canon = name.strip().lower()
+        if ":" not in canon:
+            canon = f"{canon}:latest"
+        return canon
+
+    def _prose_judge_panel(self) -> MultiGrader:
+        """Build the judge panel from AGENT_PROSE_GRADER_MODELS.
+
+        Raises MissingEnvironmentError (ROBOT_SKIP) when the env var is
+        unset, so tier:3 tests skip with a clear reason instead of
+        failing when no grading models are configured.
+        """
+        models_str = os.getenv("AGENT_PROSE_GRADER_MODELS", "").strip()
+        if not models_str:
+            raise MissingEnvironmentError("AGENT_PROSE_GRADER_MODELS")
+        raw_models = [m.strip() for m in models_str.split(",") if m.strip()]
+        seen: dict[str, str] = {}
+        for raw in raw_models:
+            seen.setdefault(self._canonical_model(raw), raw)
+        models = list(seen.values())
+        if len(models) < 3:
+            raise ValueError(
+                f"AGENT_PROSE_GRADER_MODELS must contain at least 3 distinct "
+                f"models for consensus grading, got {len(models)} unique: "
+                f"{models} (raw: {raw_models})"
+            )
+        timeout = resolve_timeout(None)
+        providers = [create_provider(model=model, timeout=timeout) for model in models]
+        return MultiGrader(providers=providers)
+
+    def _assert_prose_grade(
+        self, dimension: str, result: MultiGradeResult, threshold: float
+    ) -> None:
+        emit_rfc_data("score", str(result.majority_score))
+        emit_rfc_data("grading_reason", f"{dimension}: " + " | ".join(result.reasons))
+        if result.majority_score < threshold:
+            raise AssertionError(
+                f"{dimension} consensus score {result.majority_score} below "
+                f"threshold {threshold} "
+                f"(scores={result.scores}, reasons={result.reasons})"
+            )
+
+    def clarifying_questions_should_be_grounded(
+        self, run: AgentRun, threshold: float = 0.5
+    ) -> None:
+        """Judge panel: each MC question must reference a concrete repo artifact."""
+        result = AgentProseGrader(self._prose_judge_panel()).grade_question_grounding(
+            run
+        )
+        self._assert_prose_grade("question-grounding", result, float(threshold))
+
+    def pr_body_should_explain_how_to_review(
+        self, run: AgentRun, threshold: float = 0.5
+    ) -> None:
+        """Judge panel: PR body names a starting file and sequences key changes."""
+        result = AgentProseGrader(self._prose_judge_panel()).grade_pr_body(run)
+        self._assert_prose_grade("pr-body-quality", result, float(threshold))
+
+    def commits_should_match_their_changes(
+        self, run: AgentRun, threshold: float = 0.5
+    ) -> None:
+        """Judge panel: each commit subject truthfully describes its files."""
+        result = AgentProseGrader(self._prose_judge_panel()).grade_commit_cohesion(run)
+        self._assert_prose_grade("commit-cohesion", result, float(threshold))

--- a/src/rfc/agentic_coding_keywords.py
+++ b/src/rfc/agentic_coding_keywords.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+from robot.api import logger
+
 from rfc import agent_verifiers as verifiers
 from rfc.agent_config import (
     DEFAULT_LOCAL_AGENTS_PATH,
@@ -140,12 +142,18 @@ class AgenticCodingKeywords:
             canon = f"{canon}:latest"
         return canon
 
-    def _prose_judge_panel(self) -> MultiGrader:
+    def _generation_model(self, run: AgentRun) -> str:
+        """The model that produced ``run``'s prose ('' for fake replays)."""
+        return self._agent_config(run.agent_id).model
+
+    def _prose_judge_panel(self, generation_model: str = "") -> MultiGrader:
         """Build the judge panel from AGENT_PROSE_GRADER_MODELS.
 
         Raises MissingEnvironmentError (ROBOT_SKIP) when the env var is
         unset, so tier:3 tests skip with a clear reason instead of
-        failing when no grading models are configured.
+        failing when no grading models are configured. Rejects a panel
+        containing ``generation_model`` — that judge would grade its own
+        output (ai/testing.md distinct-judges rule).
         """
         models_str = os.getenv("AGENT_PROSE_GRADER_MODELS", "").strip()
         if not models_str:
@@ -161,6 +169,13 @@ class AgenticCodingKeywords:
                 f"models for consensus grading, got {len(models)} unique: "
                 f"{models} (raw: {raw_models})"
             )
+        if generation_model and self._canonical_model(generation_model) in seen:
+            raise ValueError(
+                f"AGENT_PROSE_GRADER_MODELS must not contain the generation "
+                f"model '{generation_model}' — that judge would grade its "
+                f"own output, violating the ai/testing.md distinct-judges "
+                f"rule."
+            )
         timeout = resolve_timeout(None)
         providers = [create_provider(model=model, timeout=timeout) for model in models]
         return MultiGrader(providers=providers)
@@ -170,6 +185,12 @@ class AgenticCodingKeywords:
     ) -> None:
         emit_rfc_data("score", str(result.majority_score))
         emit_rfc_data("grading_reason", f"{dimension}: " + " | ".join(result.reasons))
+        if not result.unanimous:
+            logger.warn(
+                f"{dimension}: prose judges disagree — scores={result.scores}, "
+                f"agreement={result.agreement_ratio:.2f}, "
+                f"reasons={result.reasons}"
+            )
         if result.majority_score < threshold:
             raise AssertionError(
                 f"{dimension} consensus score {result.majority_score} below "
@@ -181,21 +202,22 @@ class AgenticCodingKeywords:
         self, run: AgentRun, threshold: float = 0.5
     ) -> None:
         """Judge panel: each MC question must reference a concrete repo artifact."""
-        result = AgentProseGrader(self._prose_judge_panel()).grade_question_grounding(
-            run
-        )
+        panel = self._prose_judge_panel(generation_model=self._generation_model(run))
+        result = AgentProseGrader(panel).grade_question_grounding(run)
         self._assert_prose_grade("question-grounding", result, float(threshold))
 
     def pr_body_should_explain_how_to_review(
         self, run: AgentRun, threshold: float = 0.5
     ) -> None:
         """Judge panel: PR body names a starting file and sequences key changes."""
-        result = AgentProseGrader(self._prose_judge_panel()).grade_pr_body(run)
+        panel = self._prose_judge_panel(generation_model=self._generation_model(run))
+        result = AgentProseGrader(panel).grade_pr_body(run)
         self._assert_prose_grade("pr-body-quality", result, float(threshold))
 
     def commits_should_match_their_changes(
         self, run: AgentRun, threshold: float = 0.5
     ) -> None:
         """Judge panel: each commit subject truthfully describes its files."""
-        result = AgentProseGrader(self._prose_judge_panel()).grade_commit_cohesion(run)
+        panel = self._prose_judge_panel(generation_model=self._generation_model(run))
+        result = AgentProseGrader(panel).grade_commit_cohesion(run)
         self._assert_prose_grade("commit-cohesion", result, float(threshold))

--- a/tests/test_agent_prose_grader.py
+++ b/tests/test_agent_prose_grader.py
@@ -1,0 +1,136 @@
+"""Tests for rfc.agent_prose_grader and the tier:3 prose keywords (#289)."""
+
+import json
+
+import pytest
+
+from rfc.agent_prose_grader import AgentProseGrader
+from rfc.agent_run import AgentCommit, AgentPR, AgentQuestion, AgentRun
+from rfc.agentic_coding_keywords import AgenticCodingKeywords
+from rfc.exceptions import MissingEnvironmentError
+from rfc.multi_grader import MultiGrader
+
+
+class FakeJudge:
+    """Provider stub returning a fixed score; records the prompts it saw."""
+
+    def __init__(self, score: float, reason: str = "ok") -> None:
+        self.score = score
+        self.reason = reason
+        self.prompts: list[str] = []
+
+    def generate(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return json.dumps({"score": self.score, "reason": self.reason})
+
+
+def _panel(*scores: float) -> MultiGrader:
+    return MultiGrader(providers=[FakeJudge(s) for s in scores])
+
+
+def _run(**overrides) -> AgentRun:
+    base = dict(
+        agent_id="claude-code",
+        scenario_id="ambiguous_task",
+        task="Clean up the metrics stuff.",
+        base_branch="claude-code-staging",
+        branch_name="claude/clean-metrics-cd456",
+        questions=(
+            AgentQuestion(
+                text="metrics.py has two uncalled exports. Remove them?",
+                options=("a) remove", "b) keep"),
+            ),
+        ),
+        commits=(
+            AgentCommit(
+                sha="3333ccc",
+                subject="test: add failing test for is_palindrome",
+                files_changed=("tests/test_strings.py",),
+            ),
+        ),
+        pr=AgentPR(
+            title="feat: add is_palindrome",
+            body="## How to review\nStart with src/rfc/strings.py.",
+        ),
+    )
+    base.update(overrides)
+    return AgentRun(**base)
+
+
+class TestAgentProseGrader:
+    def test_question_grounding_passes_prompt_context(self):
+        panel = _panel(1.0, 1.0, 1.0)
+        result = AgentProseGrader(panel).grade_question_grounding(_run())
+        assert result.majority_score == 1.0
+        prompt = panel.providers[0].prompts[0]
+        assert "metrics.py has two uncalled exports" in prompt
+        assert "Clean up the metrics stuff." in prompt
+
+    def test_question_grounding_requires_questions(self):
+        with pytest.raises(ValueError, match="question"):
+            AgentProseGrader(_panel(1, 1, 1)).grade_question_grounding(
+                _run(questions=())
+            )
+
+    def test_pr_body_grading_consensus_is_median(self):
+        result = AgentProseGrader(_panel(0.0, 1.0, 1.0)).grade_pr_body(_run())
+        assert result.majority_score == 1.0
+
+    def test_pr_body_requires_pr(self):
+        with pytest.raises(ValueError, match="PR"):
+            AgentProseGrader(_panel(1, 1, 1)).grade_pr_body(_run(pr=None))
+
+    def test_commit_cohesion_includes_files_changed(self):
+        panel = _panel(1.0, 1.0, 1.0)
+        AgentProseGrader(panel).grade_commit_cohesion(_run())
+        prompt = panel.providers[0].prompts[0]
+        assert "tests/test_strings.py" in prompt
+        assert "test: add failing test for is_palindrome" in prompt
+
+    def test_commit_cohesion_requires_commits(self):
+        with pytest.raises(ValueError, match="commit"):
+            AgentProseGrader(_panel(1, 1, 1)).grade_commit_cohesion(_run(commits=()))
+
+
+class TestProseKeywords:
+    @pytest.fixture()
+    def keywords(self):
+        return AgenticCodingKeywords()
+
+    def test_skip_when_env_unset(self, keywords, monkeypatch):
+        monkeypatch.delenv("AGENT_PROSE_GRADER_MODELS", raising=False)
+        with pytest.raises(MissingEnvironmentError):
+            keywords.clarifying_questions_should_be_grounded(_run())
+
+    def test_panel_requires_three_distinct_models(self, keywords, monkeypatch):
+        monkeypatch.setenv("AGENT_PROSE_GRADER_MODELS", "m1,m1:latest,M1")
+        with pytest.raises(ValueError, match="3"):
+            keywords.clarifying_questions_should_be_grounded(_run())
+
+    def test_grounded_questions_pass(self, keywords, monkeypatch):
+        monkeypatch.setattr(
+            keywords, "_prose_judge_panel", lambda: _panel(1.0, 1.0, 1.0)
+        )
+        keywords.clarifying_questions_should_be_grounded(_run())
+
+    def test_ungrounded_questions_fail_with_reasons(self, keywords, monkeypatch):
+        panel = MultiGrader(
+            providers=[FakeJudge(0.0, reason="no file referenced")] * 3
+        )
+        monkeypatch.setattr(keywords, "_prose_judge_panel", lambda: panel)
+        with pytest.raises(AssertionError, match="no file referenced"):
+            keywords.clarifying_questions_should_be_grounded(_run())
+
+    def test_pr_body_threshold_is_configurable(self, keywords, monkeypatch):
+        monkeypatch.setattr(
+            keywords, "_prose_judge_panel", lambda: _panel(0.6, 0.6, 0.6)
+        )
+        keywords.pr_body_should_explain_how_to_review(_run(), threshold=0.5)
+        with pytest.raises(AssertionError):
+            keywords.pr_body_should_explain_how_to_review(_run(), threshold=0.7)
+
+    def test_commits_keyword_passes(self, keywords, monkeypatch):
+        monkeypatch.setattr(
+            keywords, "_prose_judge_panel", lambda: _panel(1.0, 1.0, 1.0)
+        )
+        keywords.commits_should_match_their_changes(_run())

--- a/tests/test_agent_prose_grader.py
+++ b/tests/test_agent_prose_grader.py
@@ -5,7 +5,7 @@ import json
 import pytest
 
 from rfc.agent_prose_grader import AgentProseGrader
-from rfc.agent_run import AgentCommit, AgentPR, AgentQuestion, AgentRun
+from rfc.agent_run import AgentCommand, AgentCommit, AgentPR, AgentQuestion, AgentRun
 from rfc.agentic_coding_keywords import AgenticCodingKeywords
 from rfc.exceptions import MissingEnvironmentError
 from rfc.multi_grader import MultiGrader
@@ -66,6 +66,29 @@ class TestAgentProseGrader:
         assert "metrics.py has two uncalled exports" in prompt
         assert "Clean up the metrics stuff." in prompt
 
+    def test_question_grounding_includes_command_evidence(self):
+        """Judges must see what the agent actually observed in the repo,
+        so fabricated-but-plausible artifact names can't pass (#289 P1)."""
+        panel = _panel(1.0, 1.0, 1.0)
+        run = _run(
+            commands=(
+                AgentCommand(
+                    argv=("grep", "-n", "metrics", "src/metrics.py"),
+                    stdout_tail="42: def unused_export",
+                ),
+            )
+        )
+        AgentProseGrader(panel).grade_question_grounding(run)
+        prompt = panel.providers[0].prompts[0]
+        assert "grep -n metrics src/metrics.py" in prompt
+        assert "42: def unused_export" in prompt
+
+    def test_question_grounding_notes_missing_evidence(self):
+        panel = _panel(1.0, 1.0, 1.0)
+        AgentProseGrader(panel).grade_question_grounding(_run())
+        prompt = panel.providers[0].prompts[0]
+        assert "no repository evidence captured" in prompt
+
     def test_question_grounding_requires_questions(self):
         with pytest.raises(ValueError, match="question"):
             AgentProseGrader(_panel(1, 1, 1)).grade_question_grounding(
@@ -107,23 +130,39 @@ class TestProseKeywords:
         with pytest.raises(ValueError, match="3"):
             keywords.clarifying_questions_should_be_grounded(_run())
 
+    def test_panel_rejects_generation_model_overlap(self, keywords, monkeypatch):
+        """A judge that is also the generation model would grade its own
+        output (ai/testing.md distinct-judges rule, #289 review P1)."""
+        monkeypatch.delenv("DEFAULT_MODEL", raising=False)
+        monkeypatch.setenv("AGENT_PROSE_GRADER_MODELS", "phi4:14b,m2,m3")
+        with pytest.raises(ValueError, match="generation model"):
+            keywords.clarifying_questions_should_be_grounded(
+                _run(agent_id="ollama-local")
+            )
+
+    def test_panel_rejects_generation_model_alias_forms(self, keywords, monkeypatch):
+        monkeypatch.delenv("DEFAULT_MODEL", raising=False)
+        monkeypatch.setenv("AGENT_PROSE_GRADER_MODELS", "PHI4:14b,m2,m3")
+        with pytest.raises(ValueError, match="generation model"):
+            keywords.clarifying_questions_should_be_grounded(
+                _run(agent_id="ollama-local")
+            )
+
     def test_grounded_questions_pass(self, keywords, monkeypatch):
         monkeypatch.setattr(
-            keywords, "_prose_judge_panel", lambda: _panel(1.0, 1.0, 1.0)
+            keywords, "_prose_judge_panel", lambda *a, **k: _panel(1.0, 1.0, 1.0)
         )
         keywords.clarifying_questions_should_be_grounded(_run())
 
     def test_ungrounded_questions_fail_with_reasons(self, keywords, monkeypatch):
-        panel = MultiGrader(
-            providers=[FakeJudge(0.0, reason="no file referenced")] * 3
-        )
-        monkeypatch.setattr(keywords, "_prose_judge_panel", lambda: panel)
+        panel = MultiGrader(providers=[FakeJudge(0.0, reason="no file referenced")] * 3)
+        monkeypatch.setattr(keywords, "_prose_judge_panel", lambda *a, **k: panel)
         with pytest.raises(AssertionError, match="no file referenced"):
             keywords.clarifying_questions_should_be_grounded(_run())
 
     def test_pr_body_threshold_is_configurable(self, keywords, monkeypatch):
         monkeypatch.setattr(
-            keywords, "_prose_judge_panel", lambda: _panel(0.6, 0.6, 0.6)
+            keywords, "_prose_judge_panel", lambda *a, **k: _panel(0.6, 0.6, 0.6)
         )
         keywords.pr_body_should_explain_how_to_review(_run(), threshold=0.5)
         with pytest.raises(AssertionError):
@@ -131,6 +170,32 @@ class TestProseKeywords:
 
     def test_commits_keyword_passes(self, keywords, monkeypatch):
         monkeypatch.setattr(
-            keywords, "_prose_judge_panel", lambda: _panel(1.0, 1.0, 1.0)
+            keywords, "_prose_judge_panel", lambda *a, **k: _panel(1.0, 1.0, 1.0)
         )
         keywords.commits_should_match_their_changes(_run())
+
+    def test_non_unanimous_panel_emits_warn(self, keywords, monkeypatch):
+        """ai/testing.md: tier:3 tests must WARN when graders disagree."""
+        warns: list[str] = []
+        monkeypatch.setattr(
+            "rfc.agentic_coding_keywords.logger.warn",
+            lambda msg, *a, **k: warns.append(str(msg)),
+        )
+        monkeypatch.setattr(
+            keywords, "_prose_judge_panel", lambda *a, **k: _panel(0.0, 1.0, 1.0)
+        )
+        keywords.clarifying_questions_should_be_grounded(_run())
+        assert any("disagree" in w for w in warns)
+        assert any("question-grounding" in w for w in warns)
+
+    def test_unanimous_panel_emits_no_warn(self, keywords, monkeypatch):
+        warns: list[str] = []
+        monkeypatch.setattr(
+            "rfc.agentic_coding_keywords.logger.warn",
+            lambda msg, *a, **k: warns.append(str(msg)),
+        )
+        monkeypatch.setattr(
+            keywords, "_prose_judge_panel", lambda *a, **k: _panel(1.0, 1.0, 1.0)
+        )
+        keywords.clarifying_questions_should_be_grounded(_run())
+        assert warns == []


### PR DESCRIPTION
## Summary

Implements #289: LLM-as-judge prose graders for the agentic-coding suite — clarifying-question grounding, PR-description how-to-review quality, and commit-message cohesion — with multi-grader consensus per `ai/testing.md`, plus the `tier:3 verify:llms` Robot suite exercising them against the existing fixtures.

Closes #289.

## How to review

**Start here:** `src/rfc/agent_prose_grader.py` — the three grading dimensions and their rubrics.

**Key changes:**
- `src/rfc/agent_prose_grader.py` — `AgentProseGrader` wraps the existing `MultiGrader` (median-of-3+ consensus); each method validates the run has the artifact to grade (questions / PR body / commits) and builds a dimension-specific prompt+rubric
- `src/rfc/agentic_coding_keywords.py` — three new keywords; the judge panel is built lazily from `AGENT_PROSE_GRADER_MODELS` (3+ distinct models after canonical dedupe, mirroring the creativity panel from #260) and raises `MissingEnvironmentError` (ROBOT_SKIP) when unset, satisfying the issue's degrade-gracefully constraint; scores/reasons are emitted via the standard `score`/`grading_reason` RFC_DATA keys
- `robot/agentic_coding/test_prose_quality.robot` — three cases, each tagged exactly one `tier:3` + one `verify:llms` (meta-tests enforce this); placed at the suite root matching the existing layout (the issue's `tests/` subpath doesn't exist in this suite)
- `robot/agentic_coding/fixtures/tdd_red_green/run.yaml` — gains the `pr:` block the PR-body and commit-cohesion graders need
- `tests/test_agent_prose_grader.py` — 12 tests written failing-first: prompt content, consensus median, missing-artifact ValueErrors, env-unset skip, 3-distinct-models guard, threshold behaviour, failure messages carrying judge reasons

**What to ignore:** the version bump commit.

## Evidence of testing

<details>
<summary>pytest output</summary>

```
2982 passed, 2 skipped, 10 warnings in 9.51s
```
(second skip is the tier-1 grader-import meta-test correctly skipping the new tier:3 file)
</details>

<details>
<summary>pre-commit output</summary>

```
all hooks Passed (check yaml/json, eol, whitespace, merge conflicts,
ruff, ruff format, mypy, Block FTP usage)
```
</details>

<details>
<summary>code-quality-check output</summary>

```
ruff clean; mypy Success; 2982 passed, 2 skipped
```
</details>

<details>
<summary>robot-dryrun output</summary>

```
639 tests, 639 passed, 0 failed
```
</details>

## Critical changes

- New env var `AGENT_PROSE_GRADER_MODELS` (3+ comma-separated judge models); without it the tier:3 prose tests skip — no CI behaviour change.
- Version bump 1.11.7 → 1.12.0 (minor). Sibling PRs #408/#409 carry the same bump; merge-order rebases apply.

## Checklist

- [x] All pytest tests pass
- [x] pre-commit passes
- [x] code-quality-check passes (ruff + mypy)
- [x] robot-dryrun passes
- [x] Self-reviewed diff — no scope creep, no debug prints
- [x] Changes comply with `ai/agents.md` contract
- [x] Changes comply with `ai/testing.md` tier rules
- [x] New Robot tests have `tier:*` and `verify:*` tags
- [x] No unresolved `TODO`/`FIXME` in changed files
- [x] Type hints on all new Python code
- [x] Commit history is atomic and bisectable
- [ ] Version bump confirmed with user (`pyproject.toml` + `src/rfc/__init__.py`) — assumed minor per policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)