### PR TITLE
fix: gate ALL pre-commit hooks in CI and align mypy versions (#496)

### DIFF
--- a/.github/workflows/robot-tests.yml
+++ b/.github/workflows/robot-tests.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Mypy
         run: uv run mypy src/
 
+      - name: Pre-commit (all hooks, all files)
+        run: uv run pre-commit run --all-files --show-diff-on-failure
+
       - name: Pytest with coverage
         run: uv run pytest --cov --cov-report=term-missing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dev = [
     "pre-commit",
     "python-dotenv",
     "ruff==0.14.10",
-    "mypy",
+    "mypy==1.10.0",
     "types-requests",
     "types-PyYAML",
     "types-docker",

--- a/scripts/import_hf_benchmark.py
+++ b/scripts/import_hf_benchmark.py
@@ -88,9 +88,7 @@ def fetch_rows(
     return rows[:max_rows]
 
 
-def convert_ifeval_rows(
-    rows: List[Dict[str, Any]], limit: int
-) -> List[Dict[str, Any]]:
+def convert_ifeval_rows(rows: List[Dict[str, Any]], limit: int) -> List[Dict[str, Any]]:
     """Convert raw google/IFEval rows to committed test items.
 
     Keeps only items whose instructions are ALL gradable by

--- a/tests/test_feedback_first_policy_docs.py
+++ b/tests/test_feedback_first_policy_docs.py
@@ -29,9 +29,7 @@ class TestEngineeringPrompt:
         text = _read(".claude/agents/engineering.md")
         assert "Service your open PRs FIRST" in text
         # step 0 must come before the queue pull
-        assert text.index("Service your open PRs FIRST") < text.index(
-            "Pull the queue"
-        )
+        assert text.index("Service your open PRs FIRST") < text.index("Pull the queue")
         assert "TEST-PLAN: FAIL" in text
         assert "gh pr checks" in text
 

--- a/tests/test_submodule_ownership.py
+++ b/tests/test_submodule_ownership.py
@@ -141,7 +141,9 @@ class TestKnowledgeOwnership:
     def test_knowledge_bump_by_other_agent_rejected(self) -> None:
         changes = [
             GitlinkChange(
-                path="knowledge", commit="abc1234", author_email="test-design@agents.rfc"
+                path="knowledge",
+                commit="abc1234",
+                author_email="test-design@agents.rfc",
             )
         ]
         violations = evaluate_changes(changes)

--- a/tests/test_tooling_alignment.py
+++ b/tests/test_tooling_alignment.py
@@ -60,3 +60,56 @@ def test_ci_runs_ruff_format_check() -> None:
     assert any(re.search(r"ruff format --check", cmd) for cmd in commands), (
         "CI no longer runs 'ruff format --check' — the #478 drift gate was removed"
     )
+
+
+def _pyproject_pin(package: str) -> str:
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    dev_deps = data["project"]["optional-dependencies"]["dev"]
+    specs = [d for d in dev_deps if re.match(rf"{package}\s*(==|$)", d)]
+    assert specs, f"no {package!r} entry in [project.optional-dependencies].dev"
+    match = re.fullmatch(rf"{package}\s*==\s*([\d.]+)", specs[0])
+    assert match, (
+        f"{package} dev dependency is not exact-pinned: {specs[0]!r} (see #496)"
+    )
+    return match.group(1)
+
+
+def _precommit_rev(repo_fragment: str) -> str:
+    config = yaml.safe_load((REPO_ROOT / ".pre-commit-config.yaml").read_text())
+    revs = [
+        repo["rev"] for repo in config["repos"] if repo_fragment in repo.get("repo", "")
+    ]
+    assert revs, f"no {repo_fragment!r} repo in .pre-commit-config.yaml"
+    return revs[0].lstrip("v")
+
+
+def test_mypy_pin_matches_precommit_hook() -> None:
+    """pyproject's mypy pin and the mirrors-mypy hook rev must match (#496).
+
+    Same two-tools-two-versions skew class as #478: CI runs the dev
+    dependency while pre-commit runs the pinned mirror — if they drift,
+    one gate's 'clean' is the other's 'broken'.
+    """
+    assert _pyproject_pin("mypy") == _precommit_rev("mirrors-mypy"), (
+        "mypy version skew: pyproject and .pre-commit-config.yaml disagree — "
+        "bump both together (#496)"
+    )
+
+
+def test_ci_runs_all_precommit_hooks() -> None:
+    """CI must run the full pre-commit suite, not just ruff (#496).
+
+    Otherwise a PR introducing trailing whitespace or EOF drift merges
+    green and breaks `pre-commit run --all-files` for every branch.
+    """
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github" / "workflows" / "robot-tests.yml").read_text()
+    )
+    commands = [
+        step.get("run", "")
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", [])
+    ]
+    assert any(re.search(r"pre-commit run --all-files", cmd) for cmd in commands), (
+        "CI does not run 'pre-commit run --all-files' — the #496 gate is missing"
+    )


### PR DESCRIPTION
## Summary

Fixes #496: #481 closed the format-drift loop for ruff only. This PR closes the whole class — the CI lint job now runs `pre-commit run --all-files --show-diff-on-failure`, so a PR that would break the all-files gate (trailing whitespace, EOF drift, yaml/json breakage, hook-version skew) can never merge green. mypy gets the same version alignment ruff got: `mypy==1.10.0` pinned to match the `mirrors-mypy` hook rev.

## How to review

**Key changes:**
- `.github/workflows/robot-tests.yml` — one new lint step running the full hook suite.
- `pyproject.toml` — `mypy==1.10.0` (verified: `uv run mypy src/` passes on 124 files at this version).
- `tests/test_tooling_alignment.py` — two new guards (TDD, red before): mypy pin must match the hook rev; CI must keep the all-files step.

**What to ignore:** the trailing style commit normalizes two files that drifted onto staging — the last instance of the class this PR eliminates.

## Evidence of testing

- TDD red→green on both new alignment tests.
- `uv run pytest`: 3450 passed, 3 skipped. `pre-commit run --all-files`: all hooks pass on this branch.

## Critical changes

CI behavior: the lint job is now strictly stricter. mypy downgrade-to-pin (floating → 1.10.0) verified clean against src/.

## Checklist

- [x] TDD — failing tests first
- [x] All verification commands pass
- [x] Self-reviewed diff
- [x] Commits signed off per ai/GIT.md (rfc-engineering-agent + Model trailer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)