### PR TITLE
fix: guard None values before int/float in _emit_dialog_turns (#418)

### DIFF
--- a/src/rfc/keywords.py
+++ b/src/rfc/keywords.py
@@ -132,11 +132,11 @@ class LLMKeywords:
             "timestamp": timestamp,
         }
         metrics = self.client.last_metrics or {}
-        if "prompt_eval_count" in metrics:
+        if metrics.get("prompt_eval_count") is not None:
             assistant_turn["prompt_tokens"] = int(metrics["prompt_eval_count"])
-        if "eval_count" in metrics:
+        if metrics.get("eval_count") is not None:
             assistant_turn["completion_tokens"] = int(metrics["eval_count"])
-        if "total_duration_ns" in metrics:
+        if metrics.get("total_duration_ns") is not None:
             assistant_turn["latency_ms"] = float(metrics["total_duration_ns"]) / 1e6
         emit_rfc_data("dialog_turn", json.dumps(assistant_turn))
 

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -133,6 +133,48 @@ class TestLLMKeywordsAsk:
         metrics_calls = [c for c in info_calls if "RFC_DATA:llm_metrics:" in c]
         assert len(metrics_calls) == 0
 
+    @patch.dict(os.environ, {"RFC_DIALOG_RECORDING_ID": "rec-null-test"})
+    @patch("rfc.rfc_data.logger")
+    @patch("rfc.keywords.logger")
+    @patch("rfc.keywords.create_provider")
+    @patch("rfc.keywords.Grader")
+    def test_dialog_turns_skip_null_metric_values(
+        self, MockGrader, mock_create, mock_logger, mock_rfc_logger
+    ):
+        """Metrics with None values (absent usage) must not raise TypeError.
+
+        _extract_metrics returns None for prompt_eval_count/eval_count when
+        the provider response omits the usage block.  _emit_dialog_turns checks
+        key presence, so it would call int(None) without a non-null guard.
+        """
+        kw = LLMKeywords()
+        kw.client.generate.return_value = "answer"
+        kw.client.max_tokens = 256
+        kw.client.num_ctx = None
+        kw.client.last_metrics = {
+            "model_name": "gpt-4o",
+            "prompt_eval_count": None,
+            "eval_count": None,
+            "total_duration_ns": None,
+        }
+
+        kw.ask_llm("hello")  # must not raise TypeError
+
+        # The assistant dialog_turn must be emitted without the null fields
+        info_calls = [c.args[0] for c in mock_rfc_logger.info.call_args_list]
+        turn_calls = [c for c in info_calls if "RFC_DATA:dialog_turn:" in c]
+        assistant_payloads = [
+            json.loads(c.split("RFC_DATA:dialog_turn:", 1)[1])
+            for c in turn_calls
+            if json.loads(c.split("RFC_DATA:dialog_turn:", 1)[1]).get("role")
+            == "assistant"
+        ]
+        assert len(assistant_payloads) == 1
+        turn = assistant_payloads[0]
+        assert "prompt_tokens" not in turn
+        assert "completion_tokens" not in turn
+        assert "latency_ms" not in turn
+
 
 class TestLLMKeywordsAskThinking:
     @patch("rfc.keywords.logger")


### PR DESCRIPTION
## Summary

- Guards against `None` metric values in `_emit_dialog_turns` before calling `int()` / `float()`, fixing the `TypeError` raised when a provider response omits the usage block.
- Adds a pytest that reproduces the exact crash (sets `prompt_eval_count`, `eval_count`, `total_duration_ns` to `None` with an active recording bracket, asserts no `TypeError` and that null fields are absent from the emitted dialog turn).

Closes #418.

## How to review

**Root cause:** `src/rfc/keywords.py:135-140` checked `"key" in metrics` — truthy even when the value is `None`. `_extract_metrics` in `openai_client.py` legitimately returns `None` for these keys when the API response omits `usage`. So `int(None)` / `float(None)` raised a `TypeError`, causing `Ask LLM` to fail and emit only the user turn.

**Fix:** Replace key-presence checks with `metrics.get("key") is not None` so `None`-valued keys are skipped rather than converted. Two lines touched in `src/rfc/keywords.py`.

**Test:** `tests/test_keywords.py::TestLLMKeywordsAsk::test_dialog_turns_skip_null_metric_values` — confirmed failing before the fix, passing after.

## Evidence of testing

```
$ uv run pytest tests/test_keywords.py::TestLLMKeywordsAsk::test_dialog_turns_skip_null_metric_values -xvs
1 passed in 0.19s

$ uv run pytest -q
4 failed, 2930 passed, 23 skipped, 9 warnings, 17 errors
(pre-existing failures in test_harness_cli.py — git fixture env issue, present on base branch)

$ uv tool run pre-commit run --all-files
All hooks: Passed

$ make robot-dryrun
639 tests, 639 passed, 0 failed
```

## Critical changes

- `src/rfc/keywords.py` — two-line guard change in `_emit_dialog_turns`. No API, schema, or DB changes.
- No new files outside `src/rfc/`.
- No new Robot tests (fix is in Python keyword logic).

## Checklist

- [x] All pytest tests pass (pre-existing failures unchanged)
- [x] pre-commit passes
- [x] robot-dryrun passes
- [x] Self-reviewed diff — no scope creep
- [x] Type hints unchanged (no new Python signatures)
- [x] Commit is atomic and bisectable

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqP84wXs613r3ZaiKXnRWz)_