### PR TITLE
fix: skill-pack sync no longer prunes links of uninitialized packs (#453)

### DIFF
--- a/scripts/sync_skill_packs.py
+++ b/scripts/sync_skill_packs.py
@@ -89,6 +89,17 @@ def discover_skills(repo_root: Path, pack: SkillPack) -> list[Skill]:
     return skills
 
 
+def pack_is_initialized(repo_root: Path, pack: SkillPack) -> bool:
+    """Whether the pack's submodule is actually checked out.
+
+    A clone made without ``--recurse-submodules`` leaves the gitlink as an
+    existing-but-empty directory; planning against it yields zero links and
+    pruning would then delete every committed link for the pack (#453).
+    """
+    pack_root = repo_root / pack.path
+    return pack_root.is_dir() and next(pack_root.iterdir(), None) is not None
+
+
 def plan_links(
     repo_root: Path, packs: list[SkillPack], patterns: list[str]
 ) -> dict[str, Path]:
@@ -118,13 +129,19 @@ def plan_links(
 
 
 def sync_links(
-    skills_dir: Path, links: dict[str, Path], dry_run: bool = False
+    skills_dir: Path,
+    links: dict[str, Path],
+    dry_run: bool = False,
+    prune_prefixes: set[str] | None = None,
 ) -> tuple[list[str], list[str]]:
     """Create planned symlinks, prune pack-owned strays. Returns (created, pruned).
 
     A link is "pack-owned" (prunable) when it is a symlink pointing into
     vendor/skill-packs/ — real directories are never touched, so a local
-    skill that collides with a pack name always wins.
+    skill that collides with a pack name always wins. When *prune_prefixes*
+    is given, only links whose name carries one of those pack prefixes are
+    prune candidates — links of packs that are not initialized in this
+    checkout are left alone (#453).
     """
     created: list[str] = []
     pruned: list[str] = []
@@ -133,6 +150,10 @@ def sync_links(
             continue
         target = Path(entry.readlink())
         if "skill-packs" not in target.parts:
+            continue
+        if prune_prefixes is not None and not any(
+            pref and entry.name.startswith(pref) for pref in prune_prefixes
+        ):
             continue
         if entry.name not in links:
             if not dry_run:
@@ -169,8 +190,22 @@ def main(argv: list[str] | None = None) -> int:
     root = Path(args.root).resolve()
     packs = load_manifest(root / MANIFEST)
     patterns = load_ignore_patterns(root / SKILLIGNORE)
-    links = plan_links(root, packs, patterns)
-    created, pruned = sync_links(root / SKILLS_DIR, links, dry_run=args.dry_run)
+    active = [p for p in packs if pack_is_initialized(root, p)]
+    for pack in packs:
+        if pack not in active:
+            print(
+                f"WARN: pack '{pack.name}' is not initialized "
+                f"({pack.path} is empty) — skipping its links; run "
+                f"`git submodule update --init {pack.path}`",
+                file=sys.stderr,
+            )
+    links = plan_links(root, active, patterns)
+    created, pruned = sync_links(
+        root / SKILLS_DIR,
+        links,
+        dry_run=args.dry_run,
+        prune_prefixes={p.prefix for p in active},
+    )
 
     verb = "would create" if args.dry_run else "created"
     print(

--- a/tests/test_dialog_e2e_keywords.py
+++ b/tests/test_dialog_e2e_keywords.py
@@ -117,7 +117,9 @@ class TestRunDialogFixtureSuite:
         assert env["DIALOG_DATABASE_URL"] == url
         assert all(url not in part for part in run.call_args[0][0])
 
-    def test_clears_stale_recording_bracket_env(self, kw, tmp_path, monkeypatch) -> None:
+    def test_clears_stale_recording_bracket_env(
+        self, kw, tmp_path, monkeypatch
+    ) -> None:
         monkeypatch.setenv(RECORDING_ENV_VAR, "stale-id")
         with patch(
             "rfc.dialog_e2e_keywords.subprocess.run",
@@ -144,7 +146,8 @@ class TestRunDialogFixtureSuite:
         proc.stderr = "[ WARN ] HarnessDatabase init failed: connection refused"
         with patch("rfc.dialog_e2e_keywords.subprocess.run", return_value=proc):
             result = kw.run_dialog_fixture_suite(
-                str(tmp_path / "child"), database_url="postgresql://bad:bad@127.0.0.1:9/x"
+                str(tmp_path / "child"),
+                database_url="postgresql://bad:bad@127.0.0.1:9/x",
             )
         assert result["rc"] == 0
         assert result["warning_found"] is True
@@ -154,7 +157,9 @@ class TestRunDialogFixtureSuite:
             "rfc.dialog_e2e_keywords.subprocess.run",
             return_value=self._completed(),
         ):
-            result = kw.run_dialog_fixture_suite(str(tmp_path / "child"), database_url="x")
+            result = kw.run_dialog_fixture_suite(
+                str(tmp_path / "child"), database_url="x"
+            )
         assert result["warning_found"] is False
 
 
@@ -189,8 +194,15 @@ class TestAssertDialogRecordingPersisted:
         )
         db.save_turns(
             [
-                DialogTurn(recording_id="rec-gap", turn_number=1, role="user", timestamp=T0),
-                DialogTurn(recording_id="rec-gap", turn_number=3, role="assistant", timestamp=T0),
+                DialogTurn(
+                    recording_id="rec-gap", turn_number=1, role="user", timestamp=T0
+                ),
+                DialogTurn(
+                    recording_id="rec-gap",
+                    turn_number=3,
+                    role="assistant",
+                    timestamp=T0,
+                ),
             ]
         )
         db.end_recording("rec-gap", T1)

--- a/tests/test_sync_skill_packs.py
+++ b/tests/test_sync_skill_packs.py
@@ -146,3 +146,41 @@ class TestPlanAndSync:
         sync_links(skills_dir, links)
         created, pruned = sync_links(skills_dir, links)
         assert created == [] and pruned == []
+
+
+class TestUninitializedPack:
+    """A clone without --recurse-submodules must not nuke committed links (#453)."""
+
+    def test_pack_is_initialized(self, repo: Path) -> None:
+        from scripts.sync_skill_packs import pack_is_initialized
+
+        packs = load_manifest(repo / "config" / "skill_packs.yaml")
+        assert pack_is_initialized(repo, packs[0]) is True
+        # Uninitialized submodule == existing but empty directory
+        import shutil
+
+        pack_dir = repo / packs[0].path
+        shutil.rmtree(pack_dir)
+        pack_dir.mkdir(parents=True)
+        assert pack_is_initialized(repo, packs[0]) is False
+
+    def test_uninitialized_pack_preserves_committed_links(self, repo: Path) -> None:
+        """Empty pack dir → zero planned links → prune must NOT fire."""
+        import shutil
+
+        from scripts.sync_skill_packs import main
+
+        # First sync with the pack present creates the committed links.
+        assert main(["--root", str(repo)]) == 0
+        skills_dir = repo / ".claude" / "skills"
+        before = sorted(p.name for p in skills_dir.iterdir() if p.is_symlink())
+        assert before, "fixture should have created pack links"
+
+        # Simulate a fresh clone: submodule dir exists but is empty.
+        pack_dir = repo / "vendor" / "skill-packs" / "mattpocock"
+        shutil.rmtree(pack_dir)
+        pack_dir.mkdir(parents=True)
+
+        assert main(["--root", str(repo)]) == 0
+        after = sorted(p.name for p in skills_dir.iterdir() if p.is_symlink())
+        assert after == before, "links must survive an uninitialized pack"


### PR DESCRIPTION
## Summary

Fixes #453: in a clone without `--recurse-submodules`, the pack submodule directory is empty, discovery plans zero links, and `sync_links` deleted **all 29 committed `mp-*` symlinks** as strays.

## How to review

**Start here:** `scripts/sync_skill_packs.py` — new `pack_is_initialized` (existing-but-empty dir = not initialized); `main()` skips uninitialized packs with a WARN naming the `git submodule update --init` command; `sync_links` gains `prune_prefixes` so only initialized packs' links are prune candidates.

**Key changes:**
- `tests/test_sync_skill_packs.py::TestUninitializedPack` — TDD pair: unit test for the initialization check; integration test proving committed links survive a sync against an empty pack dir (failed with 'links must survive' before the fix).

## Evidence of testing

- TDD red→green; `uv run pytest`: 3235 passed, 2 skipped.
- `pre-commit run --all-files` / `make code-quality-check`: pass.

## Critical changes

Behavioral: `sync` in a partially-initialized checkout is now conservative (warns + leaves links) instead of destructive. Fully-initialized checkouts behave identically.

## Checklist

- [x] TDD — failing tests first
- [x] All verification commands pass
- [x] Self-reviewed diff
- [x] Commits signed off per ai/GIT.md (rfc-engineering-agent + Model trailer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)