### PR TITLE
fix: rename ROBOT_SKIP to ROBOT_SKIP_EXECUTION so skip exceptions actually skip (#427)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,8 +93,14 @@ CEO_MAX_TOKENS=4096
 # ── Creativity Joke Judging (issue #260) ────────────────────────────
 # Comma-separated list of 3+ judge models distinct from the generation
 # model. `Creative.Grade Joke` requires this to avoid self-grading bias;
-# tests skip (ROBOT_SKIP) when unset.
+# tests skip (ROBOT_SKIP_EXECUTION) when unset.
 CREATIVITY_GRADER_MODELS=qwen2:latest,phi3:latest,gemma2:latest
+
+# ── Agentic Coding Prose Graders (issue #289) ───────────────────────
+# Comma-separated list of 3+ distinct judge models for tier:3 prose
+# grading; must not include the generation model (no self-grading).
+# Tier:3 prose tests skip (ROBOT_SKIP_EXECUTION) when unset.
+AGENT_PROSE_GRADER_MODELS=phi4:14b,llama3.1:latest,gemma2:latest
 
 # Web search API endpoint for market/patent research enrichment
 WEB_SEARCH_ENDPOINT=

--- a/src/rfc/agentic_coding_keywords.py
+++ b/src/rfc/agentic_coding_keywords.py
@@ -149,7 +149,7 @@ class AgenticCodingKeywords:
     def _prose_judge_panel(self, generation_model: str = "") -> MultiGrader:
         """Build the judge panel from AGENT_PROSE_GRADER_MODELS.
 
-        Raises MissingEnvironmentError (ROBOT_SKIP) when the env var is
+        Raises MissingEnvironmentError (ROBOT_SKIP_EXECUTION) when the env var is
         unset, so tier:3 tests skip with a clear reason instead of
         failing when no grading models are configured. Rejects a panel
         containing ``generation_model`` — that judge would grade its own

--- a/src/rfc/creativity_keywords.py
+++ b/src/rfc/creativity_keywords.py
@@ -67,7 +67,7 @@ class CreativityKeywords:
     def creativity_grader(self) -> CreativityGrader:
         """Lazily build a panel-backed grader from CREATIVITY_GRADER_MODELS.
 
-        Raises MissingEnvironmentError (ROBOT_SKIP) if the env var is unset
+        Raises MissingEnvironmentError (ROBOT_SKIP_EXECUTION) if the env var is unset
         or has fewer than 3 models. This skips the test rather than silently
         falling back to the generation client (issue #260).
         """

--- a/src/rfc/exceptions.py
+++ b/src/rfc/exceptions.py
@@ -1,7 +1,7 @@
-"""Centralised exception hierarchy with Robot Framework ROBOT_SKIP support.
+"""Centralised exception hierarchy with Robot Framework ROBOT_SKIP_EXECUTION support.
 
-Robot Framework recognises the ``ROBOT_SKIP`` class attribute on exceptions.
-When a keyword raises an exception whose class has ``ROBOT_SKIP = True``,
+Robot Framework recognises the ``ROBOT_SKIP_EXECUTION`` class attribute on exceptions.
+When a keyword raises an exception whose class has ``ROBOT_SKIP_EXECUTION = True``,
 the test is marked **skipped** instead of **failed**.  This module defines
 a base class and concrete subclasses for every infrastructure / environment
 error that should skip — not fail — a test.
@@ -13,11 +13,11 @@ from typing import List
 class RFCSkipError(Exception):
     """Base for infrastructure errors that should SKIP, not FAIL.
 
-    All subclasses inherit ``ROBOT_SKIP = True`` so Robot Framework marks
+    All subclasses inherit ``ROBOT_SKIP_EXECUTION = True`` so Robot Framework marks
     the enclosing test as *skipped* rather than *failed*.
     """
 
-    ROBOT_SKIP: bool = True
+    ROBOT_SKIP_EXECUTION: bool = True
 
 
 # ── Ollama ────────────────────────────────────────────────────────────

--- a/tests/test_creativity_keywords.py
+++ b/tests/test_creativity_keywords.py
@@ -63,7 +63,7 @@ class TestCreativityKeywords:
         kw = CreativityKeywords()
         with pytest.raises(MissingEnvironmentError) as exc_info:
             kw.grade_joke("Tell me a joke", "joke text", "humor")
-        assert exc_info.value.ROBOT_SKIP is True
+        assert exc_info.value.ROBOT_SKIP_EXECUTION is True
         assert "CREATIVITY_GRADER_MODELS" in str(exc_info.value)
 
     @patch("rfc.creativity_keywords.create_provider")
@@ -390,4 +390,4 @@ class TestCreativityKeywords:
         kw = CreativityKeywords()
         with pytest.raises(EmptyLLMResponseError) as exc_info:
             kw.ask_and_grade_joke_with_retry("Tell me a joke", "humor")
-        assert exc_info.value.ROBOT_SKIP is True
+        assert exc_info.value.ROBOT_SKIP_EXECUTION is True

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -15,16 +15,34 @@ from rfc.exceptions import (
 
 class TestRFCSkipError:
     def test_robot_skip_attribute(self) -> None:
-        assert RFCSkipError.ROBOT_SKIP is True
+        assert RFCSkipError.ROBOT_SKIP_EXECUTION is True
 
     def test_is_exception(self) -> None:
         assert issubclass(RFCSkipError, Exception)
+
+    def test_robot_framework_actually_skips(self) -> None:
+        """RF must classify a raised RFCSkipError as SKIP, not FAIL (#427).
+
+        Exercises Robot Framework's own error machinery rather than our
+        attribute name: RF reads ``ROBOT_SKIP_EXECUTION`` via
+        ``HandlerExecutionFailed``. The old ``ROBOT_SKIP`` name was never
+        recognised, so every "skip" actually failed the test.
+        """
+        from robot.errors import HandlerExecutionFailed
+        from robot.utils import ErrorDetails
+
+        try:
+            raise MissingEnvironmentError("AGENT_PROSE_GRADER_MODELS")
+        except MissingEnvironmentError:
+            failure = HandlerExecutionFailed(ErrorDetails())
+        assert failure.skip is True
+        assert failure.status == "SKIP"
 
 
 class TestOllamaModelNotFoundError:
     def test_inherits_skip(self) -> None:
         assert issubclass(OllamaModelNotFoundError, RFCSkipError)
-        assert OllamaModelNotFoundError.ROBOT_SKIP is True
+        assert OllamaModelNotFoundError.ROBOT_SKIP_EXECUTION is True
 
     def test_attributes(self) -> None:
         exc = OllamaModelNotFoundError("phi4:14b", "http://localhost:11434")
@@ -44,7 +62,7 @@ class TestOllamaModelNotFoundError:
 class TestOllamaTimeoutError:
     def test_inherits_skip(self) -> None:
         assert issubclass(OllamaTimeoutError, RFCSkipError)
-        assert OllamaTimeoutError.ROBOT_SKIP is True
+        assert OllamaTimeoutError.ROBOT_SKIP_EXECUTION is True
 
     def test_attributes(self) -> None:
         exc = OllamaTimeoutError(elapsed=120, models=["llama3"])
@@ -57,7 +75,7 @@ class TestOllamaTimeoutError:
 class TestEmptyLLMResponseError:
     def test_inherits_skip(self) -> None:
         assert issubclass(EmptyLLMResponseError, RFCSkipError)
-        assert EmptyLLMResponseError.ROBOT_SKIP is True
+        assert EmptyLLMResponseError.ROBOT_SKIP_EXECUTION is True
 
     def test_attributes(self) -> None:
         exc = EmptyLLMResponseError(model="phi4:14b", prompt_snippet="Tell me a joke")
@@ -76,7 +94,7 @@ class TestEmptyLLMResponseError:
 class TestDockerNotAvailableError:
     def test_inherits_skip(self) -> None:
         assert issubclass(DockerNotAvailableError, RFCSkipError)
-        assert DockerNotAvailableError.ROBOT_SKIP is True
+        assert DockerNotAvailableError.ROBOT_SKIP_EXECUTION is True
 
     def test_message(self) -> None:
         exc = DockerNotAvailableError()
@@ -86,7 +104,7 @@ class TestDockerNotAvailableError:
 class TestPortAllocationError:
     def test_inherits_skip(self) -> None:
         assert issubclass(PortAllocationError, RFCSkipError)
-        assert PortAllocationError.ROBOT_SKIP is True
+        assert PortAllocationError.ROBOT_SKIP_EXECUTION is True
 
     def test_attributes(self) -> None:
         exc = PortAllocationError(start_port=11434, end_port=11500)
@@ -99,7 +117,7 @@ class TestPortAllocationError:
 class TestMissingDependencyError:
     def test_inherits_skip(self) -> None:
         assert issubclass(MissingDependencyError, RFCSkipError)
-        assert MissingDependencyError.ROBOT_SKIP is True
+        assert MissingDependencyError.ROBOT_SKIP_EXECUTION is True
 
     def test_attributes(self) -> None:
         exc = MissingDependencyError(
@@ -114,7 +132,7 @@ class TestMissingDependencyError:
 class TestMissingEnvironmentError:
     def test_inherits_skip(self) -> None:
         assert issubclass(MissingEnvironmentError, RFCSkipError)
-        assert MissingEnvironmentError.ROBOT_SKIP is True
+        assert MissingEnvironmentError.ROBOT_SKIP_EXECUTION is True
 
     def test_attributes(self) -> None:
         exc = MissingEnvironmentError(variable="DATABASE_URL")
@@ -125,7 +143,7 @@ class TestMissingEnvironmentError:
 class TestMissingProviderConfigError:
     def test_inherits_skip(self) -> None:
         assert issubclass(MissingProviderConfigError, RFCSkipError)
-        assert MissingProviderConfigError.ROBOT_SKIP is True
+        assert MissingProviderConfigError.ROBOT_SKIP_EXECUTION is True
 
     def test_attributes(self) -> None:
         exc = MissingProviderConfigError(provider="openai", variable="OPENAI_API_KEY")

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -446,7 +446,7 @@ class TestAskAndGradeWithRetry:
 
         with pytest.raises(EmptyLLMResponseError) as exc_info:
             kw.ask_and_grade_with_retry("Q", "42", max_retries=3)
-        assert exc_info.value.ROBOT_SKIP is True
+        assert exc_info.value.ROBOT_SKIP_EXECUTION is True
         assert kw.client.generate.call_count == 1
         assert kw.client.max_tokens == 256
 

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -781,8 +781,8 @@ class TestModelNotFoundError:
         assert "try pulling it first" in str(exc)
 
     def test_robot_skip_attribute(self):
-        """OllamaModelNotFoundError has ROBOT_SKIP for RF integration."""
-        assert OllamaModelNotFoundError.ROBOT_SKIP is True
+        """OllamaModelNotFoundError has ROBOT_SKIP_EXECUTION for RF integration."""
+        assert OllamaModelNotFoundError.ROBOT_SKIP_EXECUTION is True
 
 
 class TestLLMClientAlias:


### PR DESCRIPTION
## Summary

Fixes #427 — and a wider latent bug it exposed. Robot Framework recognises the `ROBOT_SKIP_EXECUTION` attribute on raised exceptions; our `RFCSkipError` hierarchy declared `ROBOT_SKIP`, which RF never reads. So **every** skip-intended exception (missing env vars, Ollama timeouts, Docker unavailable, empty LLM responses) has been FAILING tests instead of skipping them. The prose graders' hard-fail when `AGENT_PROSE_GRADER_MODELS` is unset was one symptom.

## How to review

**Start here:** `src/rfc/exceptions.py` — the one-line attribute rename on `RFCSkipError` is the whole fix; everything else is references.

**Key changes:**
- `tests/test_exceptions.py::test_robot_framework_actually_skips` — new behavioral test that drives RF's own `HandlerExecutionFailed` machinery (asserts `failure.skip is True`). This is the regression guard: the old tests asserted our attribute name, which is exactly how the wrong name survived.
- `.env.example` — documents `AGENT_PROSE_GRADER_MODELS` (3+ distinct judges, no self-grading), the issue's second ask.

**What to ignore:** the mechanical `ROBOT_SKIP` → `ROBOT_SKIP_EXECUTION` renames in tests and docstrings.

## Evidence of testing

- TDD: behavioral test written first, failed with `assert False is True` (RF did not skip), passes after the rename.
- `uv run pytest`: 3066 passed, 2 skipped.
- `pre-commit run --all-files`: all hooks pass.
- `make code-quality-check`: coverage 87.93%.
- `make robot-dryrun`: suites parse.

## Critical changes

Behavioral change at runtime: infrastructure errors in Robot runs now produce **SKIP** instead of **FAIL** — this is the documented intent of the hierarchy and CLAUDE.md's skip-and-log rule, but pass/fail dashboards will show skips where they previously showed failures. **Note:** Lint & Typecheck may show the pre-existing base-branch registration failure until PR #419 merges; unrelated.

## Checklist

- [x] TDD — failing behavioral test first
- [x] All pytest tests pass
- [x] pre-commit / code-quality-check / robot-dryrun pass
- [x] Self-reviewed diff — no scope creep
- [x] No version bump yet — recommend **minor** (behavioral change to the public exception contract); will bump if you confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)