### PR TITLE
docs: document four-role agent system in readme.md (#434)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -314,6 +314,23 @@ See [ai/agents.md](https://github.com/tkarcheski/robotframework-chat/blob/main/a
 | [docs/GRAFANA_SUPERSET_SETUP.md](https://github.com/tkarcheski/robotframework-chat/blob/main/docs/GRAFANA_SUPERSET_SETUP.md) | Superset visualization stack setup (Grafana deferred to v2+) |
 | [docs/SUPERSET_EXPORT_GUIDE.md](https://github.com/tkarcheski/robotframework-chat/blob/main/docs/SUPERSET_EXPORT_GUIDE.md) | Superset dashboard export, import, and backup |
 | [Ollama Configuration](#ollama-configuration) | Multi-model loading, VRAM sizing, and multi-node setup |
+| [ai/ROLES.md](https://github.com/tkarcheski/robotframework-chat/blob/main/ai/ROLES.md) | Four-role agent system — engineering, test-design, project-management, design |
+| [ai/GIT.md](https://github.com/tkarcheski/robotframework-chat/blob/main/ai/GIT.md) | Git topology contract for concurrent agent operation (worktrees, identities, submodule ownership) |
+
+---
+
+## Role System
+
+This repo runs a **four-role agent system** for continuous development and quality assurance:
+
+| Role | Responsibility |
+|------|----------------|
+| **engineering** | Picks up `status:ready` issues, implements on a branch, opens pull requests |
+| **test-design** | Reviews open PRs, writes test plans, executes them, posts PASS/FAIL verdicts |
+| **project-management** | Triages issues, sets priorities, monitors CI health, grooms the backlog |
+| **design** | Architecture RFCs, system-wide improvements, open-ended design exploration |
+
+The roles communicate through GitHub labels (`status:*`, `P0–P3`, `from:*`, `type:*`) and run concurrently in isolated git worktrees. See [`ai/ROLES.md`](https://github.com/tkarcheski/robotframework-chat/blob/main/ai/ROLES.md) for the full contract and [`ai/GIT.md`](https://github.com/tkarcheski/robotframework-chat/blob/main/ai/GIT.md) for the git topology. Role prompts live in [`.claude/agents/`](https://github.com/tkarcheski/robotframework-chat/blob/main/.claude/agents/).
 
 ---
 


### PR DESCRIPTION
## Summary

- Add a **Role System** section to `readme.md` with a table describing the four roles (engineering, test-design, project-management, design) and links to `ai/ROLES.md`, `ai/GIT.md`, and `.claude/agents/`
- Add two rows to the Documentation table pointing at `ai/ROLES.md` and `ai/GIT.md`, which were absent despite being primary contracts for the automated development workflow

Closes #434

## How to review

The entire change is 17 lines added to `readme.md`. The Role System section sits between Documentation and Contributing. No code touched.

## Evidence of testing

- `uv run ruff check .` — **All checks passed**
- `make robot-dryrun` — **639 tests, 639 passed, 0 failed**
- `uv run pytest -q` — 2933 passed; 3 failures + 17 errors are all **pre-existing** environment issues (missing `sqlalchemy` / missing docker type stubs, documented in #439) — none related to this docs change

## Critical changes

None. Pure documentation addition; no Python, no Robot, no config.

## Checklist

- [x] Pytest pre-existing failures are unrelated to this change (pure markdown)
- [x] ruff check passes
- [x] robot-dryrun passes (639/639)
- [x] Self-reviewed diff — 17 lines, no scope creep
- [x] No new files created (existing readme.md only)
- [x] No type hints needed (no Python code)
- [x] No Robot tests needed (no logic change)

https://claude.ai/code/session_01Xgh27SMSjoGoPsmSVcZbPF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xgh27SMSjoGoPsmSVcZbPF)_