### PR TITLE
docs: add Superset health check commands to CLAUDE.md and PM agent (#513)

### DIFF
--- a/.claude/agents/project-management.md
+++ b/.claude/agents/project-management.md
@@ -90,9 +90,9 @@ dashboards/alerts listed in CLAUDE.md. Anything degrading gets a `from:pm`,
 no evidence ignored.
 
 Also check Superset server health each iteration (commands in CLAUDE.md § Monitoring & dashboards):
-- `docker ps --filter name=rfc-` — all RFC containers up and healthy
-- `curl -fsS localhost:8088/health` — Superset API alive
-- `psql $DATABASE_URL -c "SELECT MAX(created_at) FROM test_runs"` — data freshness (<48h when runs expected)
+- `docker compose ps --all` — all stack services; check `State`/`Status` for any stopped or unhealthy service (`docker ps` alone hides stopped containers, and Compose names are project-prefixed, not `rfc-`)
+- `curl -fsS "localhost:${SUPERSET_PORT:-8088}/health"` — Superset API alive (honors `SUPERSET_PORT`)
+- `psql $DATABASE_URL -c "SELECT MAX(timestamp) FROM test_runs"` — data freshness (<48h when runs expected)
 - `make superset-diagnose` — deep connectivity + pipeline check (run on first degradation sign)
 
 Any failure → file a `from:pm`, `type:monitoring` issue immediately with the command output attached.

--- a/.claude/agents/project-management.md
+++ b/.claude/agents/project-management.md
@@ -89,6 +89,14 @@ dashboards/alerts listed in CLAUDE.md. Anything degrading gets a `from:pm`,
 `type:monitoring` issue with the data attached. No alarm without evidence;
 no evidence ignored.
 
+Also check Superset server health each iteration (commands in CLAUDE.md § Monitoring & dashboards):
+- `docker ps --filter name=rfc-` — all RFC containers up and healthy
+- `curl -fsS localhost:8088/health` — Superset API alive
+- `psql $DATABASE_URL -c "SELECT MAX(created_at) FROM test_runs"` — data freshness (<48h when runs expected)
+- `make superset-diagnose` — deep connectivity + pipeline check (run on first degradation sign)
+
+Any failure → file a `from:pm`, `type:monitoring` issue immediately with the command output attached.
+
 Also audit git hygiene per `ai/GIT.md` (read-only):
 - `git worktree list` — worktrees whose branches have merged are stale; flag
   the creating role (or the human) to remove them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,9 +168,9 @@ prompt conflict, `ai/ROLES.md` wins.
   (see `ai/agents.md`).
 - Superset health checks (run these when diagnosing a dashboard outage or in PM sweeps):
   ```bash
-  docker ps --filter name=rfc-              # all RFC containers running and healthy
-  curl -fsS localhost:8088/health           # Superset API alive
-  psql $DATABASE_URL -c "SELECT MAX(created_at) FROM test_runs"  # data freshness (<48h when runs expected)
+  docker compose ps --all                   # all stack services — check State/Status for stopped/unhealthy
+  curl -fsS "localhost:${SUPERSET_PORT:-8088}/health"  # Superset API alive (honors SUPERSET_PORT)
+  psql $DATABASE_URL -c "SELECT MAX(timestamp) FROM test_runs"  # data freshness (<48h when runs expected)
   make superset-diagnose                    # deep connectivity + pipeline check
   ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,13 @@ prompt conflict, `ai/ROLES.md` wins.
 - CI: GitHub Actions — `gh run list` / `gh pr checks <number>`.
 - Test results are archived to SQL and visualized in Apache Superset dashboards
   (see `ai/agents.md`).
+- Superset health checks (run these when diagnosing a dashboard outage or in PM sweeps):
+  ```bash
+  docker ps --filter name=rfc-              # all RFC containers running and healthy
+  curl -fsS localhost:8088/health           # Superset API alive
+  psql $DATABASE_URL -c "SELECT MAX(created_at) FROM test_runs"  # data freshness (<48h when runs expected)
+  make superset-diagnose                    # deep connectivity + pipeline check
+  ```
 
 ---
 


### PR DESCRIPTION
## Summary

Part 1 of #513: surfaces the four concrete Superset health-check commands so they're visible in the right places and run automatically by the PM role.

- **`CLAUDE.md` § Monitoring & dashboards** — adds a `bash` block with the four commands (`docker ps --filter name=rfc-`, `curl -fsS localhost:8088/health`, `psql $DATABASE_URL` freshness probe, `make superset-diagnose`) so any agent or human can find them by reading the routing file.
- **`.claude/agents/project-management.md` § 4 Systems monitoring** — adds the Superset health checklist to the PM role's sweep-4 step, with the "any failure → file a `from:pm type:monitoring` issue with output attached" trigger.

Part 2 (prompt-diff wording review for the PM agent) is labelled `from:design` and is deferred pending design-role review.

## How to review

Two-file doc-only diff. Check that:
1. The four commands in `CLAUDE.md` match what `make superset-diagnose` and the container topology actually use.
2. The PM sweep instruction is clear enough that a fresh PM-role invocation will run the checks without ambiguity.

## Evidence of testing

- `make robot-dryrun` — **659/659 PASS**
- `uv run pytest` — pre-existing baseline failures in the execution environment (6 failures + 40 errors in `test_dialog_e2e_keywords`, `test_harness_cli`, `test_harness_snapshot`, `test_submodule_ownership_integration`) unrelated to this doc-only change; `pre-commit` not installed in the remote container
- No Python code changed; no Robot tests changed

## Critical changes

None — doc edits only. The `make superset-diagnose` target already exists in the Makefile (line 290).

## Checklist

- [x] robot-dryrun passes
- [x] Self-reviewed diff — scope matches #513 Part 1 exactly
- [x] No new Python files, no new Robot suites
- [ ] `uv run pytest` / `pre-commit` / `make code-quality-check` — cannot verify in remote container (pre-existing baseline failures); run locally before marking ready
- [x] No version bump needed (doc-only)

Closes Part 1 of #513 (Part 2 deferred to design role).

https://claude.ai/code/session_014jAo89qvRuFg7SPq24L2Pa

---
_Generated by [Claude Code](https://claude.ai/code/session_014jAo89qvRuFg7SPq24L2Pa)_