### PR TITLE
fix: make top-level pack links eligible for pruning (#463)

### DIFF
--- a/scripts/sync_skill_packs.py
+++ b/scripts/sync_skill_packs.py
@@ -55,9 +55,7 @@ class Skill:
 def load_manifest(path: Path) -> list[SkillPack]:
     data = yaml.safe_load(path.read_text())
     return [
-        SkillPack(
-            name=p["name"], path=p["path"], prefix=p["prefix"], glob=p["glob"]
-        )
+        SkillPack(name=p["name"], path=p["path"], prefix=p["prefix"], glob=p["glob"])
         for p in data.get("packs", [])
     ]
 
@@ -104,8 +102,7 @@ def plan_links(
             link_name = f"{pack.prefix}{skill.name}"
             if link_name in links:
                 print(
-                    f"WARN: duplicate skill name '{link_name}' "
-                    f"({skill.ident} skipped)",
+                    f"WARN: duplicate skill name '{link_name}' ({skill.ident} skipped)",
                     file=sys.stderr,
                 )
                 continue
@@ -121,21 +118,37 @@ def plan_links(
 
 
 def sync_links(
-    skills_dir: Path, links: dict[str, Path], dry_run: bool = False
+    skills_dir: Path,
+    links: dict[str, Path],
+    dry_run: bool = False,
+    pack_roots: list[Path] | None = None,
 ) -> tuple[list[str], list[str]]:
     """Create planned symlinks, prune pack-owned strays. Returns (created, pruned).
 
-    A link is "pack-owned" (prunable) when it is a symlink pointing into
-    vendor/skill-packs/ — real directories are never touched, so a local
-    skill that collides with a pack name always wins.
+    A link is "pack-owned" (prunable) when it is a symlink whose target
+    resolves under one of *pack_roots* (absolute pack checkout paths) —
+    real directories are never touched, so a local skill that collides
+    with a pack name always wins. Without *pack_roots* the legacy
+    heuristic applies: targets containing a skill-packs path component.
+    Packs mounted outside vendor/skill-packs/ (e.g. the top-level
+    knowledge brain) are only prunable via *pack_roots* (#463).
     """
+
+    def _pack_owned(target: Path) -> bool:
+        if pack_roots is None:
+            return "skill-packs" in target.parts
+        resolved = (
+            (skills_dir / target).resolve() if not target.is_absolute() else target
+        )
+        return any(resolved.is_relative_to(root) for root in pack_roots)
+
     created: list[str] = []
     pruned: list[str] = []
     for entry in sorted(skills_dir.iterdir() if skills_dir.exists() else []):
         if not entry.is_symlink():
             continue
         target = Path(entry.readlink())
-        if "skill-packs" not in target.parts:
+        if not _pack_owned(target):
             continue
         if entry.name not in links:
             if not dry_run:
@@ -173,7 +186,10 @@ def main(argv: list[str] | None = None) -> int:
     packs = load_manifest(root / MANIFEST)
     patterns = load_ignore_patterns(root / SKILLIGNORE)
     links = plan_links(root, packs, patterns)
-    created, pruned = sync_links(root / SKILLS_DIR, links, dry_run=args.dry_run)
+    pack_roots = [(root / p.path).resolve() for p in packs]
+    created, pruned = sync_links(
+        root / SKILLS_DIR, links, dry_run=args.dry_run, pack_roots=pack_roots
+    )
 
     verb = "would create" if args.dry_run else "created"
     print(

--- a/tests/test_sync_skill_packs.py
+++ b/tests/test_sync_skill_packs.py
@@ -106,7 +106,9 @@ class TestPlanAndSync:
         assert "mp-tdd" in links
         assert "mp-qa" not in links  # ignored
         # targets are relative paths from .claude/skills/ into the pack
-        assert links["mp-tdd"] == Path("../../vendor/skill-packs/mattpocock/skills/engineering/tdd")
+        assert links["mp-tdd"] == Path(
+            "../../vendor/skill-packs/mattpocock/skills/engineering/tdd"
+        )
 
     def test_sync_creates_and_prunes_symlinks(self, repo: Path) -> None:
         pack = load_manifest(repo / "config" / "skill_packs.yaml")[0]
@@ -144,3 +146,43 @@ class TestPlanAndSync:
         sync_links(skills_dir, links)
         created, pruned = sync_links(skills_dir, links)
         assert created == [] and pruned == []
+
+
+class TestTopLevelPackPruning:
+    """Links of packs mounted outside vendor/skill-packs/ must be prunable (#463)."""
+
+    @pytest.fixture()
+    def knowledge_repo(self, tmp_path: Path) -> Path:
+        (tmp_path / ".claude" / "skills").mkdir(parents=True)
+        (tmp_path / "config").mkdir(exist_ok=True)
+        (tmp_path / "config" / "skill_packs.yaml").write_text(
+            "packs:\n"
+            "  - name: knowledge\n"
+            "    path: knowledge\n"
+            '    prefix: ""\n'
+            '    glob: "skills/*/SKILL.md"\n'
+            "    upstream: https://github.com/tkarcheski/knowledge\n"
+            "    fork: git@github.com:tkarcheski/knowledge.git\n"
+        )
+        for name in ["writing-prose", "tiered-recall"]:
+            d = tmp_path / "knowledge" / "skills" / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(f"# {name}\n")
+        return tmp_path
+
+    def test_removed_knowledge_skill_link_is_pruned(self, knowledge_repo: Path) -> None:
+        import shutil
+
+        from scripts.sync_skill_packs import main
+
+        assert main(["--root", str(knowledge_repo)]) == 0
+        skills_dir = knowledge_repo / ".claude" / "skills"
+        assert (skills_dir / "writing-prose").is_symlink()
+
+        # The skill disappears upstream; the committed link must be pruned.
+        shutil.rmtree(knowledge_repo / "knowledge" / "skills" / "writing-prose")
+        assert main(["--root", str(knowledge_repo)]) == 0
+        assert not (skills_dir / "writing-prose").is_symlink(), (
+            "stale (broken) link of a top-level pack must be pruned"
+        )
+        assert (skills_dir / "tiered-recall").is_symlink()


### PR DESCRIPTION
## Summary

Fixes #463 **on the #447 stack** (where the knowledge pack lives — targets `feat/447-skill-packs`, not staging). `sync_links` only treated targets containing a `skill-packs` path component as pack-owned, so the top-level `knowledge` pack's links were invisible to pruning: a skill removed/renamed/excluded upstream left a broken committed `.claude/skills/<name>` symlink behind.

## How to review

**Start here:** `scripts/sync_skill_packs.py` — `sync_links` gains `pack_roots`; a link is pack-owned when its target resolves under any configured pack checkout root. `main()` passes the resolved roots. Without `pack_roots` the legacy heuristic applies (back-compat).

**Key changes:**
- `tests/test_sync_skill_packs.py::TestTopLevelPackPruning` — TDD: knowledge-shaped fixture (top-level path, empty prefix); removing a skill upstream must prune the stale broken link. Red before (`is_symlink` leftover), green after.

## Evidence of testing

- `uv run pytest tests/test_sync_skill_packs.py`: 10 passed.
- Full pytest: 13 pre-existing failures in `tests/test_run_local_models.py` — the #442 breakage this stack inherited, already fixed on staging by #455; **merging staging into this stack clears them** (unrelated to this change).
- pre-commit on changed files: pass.

## Merge-order note

My #453 fix (PR #475, staging) also touches `sync_links` (adds `prune_prefixes` for uninitialized-pack safety). When this stack merges with staging, the two guards should compose: prune candidates = under an **initialized** pack's root. Happy to do that unification PR after either side lands.

## Checklist

- [x] TDD — failing test first
- [x] Targeted suite green; inherited failures explained above
- [x] Self-reviewed diff
- [x] Commit signed off per ai/GIT.md (rfc-engineering-agent + Model trailer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)