### PR TITLE
fix: store flask-limiter rate-limit state in Redis (#414)

### DIFF
--- a/superset/superset_config.py
+++ b/superset/superset_config.py
@@ -41,6 +41,11 @@ DATA_CACHE_CONFIG = {
     "CACHE_KEY_PREFIX": "superset_data_",
 }
 
+# flask-limiter rate-limit state — in-memory by default, which resets on
+# restart and isn't shared across workers (issue #414). DB 2 keeps it
+# apart from the caches on DB 0.
+RATELIMIT_STORAGE_URI = "redis://redis:6379/2"
+
 # Feature flags
 FEATURE_FLAGS = {
     "ENABLE_TEMPLATE_PROCESSING": True,


### PR DESCRIPTION
## Summary

One-line config fix for #414: Superset's flask-limiter warned at startup that rate-limit state was kept in process memory (resets on restart, not shared across workers). Redis already runs in the compose network for caching (DB 0); this points flask-limiter at DB 2.

## How to review

**Start here:** `superset/superset_config.py` — the only change is the new `RATELIMIT_STORAGE_URI` line after `DATA_CACHE_CONFIG`.

**Key changes:**
- `RATELIMIT_STORAGE_URI = "redis://redis:6379/2"` — DB 2 keeps limiter state apart from the caches on DB 0. The `redis` hostname already resolves in the compose network (same as `CACHE_REDIS_HOST`).

**What to ignore:** nothing else changed.

## Evidence of testing

- `ast.parse` syntax check on the config: OK.
- No Python package code touched, so the pytest/mypy surface is unchanged.
- Runtime verification needs the compose stack: after `docker compose up`, the `flask_limiter` UserWarning should no longer appear in `superset`/`superset-init` logs, and `redis-cli -n 2 keys '*'` shows limiter keys after hitting a rate-limited endpoint.

## Critical changes

None — deployment config only. No schema, API, or CI changes. **Note:** the Lint & Typecheck check will show the pre-existing base-branch failure (AgenticHarnessListener Makefile registration) until PR #419 merges; it is unrelated to this change.

## Checklist

- [x] Self-reviewed diff — no scope creep
- [x] No version bump: deployment-config-only change (per creating-prs policy, like CI-only work)
- [x] No new files outside `src/rfc/` or `robot/` (existing config file edited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)