### PR TITLE
fix: repair run_model_suites left broken by #442 merge (staging CI red)

### DIFF
--- a/scripts/check_agent_signoffs.py
+++ b/scripts/check_agent_signoffs.py
@@ -106,12 +106,9 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  - {violation}", file=sys.stderr)
         return 1
 
-    agent_count = sum(
-        1 for c in commits if c.author_email.endswith(AGENT_EMAIL_DOMAIN)
-    )
+    agent_count = sum(1 for c in commits if c.author_email.endswith(AGENT_EMAIL_DOMAIN))
     print(
-        f"agent sign-offs: ok ({agent_count} agent commit(s) of "
-        f"{len(commits)} checked)"
+        f"agent sign-offs: ok ({agent_count} agent commit(s) of {len(commits)} checked)"
     )
     return 0
 

--- a/scripts/run_local_models.py
+++ b/scripts/run_local_models.py
@@ -423,67 +423,43 @@ def run_model_suites(
     preflight_enabled = execution.get("preflight", False)
     preflight_timeout = execution.get("preflight_timeout", DEFAULT_PREFLIGHT_TIMEOUT)
 
-    results: list[RunResult] = []
+    hosts = _host_states_from_nodes(nodes_with_models)
+    jobs = _build_jobs(config, nodes_with_models)
+    print_lock = threading.Lock()
 
-    for node_info in nodes_with_models:
-        endpoint = node_info["endpoint"]
-        hostname = node_info["hostname"]
-        models = list(node_info.get("models", []))
-        random.shuffle(models)
+    def _run(host: HostState, job: Job) -> RunResult:
+        node_name = host.spec.name
+        endpoint = host.spec.endpoint
 
-        if models:
-            print(f"  Model order (shuffled): {models}")
-
-        for model in models:
-            if preflight_enabled and not dry_run:
-                ok, reason = preflight_model(endpoint, model, timeout=preflight_timeout)
-                if not ok:
+        if preflight_enabled and not dry_run:
+            ok, reason = preflight_model(endpoint, job.model, timeout=preflight_timeout)
+            if not ok:
+                with print_lock:
                     print(
-                        f"\n  [preflight] SKIPPING {model}@{hostname}: {reason}\n"
+                        f"\n  [preflight] SKIPPING {job.model}@{node_name}: "
+                        f"{reason}\n"
                         f"  [preflight] Recording failure and continuing with "
                         f"the next model."
                     )
-                    results.append(
-                        RunResult(
-                            node=hostname,
-                            model=model,
-                            suite=PREFLIGHT_SUITE,
-                            returncode=1,
-                            output_dir="",
-                        )
-                    )
-                    continue
-
-            for suite in suites:
-                cmd = _build_robot_command(
-                    config=config,
-                    suite=suite,
-                    endpoint=endpoint,
-                    model=model,
-                    node_name=hostname,
+                return RunResult(
+                    node=node_name,
+                    model=job.model,
+                    suite=PREFLIGHT_SUITE,
+                    returncode=1,
+                    output_dir="",
                 )
 
-                output_dir = (
-                    config.get("execution", {})
-                    .get("output_dir", "results/local/{node}/{model}")
-                    .format(
-                        node=_sanitize_name(hostname),
-                        model=_sanitize_name(model),
-                    )
-                )
-
-                if dry_run:
-                    print(f"[DRY-RUN] {' '.join(cmd)}")
-                    results.append(
-                        RunResult(
-                            node=hostname,
-                            model=model,
-                            suite=suite["name"],
-                            returncode=0,
-                            output_dir=output_dir,
-                        )
-                    )
-                    continue
+        cmd = _build_robot_command(
+            config=config,
+            suite=job.suite,
+            endpoint=endpoint,
+            model=job.model,
+            node_name=node_name,
+        )
+        output_dir = execution.get("output_dir", "results/local/{node}/{model}").format(
+            node=_sanitize_name(node_name),
+            model=_sanitize_name(job.model),
+        )
 
         if dry_run:
             with print_lock:
@@ -509,7 +485,7 @@ def run_model_suites(
         env = {
             **os.environ,
             "DEFAULT_MODEL": job.model,
-            "OLLAMA_ENDPOINT": host.spec.endpoint,
+            "OLLAMA_ENDPOINT": endpoint,
         }
         proc = subprocess.run(cmd, cwd=str(_project_root), env=env)
 

--- a/src/rfc/dialog_parsers/claude_code.py
+++ b/src/rfc/dialog_parsers/claude_code.py
@@ -71,7 +71,11 @@ def _turn_from_line(line: dict[str, Any]) -> DialogTurn | None:
         if not text:
             return None
         return DialogTurn(
-            recording_id="", turn_number=0, role="user", timestamp=timestamp, content=text
+            recording_id="",
+            turn_number=0,
+            role="user",
+            timestamp=timestamp,
+            content=text,
         )
 
     tool_calls = [b for b in blocks if b.get("type") == "tool_use"]

--- a/tests/test_agent_signoffs.py
+++ b/tests/test_agent_signoffs.py
@@ -55,7 +55,5 @@ class TestEvaluateCommits:
     def test_sharing_role_signoff_differs_from_author_is_allowed(self) -> None:
         # Mismatch is PM-judged, not CI-failed (legitimate after rewrites);
         # CI only requires that SOME agent identity signed off.
-        commit = _commit(
-            email="test-design@agents.rfc", signoffs=["design@agents.rfc"]
-        )
+        commit = _commit(email="test-design@agents.rfc", signoffs=["design@agents.rfc"])
         assert evaluate_commits([commit]) == []

--- a/tests/test_generative_listener_observe.py
+++ b/tests/test_generative_listener_observe.py
@@ -238,9 +238,7 @@ class TestGenerativeListenerObserve:
     def test_tagged_suite_produces_decision_rows(self, clean_env, tmp_path):
         db = _seed_harness(tmp_path)
         provider = SyntheticProvider()
-        listener = GenerativeListener(
-            database_url=_db_url(tmp_path), provider=provider
-        )
+        listener = GenerativeListener(database_url=_db_url(tmp_path), provider=provider)
         _run_suite(listener, tags=[GENERATIVE_OBSERVE_TAG], test_results=[False])
         rows = db.get_decisions(SESSION)
         assert {r.hook_event for r in rows} == {"start_suite", "end_test"}
@@ -251,9 +249,7 @@ class TestGenerativeListenerObserve:
     def test_passing_test_only_prompts_at_suite_start(self, clean_env, tmp_path):
         db = _seed_harness(tmp_path)
         provider = SyntheticProvider()
-        listener = GenerativeListener(
-            database_url=_db_url(tmp_path), provider=provider
-        )
+        listener = GenerativeListener(database_url=_db_url(tmp_path), provider=provider)
         _run_suite(listener, tags=[GENERATIVE_OBSERVE_TAG], test_results=[True, True])
         rows = db.get_decisions(SESSION)
         assert [r.hook_event for r in rows] == ["start_suite"]
@@ -262,9 +258,7 @@ class TestGenerativeListenerObserve:
     def test_untagged_suite_produces_no_rows(self, clean_env, tmp_path):
         db = _seed_harness(tmp_path)
         provider = SyntheticProvider()
-        listener = GenerativeListener(
-            database_url=_db_url(tmp_path), provider=provider
-        )
+        listener = GenerativeListener(database_url=_db_url(tmp_path), provider=provider)
         _run_suite(listener, tags=["tier:0"], test_results=[False])
         assert db.get_decisions(SESSION) == []
         assert provider.calls == 0
@@ -273,9 +267,7 @@ class TestGenerativeListenerObserve:
         monkeypatch.setenv("RFC_GENERATIVE_BUDGET_TOKENS", "120")
         db = _seed_harness(tmp_path)
         provider = SyntheticProvider(tokens_per_call=100)
-        listener = GenerativeListener(
-            database_url=_db_url(tmp_path), provider=provider
-        )
+        listener = GenerativeListener(database_url=_db_url(tmp_path), provider=provider)
         _run_suite(
             listener,
             tags=[GENERATIVE_OBSERVE_TAG],
@@ -291,9 +283,7 @@ class TestGenerativeListenerObserve:
         monkeypatch.setenv("RFC_GENERATIVE_BUDGET_TOKENS", "100")
         db = _seed_harness(tmp_path)
         provider = SyntheticProvider(tokens_per_call=10_000)  # drains instantly
-        listener = GenerativeListener(
-            database_url=_db_url(tmp_path), provider=provider
-        )
+        listener = GenerativeListener(database_url=_db_url(tmp_path), provider=provider)
         _run_suite(
             listener,
             tags=[GENERATIVE_OBSERVE_TAG],
@@ -319,9 +309,7 @@ class TestGenerativeListenerObserve:
     def test_no_harness_row_skips_and_warns(self, clean_env, tmp_path, caplog):
         db = HarnessDatabase(database_url=_db_url(tmp_path))  # no seeded row
         provider = SyntheticProvider()
-        listener = GenerativeListener(
-            database_url=_db_url(tmp_path), provider=provider
-        )
+        listener = GenerativeListener(database_url=_db_url(tmp_path), provider=provider)
         with caplog.at_level("WARNING"):
             _run_suite(listener, tags=[GENERATIVE_OBSERVE_TAG], test_results=[False])
         assert db.get_decisions(SESSION) == []
@@ -346,9 +334,7 @@ class TestGenerativeListenerObserve:
     def test_nested_suite_tag_detected(self, clean_env, tmp_path):
         db = _seed_harness(tmp_path)
         provider = SyntheticProvider()
-        listener = GenerativeListener(
-            database_url=_db_url(tmp_path), provider=provider
-        )
+        listener = GenerativeListener(database_url=_db_url(tmp_path), provider=provider)
         root = SimpleNamespace(
             name="Root",
             tests=[],

--- a/tests/test_run_local_models.py
+++ b/tests/test_run_local_models.py
@@ -619,8 +619,7 @@ class TestRunModelSuitesPreflight:
                 "models": ["badmodel", "goodmodel"],
             },
         ]
-        with patch("scripts.run_local_models.random.shuffle", side_effect=lambda x: x):
-            results = run_model_suites(_preflight_config(), nodes)
+        results = run_model_suites(_preflight_config(), nodes)
 
         # One preflight-failure record + one real suite run.
         assert len(results) == 2


### PR DESCRIPTION
## Summary

Staging CI (Lint & Typecheck) has been red since #442/#443 merged: `scripts/run_local_models.py` contained both the old sequential loop and orphaned fragments of the new scheduler design — 19 ruff errors, 16 of them F821 undefined names. The script could not run at all.

## How to review

**Start here:** `scripts/run_local_models.py` — `run_model_suites` is reconstructed to what the docstring and #442's design intend: build `HostState`s + the global (model, suite) job queue, define the `_run` closure (preflight → command → dry-run/banner → subprocess), dispatch via `rfc.host_scheduler.run_jobs`.

**Key changes:**
- `run_model_suites` — single coherent implementation; preflight-skip, dry-run, env, and output-dir behavior preserved from both halves.
- `tests/test_run_local_models.py` — drops the `random.shuffle` patch (the shuffle is gone by design; scheduler affinity replaces it).
- Second commit: ruff-format-only normalization of 4 files merged unformatted by other PRs.

## Evidence of testing

- `uv run ruff check .` → All checks passed (was: 19 errors)
- `uv run pytest` → 3179 passed, 2 skipped
- `pre-commit run --all-files` → all hooks pass
- `make code-quality-check` → pass
- `python scripts/run_local_models.py --help` → script imports and runs again

## Critical changes

Restores `make run-local-models` / `run-all-external` to working order; no schema/API changes. Model-order shuffling no longer exists (replaced by loaded-model affinity scheduling from #442's own design).

## Checklist

- [x] All verification commands pass (output above)
- [x] Self-reviewed diff
- [x] Commits signed off per ai/GIT.md (rfc-engineering-agent + Model trailer)
- [x] No version bump: repairs #442's intended behavior, no new surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)