### PR TITLE
test: fixture-based skip-logic regression for metrics entrypoint (#430)

### DIFF
--- a/tests/fixtures/output_xml/in_progress.xml
+++ b/tests/fixtures/output_xml/in_progress.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<robot generator="Robot 6.0.2 (Python 3.11.4 on linux)" generated="20240611 18:23:14.421" rpa="FALSE" schemaversion="4">
+<suite id="s1" name="Test Suite" source="/robot/test.robot">
+<test id="s1-t1" name="Test Case 1">
+<status status="PASS" starttime="20240611 18:23:14.422" endtime="20240611 18:23:15.001"/>
+</test>
+</suite>
+<statistics>
+<total>
+<stat pass="1" fail="0" skip="0">All Tests</stat>

--- a/tests/fixtures/output_xml/truncated_mid_element.xml
+++ b/tests/fixtures/output_xml/truncated_mid_element.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<robot generator="Robot 6.0.2 (Python 3.11.4 on linux)" generated="20240611 18:23:14.421" rpa="FALSE" schemaversion="4">
+<suite id="s1" name="Test Numerical Accuracy" source="/robot/hallucination/test_numerical_accuracy.robot">
+<suite id="s1-s1" name="Numerical Accuracy Tests">
+<test id="s1-s1-t1" name="Verify Numerical Fact 1">
+<kw name="Prompt Model" library="rfc.llm_test_keywords">
+<arg>${NUMERICAL_FACTS}[0][question]</arg>

--- a/tests/test_metrics_entrypoint.py
+++ b/tests/test_metrics_entrypoint.py
@@ -157,3 +157,59 @@ def test_generate_index_lists_root_and_nested_dashboards(tmp_path: Path) -> None
     assert ">root<" in html
     assert 'href="accounting/dashboard.html"' in html
     assert ">accounting<" in html
+
+
+class TestSkipLogicWithXmlFixtures:
+    """Fixture-based regression tests for each production skip shape in entrypoint.sh.
+
+    Canonical fixture files in tests/fixtures/output_xml/ capture the exact byte
+    sequences seen in the #413 incident so future format changes can't silently
+    break the skip path.  The zero-byte case closes a gap not covered by the
+    inline-content tests above.
+    """
+
+    FIXTURES = Path(__file__).resolve().parent / "fixtures" / "output_xml"
+
+    def _run_with_fixture_xml(
+        self,
+        tmp_path: Path,
+        fixture_name: str,
+    ) -> tuple[subprocess.CompletedProcess[str], Path]:
+        bin_dir = tmp_path / "bin"
+        _fake_robotmetrics(bin_dir)
+        results_dir = tmp_path / "results"
+        suite = results_dir / "local" / "host" / "model"
+        suite.mkdir(parents=True)
+        xml = suite / "output.xml"
+        xml.write_bytes((self.FIXTURES / fixture_name).read_bytes())
+        old_time = time.time() - 3600
+        os.utime(xml, (old_time, old_time))
+        output_dir = tmp_path / "metrics"
+        output_dir.mkdir()
+        proc = run_bash(
+            f"export PATH='{bin_dir}':\"$PATH\" "
+            f"RESULTS_DIR='{results_dir}' OUTPUT_DIR='{output_dir}' "
+            "METRICS_FRESH_WINDOW_SECONDS=120; "
+            f"source '{SCRIPT}'; generate_metrics"
+        )
+        dashboard = output_dir / "local" / "host" / "model" / "dashboard.html"
+        return proc, dashboard
+
+    def test_truncated_mid_element_is_skipped(self, tmp_path: Path) -> None:
+        proc, dashboard = self._run_with_fixture_xml(tmp_path, "truncated_mid_element.xml")
+        assert proc.returncode == 0, proc.stderr
+        assert "truncated" in proc.stdout.lower()
+        assert not dashboard.exists()
+
+    def test_in_progress_stale_file_is_skipped(self, tmp_path: Path) -> None:
+        """A stale (old mtime) file with no </robot> is skipped via the content check."""
+        proc, dashboard = self._run_with_fixture_xml(tmp_path, "in_progress.xml")
+        assert proc.returncode == 0, proc.stderr
+        assert "truncated" in proc.stdout.lower()
+        assert not dashboard.exists()
+
+    def test_zero_byte_xml_is_skipped(self, tmp_path: Path) -> None:
+        proc, dashboard = self._run_with_fixture_xml(tmp_path, "zero_byte.xml")
+        assert proc.returncode == 0, proc.stderr
+        assert "truncated" in proc.stdout.lower()
+        assert not dashboard.exists()


### PR DESCRIPTION
## Summary

- Add `tests/fixtures/output_xml/` with three canonical XML fixtures capturing each production skip shape from the #413 incident
- Add `TestSkipLogicWithXmlFixtures` class to `tests/test_metrics_entrypoint.py` with one test per fixture
- The zero-byte fixture closes a true coverage gap — not tested by the existing inline-content tests

Closes #430

## How to review

The entire change is 73 lines: 3 fixture files + 56 lines in `test_metrics_entrypoint.py`.

**Fixture files** (`tests/fixtures/output_xml/`):
- `truncated_mid_element.xml` — Robot XML halted mid-keyword-arg (the original #413 crash shape)
- `in_progress.xml` — structurally complete XML up to `<statistics>` but missing `</robot>` (killed-run scenario; stale mtime bypasses freshness check, caught by `tail -c 200 | grep -q '</robot>'`)
- `zero_byte.xml` — empty file (0 bytes); new coverage not present in existing tests

Each test confirms: `returncode == 0`, `"truncated"` in stdout, no `dashboard.html` generated — matching the assertions in the existing inline-content tests but using the canonical fixture files.

The fixtures are designed to be reused by the upcoming #418/#417 null-metrics skip tests (same fixture harness, per issue #430 note).

## Evidence of testing

- `uv run pytest tests/test_metrics_entrypoint.py -q` — **8 passed** (5 existing + 3 new)
- `uv run pytest -q` — 2936 passed, 23 skipped; 3 failures + 17 errors are all **pre-existing** environment issues documented in #439 (git signing / missing sqlalchemy) — none related to this change
- `uv run ruff check tests/test_metrics_entrypoint.py` — **All checks passed**
- `uv run mypy tests/test_metrics_entrypoint.py --ignore-missing-imports` — **no issues**
- `make robot-dryrun` — **639 tests, 639 passed, 0 failed**
- `pre-commit` not installed in this cloud environment; ruff + mypy run manually as the key hooks

## Critical changes

None. Pure test and fixture addition — no production code changed, no config changed, no schema changed.

## Checklist

- [x] `uv run pytest tests/test_metrics_entrypoint.py` passes (8/8)
- [x] Full pytest suite — pre-existing failures only, none related to this change
- [x] ruff check passes
- [x] mypy passes
- [x] robot-dryrun passes (639/639)
- [x] Self-reviewed diff — no scope creep, no debug prints
- [x] No new Python code outside `tests/` (fixture files + test class only)
- [x] No new Robot tests → no `config/test_suites.yaml` registration needed
- [x] TDD: wrote failing tests first, then added fixtures (FileNotFoundError confirmed at red phase)

https://claude.ai/code/session_01QHbAy3sZU7WJGyS57z7qLk

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHbAy3sZU7WJGyS57z7qLk)_