### PR TITLE
fix: align ruff at 0.14.10 and gate formatting in CI (#478)

### DIFF
--- a/.github/workflows/robot-tests.yml
+++ b/.github/workflows/robot-tests.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Ruff check
         run: uv run ruff check .
 
+      - name: Ruff format check
+        run: uv run ruff format --check .
+
       - name: Mypy
         run: uv run mypy src/
 

--- a/ai/test-plans/PR-481.md
+++ b/ai/test-plans/PR-481.md
@@ -1,0 +1,45 @@
+# Test Plan — PR #481: align ruff at 0.14.10 and gate formatting in CI (#478)
+
+- **PR:** #481 (`fix/478-ruff-format-drift` → `claude-code-staging`)
+- **Linked issue:** #478 — ruff-format drift on staging; 4 files fail `pre-commit run --all-files` on a clean checkout
+- **Diff under test:** `pyproject.toml` (pin `ruff==0.14.10`), `tests/test_dialog_e2e_keywords.py` (reformat), `.github/workflows/robot-tests.yml` (new `ruff format --check .` step)
+- **Author:** test-design role
+- **PR head at plan time:** 3ecbb0a
+
+## Intent check
+
+Issue #478 asks for (a) the drift fixed and (b) prevention. The diff claims the *root cause* is
+two formatters at different versions (pre-commit hook pinned v0.14.10, pyproject `ruff` unpinned
+→ 0.15.x) and fixes it by pinning pyproject to the hook's version, reformatting the one file that
+genuinely drifts under 0.14.10, and adding a CI format gate. The PR also claims the issue's
+"4 files" count was an artifact of checking with unpinned 0.15.17. Both claims are empirically
+testable — see C2. Note the repo has **no `uv.lock`**, so the pyproject pin takes effect on the
+next `uv run`/`uv sync` with nothing else to regenerate.
+
+## Cases
+
+| ID | Case | Steps | Expected | How |
+|---|---|---|---|---|
+| C1 | Intent / diff review | Read full diff vs merge base; confirm scope = pin + reformat + CI gate, nothing unrelated | Diff matches issue intent; no stray changes | manual review |
+| C2 | Root-cause claim | At base `2258e88`: `uvx ruff@0.14.10 format --check` the 4 issue files; repeat with `ruff@0.15.17` | 0.14.10 flags only `tests/test_dialog_e2e_keywords.py`; 0.15.17 flags more — validates the PR's version-skew explanation. If 0.14.10 flags files the PR does not fix, that is a FAIL (drift remains after merge) | manual command |
+| C3 | Pin effective | On PR branch: `uv run ruff --version` | `ruff 0.14.10` (was 0.15.x unpinned) | manual command |
+| C4 | Format clean (happy path) | On PR branch: `uv run ruff format --check .` | exit 0, no files would be reformatted | manual command |
+| C5 | Hook parity | On PR branch: `uv run pre-commit run ruff-format --all-files` and `uv run pre-commit run ruff --all-files` | both pass — hook (v0.14.10) and CLI (0.14.10) agree, the recurrence loop is closed | manual command |
+| C6 | CI gate wiring | Parse `.github/workflows/robot-tests.yml`; locate new step | valid YAML; step lives in the same Lint & Typecheck job, after deps install, running exactly `uv run ruff format --check .` (same command a dev runs locally) | manual review + YAML parse |
+| C7 | Gate fails on drift (negative) | Introduce deliberate drift in a tracked `.py` file; run `uv run ruff format --check .`; revert | non-zero exit naming the file — the gate actually blocks drift, not just decorates the workflow | manual command |
+| C8 | Forward-merge safety (edge) | In a scratch detached worktree: merge current `origin/claude-code-staging` into PR head; `uv run ruff format --check .` on the merge result | exit 0 — the new gate must not fail its own PR once staging's post-base commits are merged in | manual command |
+| C9 | Regression: full suite | On PR branch: `uv run pytest -q` and `uv run ruff check .` | pytest fully green (≈3233 passed, 2 skipped — the #456 `import random` failure does **not** exist at base `2258e88`, verified: no `random.` usage in `tests/test_run_local_models.py` there); ruff check exit 0 under the pinned version | existing tests |
+| C10 | Version-alignment guard (new test) | Write `tests/test_tooling_alignment.py`: parse the `ruff==X` pin from `pyproject.toml` `dev` extras and the `astral-sh/ruff-pre-commit` `rev: vX` from `.pre-commit-config.yaml`; assert equal. Also assert the CI workflow contains a `ruff format --check` step | New test passes on PR branch; would have failed on staging before this PR (unpinned ≠ pinned hook); guards the exact recurrence class #478 describes | new automated test, committed to PR branch |
+
+## Regression surface
+
+- Pinning `ruff==0.14.10` could break `ruff check` (lint, not just format) if staging code relies
+  on 0.15.x behavior — covered by C9.
+- The new CI step runs on every PR; if any file on current staging drifts under 0.14.10, every
+  subsequent PR goes red — covered by C2 (residual drift) and C8 (merge result).
+- No `uv.lock` exists, so no lockfile staleness risk.
+
+## Out of scope
+
+- Live CI execution of the workflow (asserted structurally in C6; the gate command itself is
+  exercised in C4/C7).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ swebench = [
 dev = [
     "pre-commit",
     "python-dotenv",
-    "ruff",
+    "ruff==0.14.10",
     "mypy",
     "types-requests",
     "types-PyYAML",

--- a/tests/test_dialog_e2e_keywords.py
+++ b/tests/test_dialog_e2e_keywords.py
@@ -117,7 +117,9 @@ class TestRunDialogFixtureSuite:
         assert env["DIALOG_DATABASE_URL"] == url
         assert all(url not in part for part in run.call_args[0][0])
 
-    def test_clears_stale_recording_bracket_env(self, kw, tmp_path, monkeypatch) -> None:
+    def test_clears_stale_recording_bracket_env(
+        self, kw, tmp_path, monkeypatch
+    ) -> None:
         monkeypatch.setenv(RECORDING_ENV_VAR, "stale-id")
         with patch(
             "rfc.dialog_e2e_keywords.subprocess.run",
@@ -144,7 +146,8 @@ class TestRunDialogFixtureSuite:
         proc.stderr = "[ WARN ] HarnessDatabase init failed: connection refused"
         with patch("rfc.dialog_e2e_keywords.subprocess.run", return_value=proc):
             result = kw.run_dialog_fixture_suite(
-                str(tmp_path / "child"), database_url="postgresql://bad:bad@127.0.0.1:9/x"
+                str(tmp_path / "child"),
+                database_url="postgresql://bad:bad@127.0.0.1:9/x",
             )
         assert result["rc"] == 0
         assert result["warning_found"] is True
@@ -154,7 +157,9 @@ class TestRunDialogFixtureSuite:
             "rfc.dialog_e2e_keywords.subprocess.run",
             return_value=self._completed(),
         ):
-            result = kw.run_dialog_fixture_suite(str(tmp_path / "child"), database_url="x")
+            result = kw.run_dialog_fixture_suite(
+                str(tmp_path / "child"), database_url="x"
+            )
         assert result["warning_found"] is False
 
 
@@ -189,8 +194,15 @@ class TestAssertDialogRecordingPersisted:
         )
         db.save_turns(
             [
-                DialogTurn(recording_id="rec-gap", turn_number=1, role="user", timestamp=T0),
-                DialogTurn(recording_id="rec-gap", turn_number=3, role="assistant", timestamp=T0),
+                DialogTurn(
+                    recording_id="rec-gap", turn_number=1, role="user", timestamp=T0
+                ),
+                DialogTurn(
+                    recording_id="rec-gap",
+                    turn_number=3,
+                    role="assistant",
+                    timestamp=T0,
+                ),
             ]
         )
         db.end_recording("rec-gap", T1)

--- a/tests/test_tooling_alignment.py
+++ b/tests/test_tooling_alignment.py
@@ -1,0 +1,62 @@
+"""Guard against ruff version skew between pyproject and pre-commit (#478).
+
+The drift in issue #478 recurred because two formatters ran at different
+versions: the ``ruff-pre-commit`` hook was pinned while the ``ruff`` dev
+dependency floated. PR #481 aligned them; these tests fail loudly if either
+side is ever bumped without the other, or if the CI format gate is removed.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _pyproject_ruff_pin() -> str:
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    dev_deps = data["project"]["optional-dependencies"]["dev"]
+    ruff_specs = [d for d in dev_deps if re.match(r"ruff\s*(==|$)", d)]
+    assert ruff_specs, "no 'ruff' entry in [project.optional-dependencies].dev"
+    spec = ruff_specs[0]
+    match = re.fullmatch(r"ruff\s*==\s*([\d.]+)", spec)
+    assert match, f"ruff dev dependency is not exact-pinned: {spec!r} (see #478)"
+    return match.group(1)
+
+
+def _precommit_ruff_rev() -> str:
+    config = yaml.safe_load((REPO_ROOT / ".pre-commit-config.yaml").read_text())
+    revs = [
+        repo["rev"]
+        for repo in config["repos"]
+        if "ruff-pre-commit" in repo.get("repo", "")
+    ]
+    assert revs, "no ruff-pre-commit repo in .pre-commit-config.yaml"
+    return revs[0].lstrip("v")
+
+
+def test_ruff_pin_matches_precommit_hook() -> None:
+    """pyproject's ruff pin and the pre-commit hook rev must be identical."""
+    assert _pyproject_ruff_pin() == _precommit_ruff_rev(), (
+        "ruff version skew: pyproject and .pre-commit-config.yaml disagree — "
+        "bump both together or format drift recurs (#478)"
+    )
+
+
+def test_ci_runs_ruff_format_check() -> None:
+    """The lint workflow must keep the `ruff format --check .` gate (#478)."""
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github" / "workflows" / "robot-tests.yml").read_text()
+    )
+    commands = [
+        step.get("run", "")
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", [])
+    ]
+    assert any(re.search(r"ruff format --check", cmd) for cmd in commands), (
+        "CI no longer runs 'ruff format --check' — the #478 drift gate was removed"
+    )


### PR DESCRIPTION
## Summary

Fixes #478 at the root. The drift kept recurring because two different formatters disagree: `pyproject.toml` left `ruff` unpinned (resolves 0.15.17 today) while pre-commit pins `v0.14.10`. Each tool 'fixes' the other's output, so `style:` commits reappeared after every few merges.

## How to review

**Key changes:**
- `pyproject.toml` — `ruff==0.14.10`, matching the pre-commit hook (the conservative direction: no new formatting decisions; bumping both to 0.15.x can be a deliberate follow-up).
- `tests/test_dialog_e2e_keywords.py` — the one file actually drifted under the pinned version.
- `.github/workflows/robot-tests.yml` — new `ruff format --check .` step in Lint & Typecheck, the prevention half the issue asked for: drift now fails the PR that introduces it.

**Note:** the issue listed 4 files — that count came from `ruff format --check` under the *unpinned* 0.15.17; under the pre-commit-pinned 0.14.10 only one file was genuinely drifted. The version alignment resolves the discrepancy itself.

## Evidence of testing

- `pre-commit run --all-files`: **all hooks pass** (including ruff-format) — the gate from ai/agents.md rule 4 is green on a clean checkout again.
- `uv run ruff format --check .`: 288 files already formatted.
- `uv run pytest`: 3233 passed, 2 skipped; `make code-quality-check`: pass.

## Critical changes

CI behavior: PRs introducing format drift now fail Lint & Typecheck. In-flight branches carrying their own `style:` commits (e.g. #466/#475) may trivially conflict on formatting — both sides are identical reformats.

## Checklist

- [x] All verification commands pass
- [x] Self-reviewed diff
- [x] Commit signed off per ai/GIT.md (rfc-engineering-agent + Model trailer)
- [x] No version bump: tooling/CI hygiene

🤖 Generated with [Claude Code](https://claude.com/claude-code)