### PR TITLE
fix: init RECORDING_ID before skip guards in dialog e2e suite (#461)

### DIFF
--- a/robot/dialog/tests/dialog_recorder_e2e.robot
+++ b/robot/dialog/tests/dialog_recorder_e2e.robot
@@ -27,12 +27,14 @@ ${DEAD_DB_URL}        postgresql://rfc:wrong@127.0.0.1:9/rfc_unreachable
 Dialog Recording Persists End To End
     [Documentation]    Child robot run with DialogListener writes the
     ...    recording and all turns to the database at DATABASE_URL.
+    # Init before any Skip If: Robot runs the teardown for skipped tests
+    # too, and Cleanup Recording dereferences ${RECORDING_ID} (#461).
+    ${RECORDING_ID}=    Set Variable    ${EMPTY}
+    Set Test Variable    ${RECORDING_ID}
     ${db_url}=    Set Variable    %{DATABASE_URL=}
     Skip If    "${db_url}" == ""    DATABASE_URL not set — skipping live database e2e check
     ${reachable}=    DialogE2E.Dialog Database Reachable    ${db_url}
     Skip If    not ${reachable}    Database at DATABASE_URL is unreachable
-    ${RECORDING_ID}=    Set Variable    ${EMPTY}
-    Set Test Variable    ${RECORDING_ID}
     ${run}=    DialogE2E.Run Dialog Fixture Suite
     ...    ${OUTPUT DIR}${/}dialog_e2e_child    database_url=${db_url}
     Set Test Variable    ${RECORDING_ID}    ${run}[recording_id]


### PR DESCRIPTION
## Summary

Fixes #461: Robot runs the test teardown even for SKIPped tests; `Cleanup Recording` dereferences `${RECORDING_ID}`, which was only created after the two `Skip If` guards — so the intended skip-and-log path errored with `Also teardown failed: Variable '${RECORDING_ID}' not found`.

## How to review

**Start here:** `robot/dialog/tests/dialog_recorder_e2e.robot` — the two-line init moves above the `Skip If` guards. That's the whole change.

## Evidence of testing

Ran the suite with `DATABASE_URL` unset, before and after, and compared `output.xml`:
- **Before:** test SKIP, teardown **FAIL** (`Variable '${RECORDING_ID}' not found`)
- **After:** test SKIP, teardown **PASS**
- `make robot-dryrun`: 0 errors; pre-commit clean.

## Critical changes

None — test-suite-only ordering fix.

## Checklist

- [x] Verified red→green via output.xml teardown status
- [x] robot-dryrun + pre-commit pass
- [x] Commit signed off per ai/GIT.md (rfc-engineering-agent + Model trailer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)