### PR TITLE
fix: add missing --listener flag for DialogListener in LISTENERS (#436)

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -34,6 +34,7 @@ LISTENERS = [
     "rfc.chat_log_listener.ChatLogListener",
     "--listener",
     "rfc.agentic_harness_listener.AgenticHarnessListener",
+    "--listener",
     "rfc.dialog_listener.DialogListener",
 ]
 


### PR DESCRIPTION
## Summary

- One-line fix: insert the missing `"--listener"` flag before `"rfc.dialog_listener.DialogListener"` in the `LISTENERS` list in `tasks.py`
- Without this flag, `DialogListener` was passed as a positional argument (treated as a data-source path) instead of being registered as a listener — silently not attached to any invoke-task Robot run

## How to review

The entire change is one line in `tasks.py:37`. Compare the before/after in the LISTENERS list — every other listener entry correctly has a preceding `"--listener"` string; `DialogListener` was the only one missing it.

## Evidence of testing

- `uv run pytest tests/test_dialog_recorder.py` — **21 passed** (registration test at line 120 confirms `DialogListener` remains in `LISTENERS`)
- `uv run pytest tests/test_agentic_harness_listener.py` — **16 passed**
- `ruff check tasks.py` — **All checks passed**
- `make robot-dryrun` — **639 tests, 639 passed, 0 failed**
- Pre-existing failures in this environment (git signing error in test_harness_snapshot, missing sqlalchemy in test_harness_cli) are unrelated to this change and documented in #439

## Critical changes

Config/API: none. This is a pure runtime-registration fix — no DB schema, no new files, no public API change. The only observable behavior change is that `DialogListener` now correctly attaches when invoke-task runs Robot.

## Checklist

- [x] Pytest tests pass (dialog_recorder + agentic_harness_listener suites green)
- [x] ruff check passes
- [x] robot-dryrun passes (639/639)
- [x] Self-reviewed diff — single-line change, no scope creep
- [x] Type hints: n/a (no new Python code — tasks.py is untyped config)
- [x] No new Robot tests needed (pure config fix)
- [x] Commit is atomic and bisectable

Closes #436

https://claude.ai/code/session_01MJjqrypEcvq9iauvbrZUKB

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJjqrypEcvq9iauvbrZUKB)_