### PR TITLE
fix: sqlite3 URL fallback no longer creates missing DB directories (#439)

### DIFF
--- a/scripts/sync_skill_packs.py
+++ b/scripts/sync_skill_packs.py
@@ -55,9 +55,7 @@ class Skill:
 def load_manifest(path: Path) -> list[SkillPack]:
     data = yaml.safe_load(path.read_text())
     return [
-        SkillPack(
-            name=p["name"], path=p["path"], prefix=p["prefix"], glob=p["glob"]
-        )
+        SkillPack(name=p["name"], path=p["path"], prefix=p["prefix"], glob=p["glob"])
         for p in data.get("packs", [])
     ]
 
@@ -104,8 +102,7 @@ def plan_links(
             link_name = f"{pack.prefix}{skill.name}"
             if link_name in links:
                 print(
-                    f"WARN: duplicate skill name '{link_name}' "
-                    f"({skill.ident} skipped)",
+                    f"WARN: duplicate skill name '{link_name}' ({skill.ident} skipped)",
                     file=sys.stderr,
                 )
                 continue

--- a/src/rfc/harness_db.py
+++ b/src/rfc/harness_db.py
@@ -294,9 +294,10 @@ class _HarnessBackend(abc.ABC):
 class _SQLiteHarnessBackend(_HarnessBackend):
     """SQLite backend using the stdlib sqlite3 module."""
 
-    def __init__(self, db_path: str) -> None:
+    def __init__(self, db_path: str, *, create_missing_dir: bool = True) -> None:
         self.db_path = db_path
-        os.makedirs(os.path.dirname(db_path) or ".", exist_ok=True)
+        if create_missing_dir:
+            os.makedirs(os.path.dirname(db_path) or ".", exist_ok=True)
         with sqlite3.connect(db_path) as conn:
             conn.execute("PRAGMA foreign_keys = ON")
             conn.executescript(_SQLITE_SCHEMA)
@@ -1334,7 +1335,11 @@ class HarnessDatabase:
                 self._backend = _SQLAlchemyHarnessBackend(database_url)
             elif database_url.startswith("sqlite:///"):
                 sqlite_path = database_url.replace("sqlite:///", "")
-                self._backend = _SQLiteHarnessBackend(sqlite_path)
+                # Match SQLAlchemy semantics: a URL pointing into a missing
+                # directory is unreachable, not an invitation to mkdir (#439).
+                self._backend = _SQLiteHarnessBackend(
+                    sqlite_path, create_missing_dir=False
+                )
             else:
                 raise RuntimeError(
                     "SQLAlchemy is required for non-sqlite database URLs. "

--- a/tests/test_harness_db.py
+++ b/tests/test_harness_db.py
@@ -33,6 +33,31 @@ def harness_db(request, tmp_path):
     return HarnessDatabase(database_url=f"sqlite:///{db_file}")
 
 
+class TestMissingDirectory:
+    """sqlite3 fallback must not invent missing DB directories (#439).
+
+    The SQLAlchemy backend fails when the parent directory of a
+    sqlite:/// URL does not exist; the stdlib fallback silently created
+    it, so `rfc harness start` never hit its skip-and-log path in
+    environments without sqlalchemy.
+    """
+
+    def test_sqlite_url_fallback_fails_on_missing_dir(self, tmp_path, monkeypatch):
+        import rfc.harness_db as harness_db_module
+
+        monkeypatch.setattr(harness_db_module, "HAS_SQLALCHEMY", False)
+        missing = tmp_path / "no" / "such" / "dir"
+        with pytest.raises(sqlite3.OperationalError):
+            HarnessDatabase(database_url=f"sqlite:///{missing / 'x.db'}")
+        assert not missing.exists()
+
+    def test_explicit_db_path_still_creates_dir(self, tmp_path):
+        # Legacy fast path keeps its convenience behavior.
+        db_file = tmp_path / "made" / "for" / "you" / "harness.db"
+        HarnessDatabase(db_path=str(db_file))
+        assert db_file.exists()
+
+
 class TestSchema:
     def test_init_creates_tables(self, tmp_path):
         db_file = tmp_path / "harness.db"

--- a/tests/test_metrics_entrypoint.py
+++ b/tests/test_metrics_entrypoint.py
@@ -196,7 +196,9 @@ class TestSkipLogicWithXmlFixtures:
         return proc, dashboard
 
     def test_truncated_mid_element_is_skipped(self, tmp_path: Path) -> None:
-        proc, dashboard = self._run_with_fixture_xml(tmp_path, "truncated_mid_element.xml")
+        proc, dashboard = self._run_with_fixture_xml(
+            tmp_path, "truncated_mid_element.xml"
+        )
         assert proc.returncode == 0, proc.stderr
         assert "truncated" in proc.stdout.lower()
         assert not dashboard.exists()

--- a/tests/test_submodule_ownership.py
+++ b/tests/test_submodule_ownership.py
@@ -68,10 +68,14 @@ class TestEvaluateChanges:
     def test_human_may_bump_anything(self) -> None:
         changes = [
             GitlinkChange(
-                path="results", commit="abc1234", author_email="tyler.karcheski@gmail.com"
+                path="results",
+                commit="abc1234",
+                author_email="tyler.karcheski@gmail.com",
             ),
             GitlinkChange(
-                path="monitoring/logs", commit="def5678", author_email="someone@example.com"
+                path="monitoring/logs",
+                commit="def5678",
+                author_email="someone@example.com",
             ),
         ]
         assert evaluate_changes(changes) == []
@@ -80,7 +84,9 @@ class TestEvaluateChanges:
         # A gitlink not in the table has no owner, so no agent may bump it.
         changes = [
             GitlinkChange(
-                path="some/new/submodule", commit="abc1234", author_email="design@agents.rfc"
+                path="some/new/submodule",
+                commit="abc1234",
+                author_email="design@agents.rfc",
             )
         ]
         violations = evaluate_changes(changes)

--- a/tests/test_sync_skill_packs.py
+++ b/tests/test_sync_skill_packs.py
@@ -106,7 +106,9 @@ class TestPlanAndSync:
         assert "mp-tdd" in links
         assert "mp-qa" not in links  # ignored
         # targets are relative paths from .claude/skills/ into the pack
-        assert links["mp-tdd"] == Path("../../vendor/skill-packs/mattpocock/skills/engineering/tdd")
+        assert links["mp-tdd"] == Path(
+            "../../vendor/skill-packs/mattpocock/skills/engineering/tdd"
+        )
 
     def test_sync_creates_and_prunes_symlinks(self, repo: Path) -> None:
         pack = load_manifest(repo / "config" / "skill_packs.yaml")[0]


### PR DESCRIPTION
## Summary

Fixes #439: the stdlib sqlite3 backend ran `os.makedirs` unconditionally, so a `sqlite:///` URL pointing into a nonexistent directory "connected" successfully in environments without sqlalchemy — `rfc harness start` never hit its skip-and-log path, and `test_unreachable_db_still_writes_sidecar` failed. This is option (a) from the issue (fix the backend), per the heartbeat comment's recommendation.

## How to review

**Start here:** `src/rfc/harness_db.py` — `_SQLiteHarnessBackend.__init__` gains `create_missing_dir`; the `sqlite:///` URL fallback passes `False` to match SQLAlchemy semantics (missing parent dir = unreachable → `sqlite3.OperationalError`, caught by the CLI's skip-and-log). The explicit `db_path` legacy fast path keeps its directory-creating convenience.

**Key changes:**
- `tests/test_harness_db.py::TestMissingDirectory` — TDD pair: URL fallback must raise and must NOT create the directory (red before fix); explicit `db_path` still creates dirs.

**What to ignore:** second commit is ruff-format-only normalization of 4 files merged unformatted by other PRs.

## Evidence of testing

- TDD: `test_sqlite_url_fallback_fails_on_missing_dir` failed with DID NOT RAISE before the fix, passes after.
- `uv run pytest`: 3205 passed, 2 skipped (rebased onto staging with #455).
- `pre-commit run --all-files`: all hooks pass.
- `make code-quality-check`: pass.

## Critical changes

Behavioral: in sqlalchemy-less environments, `HarnessDatabase(database_url='sqlite:///<missing-dir>/x.db')` now raises instead of silently creating the directory — which is exactly what the harness CLI's skip-and-log expects, and what the SQLAlchemy backend already did. Explicit `db_path` callers are unaffected.

## Checklist

- [x] TDD — failing test first
- [x] All verification commands pass (output above)
- [x] Self-reviewed diff
- [x] Commits signed off per ai/GIT.md (rfc-engineering-agent + Model trailer)
- [x] No version bump: bug fix restoring documented behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)