### PR TITLE
fix: aggregate textual assistant turns as the replay grading reference (#485)

### DIFF
--- a/scripts/import_hf_benchmark.py
+++ b/scripts/import_hf_benchmark.py
@@ -88,9 +88,7 @@ def fetch_rows(
     return rows[:max_rows]
 
 
-def convert_ifeval_rows(
-    rows: List[Dict[str, Any]], limit: int
-) -> List[Dict[str, Any]]:
+def convert_ifeval_rows(rows: List[Dict[str, Any]], limit: int) -> List[Dict[str, Any]]:
     """Convert raw google/IFEval rows to committed test items.
 
     Keeps only items whose instructions are ALL gradable by

--- a/src/rfc/dialog_replay.py
+++ b/src/rfc/dialog_replay.py
@@ -93,13 +93,21 @@ class ReplayResult:
 
 
 def _original_response_for(turns: list[DialogTurn], user_index: int) -> str:
-    """The first assistant turn following ``turns[user_index]``, or ''."""
+    """The complete textual assistant response after ``turns[user_index]``.
+
+    Imported Claude Code sessions keep assistant turns that contain only
+    ``tool_use`` blocks (``content=""``); a coding turn typically starts
+    with one. Grading against that empty turn corrupts the scores (#485),
+    so all textual assistant content up to the next user turn is
+    aggregated instead — tool-only turns contribute nothing.
+    """
+    parts: list[str] = []
     for turn in turns[user_index + 1 :]:
-        if turn.role == "assistant":
-            return turn.content
         if turn.role == "user":
             break
-    return ""
+        if turn.role == "assistant" and turn.content.strip():
+            parts.append(turn.content)
+    return "\n\n".join(parts)
 
 
 def _provider_token_counts(provider: LLMProvider) -> tuple[int, int]:

--- a/tests/test_dialog_replay_prompt.py
+++ b/tests/test_dialog_replay_prompt.py
@@ -410,3 +410,51 @@ class TestReplayCli:
         monkeypatch.delenv("DIALOG_DATABASE_URL", raising=False)
         rc = main(["dialog", "replay", "rec", "--target-model", "m"])
         assert rc == 2
+
+
+class TestOriginalResponseSelection:
+    """Tool-only assistant turns must not become the grading reference (#485)."""
+
+    def _turn(self, number, role, content):
+        return DialogTurn(
+            recording_id="rec-ref",
+            turn_number=number,
+            role=role,
+            timestamp=f"2026-06-12T00:01:{number:02d}Z",
+            content=content,
+        )
+
+    def test_skips_tool_only_assistant_turn(self):
+        from rfc.dialog_replay import _original_response_for
+
+        turns = [
+            self._turn(1, "user", "do the thing"),
+            self._turn(2, "assistant", ""),  # tool_use-only turn (#485)
+            self._turn(3, "assistant", "the real textual answer"),
+            self._turn(4, "user", "next question"),
+        ]
+        assert _original_response_for(turns, 0) == "the real textual answer"
+
+    def test_aggregates_multi_part_assistant_response(self):
+        from rfc.dialog_replay import _original_response_for
+
+        turns = [
+            self._turn(1, "user", "do the thing"),
+            self._turn(2, "assistant", "first I will look"),
+            self._turn(3, "assistant", ""),  # tool call in between
+            self._turn(4, "assistant", "here is the result"),
+            self._turn(5, "user", "next"),
+        ]
+        assert _original_response_for(turns, 0) == (
+            "first I will look\n\nhere is the result"
+        )
+
+    def test_all_tool_only_yields_empty(self):
+        from rfc.dialog_replay import _original_response_for
+
+        turns = [
+            self._turn(1, "user", "do the thing"),
+            self._turn(2, "assistant", ""),
+            self._turn(3, "user", "next"),
+        ]
+        assert _original_response_for(turns, 0) == ""

--- a/tests/test_feedback_first_policy_docs.py
+++ b/tests/test_feedback_first_policy_docs.py
@@ -29,9 +29,7 @@ class TestEngineeringPrompt:
         text = _read(".claude/agents/engineering.md")
         assert "Service your open PRs FIRST" in text
         # step 0 must come before the queue pull
-        assert text.index("Service your open PRs FIRST") < text.index(
-            "Pull the queue"
-        )
+        assert text.index("Service your open PRs FIRST") < text.index("Pull the queue")
         assert "TEST-PLAN: FAIL" in text
         assert "gh pr checks" in text
 

--- a/tests/test_submodule_ownership.py
+++ b/tests/test_submodule_ownership.py
@@ -141,7 +141,9 @@ class TestKnowledgeOwnership:
     def test_knowledge_bump_by_other_agent_rejected(self) -> None:
         changes = [
             GitlinkChange(
-                path="knowledge", commit="abc1234", author_email="test-design@agents.rfc"
+                path="knowledge",
+                commit="abc1234",
+                author_email="test-design@agents.rfc",
             )
         ]
         violations = evaluate_changes(changes)


### PR DESCRIPTION
## Summary

Fixes #485 (P1): `_original_response_for` took the FIRST assistant turn after the user prompt — for imported Claude Code sessions that's typically a `tool_use`-only turn with `content=''`, so prompt-mode replays graded real model responses against an **empty reference**, corrupting per-turn scores and the aggregate outcome for most coding sessions.

## How to review

**Start here:** `src/rfc/dialog_replay.py::_original_response_for` — now aggregates all textual assistant content up to the next user turn (\n\n-joined); tool-only turns contribute nothing.

**Key changes:**
- `tests/test_dialog_replay_prompt.py::TestOriginalResponseSelection` — TDD triplet: tool-only first turn skipped; multi-part response aggregated; all-tool-only still yields '' (red before, green after).

## Evidence of testing

- TDD red→green; `uv run pytest`: 3451 passed, 3 skipped.
- `pre-commit run --all-files` / `make code-quality-check`: pass.

## Critical changes

Grading semantics: references for multi-part responses now include ALL textual parts, not just the first — strictly more faithful to what the original assistant said. Existing single-text-turn recordings are unaffected.

## Checklist

- [x] TDD — failing tests first
- [x] All verification commands pass
- [x] Self-reviewed diff
- [x] Commits signed off per ai/GIT.md (rfc-engineering-agent + Model trailer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)