### PR TITLE
fix: wait_until_ready treats target-model residency as ready (#464)

### DIFF
--- a/src/rfc/ollama.py
+++ b/src/rfc/ollama.py
@@ -26,6 +26,14 @@ def _check_model_not_found(
     response.raise_for_status()
 
 
+def _canonical_model_name(name: str) -> str:
+    """Normalize a model name so tag aliases compare equal ('m' == 'm:latest')."""
+    canon = name.strip().lower()
+    if ":" not in canon:
+        canon = f"{canon}:latest"
+    return canon
+
+
 def _compute_rate(count: Optional[int], duration_ns: Optional[int]) -> Optional[float]:
     """Compute tokens/s from token count and nanosecond duration."""
     if count is None or duration_ns is None or duration_ns <= 0:
@@ -353,8 +361,18 @@ class OllamaClient:
                 logger.info("Ollama is idle, no models running")
                 return True
 
-            # Log what's running
+            # Residency != busyness: Ollama keeps idle models loaded per
+            # keep_alive. If everything resident IS the model we're about to
+            # use, waiting for it to unload (only to cold-load it again) is a
+            # deadlock, not contention (#464).
             names = [m.get("name", "unknown") for m in models]
+            target = _canonical_model_name(self.model)
+            if all(_canonical_model_name(n) == target for n in names):
+                logger.info(
+                    f"Ollama ready: only the target model is resident "
+                    f"({', '.join(names)})"
+                )
+                return True
             if elapsed >= next_warn_at:
                 logger.warn(
                     f"Still waiting for Ollama after {elapsed}s — "

--- a/tests/test_dialog_e2e_keywords.py
+++ b/tests/test_dialog_e2e_keywords.py
@@ -117,7 +117,9 @@ class TestRunDialogFixtureSuite:
         assert env["DIALOG_DATABASE_URL"] == url
         assert all(url not in part for part in run.call_args[0][0])
 
-    def test_clears_stale_recording_bracket_env(self, kw, tmp_path, monkeypatch) -> None:
+    def test_clears_stale_recording_bracket_env(
+        self, kw, tmp_path, monkeypatch
+    ) -> None:
         monkeypatch.setenv(RECORDING_ENV_VAR, "stale-id")
         with patch(
             "rfc.dialog_e2e_keywords.subprocess.run",
@@ -144,7 +146,8 @@ class TestRunDialogFixtureSuite:
         proc.stderr = "[ WARN ] HarnessDatabase init failed: connection refused"
         with patch("rfc.dialog_e2e_keywords.subprocess.run", return_value=proc):
             result = kw.run_dialog_fixture_suite(
-                str(tmp_path / "child"), database_url="postgresql://bad:bad@127.0.0.1:9/x"
+                str(tmp_path / "child"),
+                database_url="postgresql://bad:bad@127.0.0.1:9/x",
             )
         assert result["rc"] == 0
         assert result["warning_found"] is True
@@ -154,7 +157,9 @@ class TestRunDialogFixtureSuite:
             "rfc.dialog_e2e_keywords.subprocess.run",
             return_value=self._completed(),
         ):
-            result = kw.run_dialog_fixture_suite(str(tmp_path / "child"), database_url="x")
+            result = kw.run_dialog_fixture_suite(
+                str(tmp_path / "child"), database_url="x"
+            )
         assert result["warning_found"] is False
 
 
@@ -189,8 +194,15 @@ class TestAssertDialogRecordingPersisted:
         )
         db.save_turns(
             [
-                DialogTurn(recording_id="rec-gap", turn_number=1, role="user", timestamp=T0),
-                DialogTurn(recording_id="rec-gap", turn_number=3, role="assistant", timestamp=T0),
+                DialogTurn(
+                    recording_id="rec-gap", turn_number=1, role="user", timestamp=T0
+                ),
+                DialogTurn(
+                    recording_id="rec-gap",
+                    turn_number=3,
+                    role="assistant",
+                    timestamp=T0,
+                ),
             ]
         )
         db.end_recording("rec-gap", T1)

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -358,6 +358,39 @@ class TestWaitUntilReady:
 
         assert OllamaClient(model="test-model").wait_until_ready(timeout=5) is True
 
+    @patch("rfc.ollama.logger")
+    @patch("rfc.ollama.requests.get")
+    def test_resident_target_is_ready(self, mock_get, mock_logger):
+        """Residency of the model under test is readiness, not contention (#464).
+
+        Ollama keeps idle models loaded per keep_alive; after a preflight
+        probe the target model is resident, and waiting for it to UNLOAD
+        deadlocks the run (it would only be cold-loaded again).
+        """
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "models": [{"name": "test-model", "size_vram": 1024}]
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        assert OllamaClient(model="test-model").wait_until_ready(timeout=5) is True
+
+    @patch("rfc.ollama.logger")
+    @patch("rfc.ollama.requests.get")
+    def test_resident_target_latest_alias_is_ready(self, mock_get, mock_logger):
+        """'m' and 'm:latest' are the same model for residency checks (#464)."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "models": [{"name": "test-model:latest", "size_vram": 1024}]
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        assert OllamaClient(model="test-model").wait_until_ready(timeout=5) is True
+
     def test_invalid_timeout(self):
         with pytest.raises(ValueError, match="timeout must be >= 1"):
             OllamaClient(model="test-model").wait_until_ready(timeout=0)


### PR DESCRIPTION
## Summary

Fixes #464 — the deadlock blocking the 1.14.x coverage matrix. `wait_until_ready` waited for `/api/ps` to be **empty**, but Ollama keeps idle models loaded per keep_alive: after #440's preflight probe, every suite stalled waiting for the model it was about to use to *unload* (only to cold-load it again), burning minutes to the full 90-min timeout per model.

## How to review

**Start here:** `src/rfc/ollama.py` — in `wait_until_ready`, after the empty-set check: if every resident model IS the target (tag-alias aware via the new `_canonical_model_name`, so `m` == `m:latest`), readiness, not contention. Other-model residency still waits — contention protection preserved.

**Key changes:**
- `tests/test_ollama.py` — TDD pair: target resident → ready immediately; `:latest` alias → ready. Both deadlocked-to-timeout before the fix.

**What to ignore:** trailing style commit (ruff-format normalization of one unrelated test file).

## Evidence of testing

- TDD: both new tests failed with `OllamaTimeoutError` before, pass after.
- `uv run pytest`: 3235 passed, 2 skipped.
- `pre-commit run --all-files` / `make code-quality-check`: pass.

## Critical changes

Behavioral: suites no longer wait for the target model to unload before starting. This is a prerequisite for #442's loaded-model-affinity scheduler (which makes target-resident the common case). Also explains/removes the historical 26-min "load waits" from #426's log. The killed coverage-matrix run can be relaunched once this merges.

## Checklist

- [x] TDD — failing tests first
- [x] All verification commands pass
- [x] Self-reviewed diff
- [x] Commits signed off per ai/GIT.md (rfc-engineering-agent + Model trailer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)