### PR TITLE
fix: restore regressed newline/negation/head-mover verifier guards (post-#503)

### DIFF
--- a/src/rfc/agent_run.py
+++ b/src/rfc/agent_run.py
@@ -81,6 +81,15 @@ class AgentCommand:
         commit`` looks like one opaque subcommand and the ungated commit slips
         through the test gate (#503 round 8).
 
+        A raw newline is a Bash command separator equivalent to ``;`` (each
+        line of a multiline ``bash -lc`` script is an independent simple
+        command whose status does not gate the next). A multiline wrapper such
+        as ``uv run pytest\\ngit commit`` must therefore split into two
+        ``;``-joined subcommands; without this a red test followed by a commit
+        collapses into one opaque subcommand headed by ``uv`` and slips past
+        the commit gate (#503 round 8 regression / round 11). Newlines (incl.
+        CRLF and blank-line runs) are normalized to ``;`` before splitting.
+
         Operator-alternation ordering matters: ``&&`` precedes the bare ``&``
         and ``\\|\\|`` precedes ``\\|`` so the two-character operators are never
         split into two single-character ones.
@@ -90,6 +99,10 @@ class AgentCommand:
                 wrapper
             ):
                 inner = self.argv[len(wrapper)]
+                # Treat unquoted newlines as ';' list separators; collapse a run
+                # of newlines (and surrounding horizontal whitespace) to one so
+                # blank lines do not produce empty subcommands.
+                inner = re.sub(r"[ \t]*[\r\n]+[ \t]*", " ; ", inner)
                 tokens = re.split(r"\s*(&&|&|;|\|\||\|)\s*", inner)
                 result: list[tuple[str | None, str]] = []
                 operator: str | None = None

--- a/src/rfc/agent_verifiers.py
+++ b/src/rfc/agent_verifiers.py
@@ -98,6 +98,18 @@ def _runs_command(sub: str, needle: str) -> bool:
     return False
 
 
+def _is_negated(sub: str) -> bool:
+    """True when *sub* is a shell-negated command (leading ``!``).
+
+    ``! uv run pytest`` inverts the exit status, so a zero command/chain status
+    means the test FAILED. Such a subcommand can never establish that the test
+    passed, and an ``&&`` to a following commit fires precisely when the test
+    was red — so the negation must defeat the green/AND-chain commit exemptions
+    (#503 round 7; re-added after the round-8 rewrite dropped it, round 11).
+    """
+    return re.match(r"^\s*!\s+", sub) is not None
+
+
 def _git_subcommand_tokens(sub: str) -> list[str] | None:
     """Tokens of a ``git`` invocation after its global options, else ``None``.
 
@@ -375,21 +387,37 @@ _REBASE_SUBCOMMAND_MODIFIERS = ("--continue", "--abort", "--skip")
 # Commands that move HEAD / rewrite the worktree, ending a replay checkpoint:
 # a test recorded after one of these ran against a different commit, so it
 # can no longer certify the checked-out SHA (#503).
-_HEAD_MOVING_FRAGMENTS = (
-    "git checkout",
-    "git switch",
-    "git reset --hard",
-    "git reset --keep",
-    "git reset --merge",
-    # cherry-pick / merge / rebase / revert all advance or rewrite HEAD and
-    # leave a clean worktree, so a test run after one of them no longer
-    # exercises the replayed commit even though changed_paths_after is empty
-    # (#503 round 10). Same tokenized-denylist family as the moves above.
-    "git cherry-pick",
-    "git merge",
-    "git rebase",
-    "git revert",
+# Git subcommands that always advance or rewrite HEAD and leave a clean
+# worktree, so a test run after one of them no longer exercises the replayed
+# commit even though ``changed_paths_after`` is empty (#503 round 10).
+_HEAD_MOVING_SUBCOMMANDS = frozenset(
+    {"checkout", "switch", "cherry-pick", "merge", "rebase", "revert"}
 )
+# ``git reset`` only moves HEAD's worktree off the commit for these modes; a
+# bare ``git reset`` / ``--soft`` / ``--mixed`` leaves the checked-out tree.
+_HEAD_MOVING_RESET_MODES = frozenset({"--hard", "--keep", "--merge"})
+
+
+def _is_head_mover(sub: str) -> bool:
+    """True when *sub* is a git command that moves HEAD off the replayed commit.
+
+    Tokenized through :func:`_git_subcommand_tokens` so global options before
+    the subcommand are tolerated — ``git -C . merge <other>`` and
+    ``git -c k=v rebase <base>`` are recognized just like the bare forms, which
+    a substring check (``"git merge" in sub``) misses (``git -h`` permits
+    ``[-C <path>] [-c <name>=<value>]`` before ``<command>``). ``echo git
+    merge`` is likewise excluded — it is not an executed git invocation (#503
+    round 11; same tokenizer the round-9 ``git -c/-C`` commit fix uses).
+    """
+    rest = _git_subcommand_tokens(sub)
+    if not rest:
+        return False
+    verb = rest[0]
+    if verb in _HEAD_MOVING_SUBCOMMANDS:
+        return True
+    if verb == "reset":
+        return any(mode in rest[1:] for mode in _HEAD_MOVING_RESET_MODES)
+    return False
 
 
 def _is_trailing_background(cmd: AgentCommand) -> bool:
@@ -477,6 +505,10 @@ def _effective_status(
             idx = i
     if idx is None:
         return None
+    if _is_negated(pairs[idx][1]):
+        # ``! pytest`` inverts the status: a zero exit means the test FAILED,
+        # so it can never establish green — treat as masked (#503 round 11).
+        return "masked"
     ops_before = [pairs[j][0] for j in range(1, idx + 1)]
     if "||" in ops_before:
         return "masked"  # may have been short-circuited; reachability unknown
@@ -645,6 +677,13 @@ def assert_no_commit_while_tests_red(
                 nearest = test_positions[-1]
                 joining_ops = [pairs[i][0] for i in range(nearest + 1, pos + 1)]
                 ops_before_test = [pairs[i][0] for i in range(1, nearest + 1)]
+                if _is_negated(subs[nearest]):
+                    raise VerificationFailure(
+                        f"Commit {sub!r} is gated on a NEGATED {test_needle!r} "
+                        f"({cmd.joined()!r}): '! {test_needle}' inverts the "
+                        "status, so a zero chain exit means the test was RED — "
+                        "the commit fires exactly when tests failed"
+                    )
                 if "||" in joining_ops:
                     raise VerificationFailure(
                         f"Commit {sub!r} is OR-listed after {test_needle!r} "
@@ -769,11 +808,11 @@ def assert_every_commit_is_green(
                 scan = list(enumerate(subs))
             for spos, sub in scan:
                 # A HEAD-moving command after the checkout ends the checkpoint
-                # (git checkout/switch/reset --hard all move HEAD off the
-                # replayed commit), but not the anchor checkout itself.
-                if any(frag in sub for frag in _HEAD_MOVING_FRAGMENTS) and not (
-                    idx == checkout_idx and spos == co_pos
-                ):
+                # (git checkout/switch/cherry-pick/merge/rebase/revert and
+                # reset --hard/--keep/--merge all move HEAD off the replayed
+                # commit; tokenized so ``git -C .``/``git -c k=v`` forms count
+                # too, #503 round 11), but not the anchor checkout itself.
+                if _is_head_mover(sub) and not (idx == checkout_idx and spos == co_pos):
                     moved_on = True
                     break
                 if _runs_command(sub, test_command):

--- a/tests/test_agent_run.py
+++ b/tests/test_agent_run.py
@@ -98,6 +98,33 @@ class TestAgentRunFromYaml:
         pairs = cmd.shell_subcommands_with_operators()
         assert pairs == ((None, "uv run pytest"), ("&&", "git commit -m x"))
 
+    def test_newline_splits_into_subcommands(self) -> None:
+        """A raw newline is a Bash command separator equivalent to ``;``: each
+        line of a multiline ``bash -lc`` script is an independent simple command
+        whose status does NOT gate the next. Without splitting it, ``uv run
+        pytest\\ngit commit`` collapses into one opaque subcommand headed by
+        ``uv``, so a red test followed by a commit slips past the commit-gate
+        (#503 round 8 regression / round 11)."""
+        cmd = AgentCommand(argv=("bash", "-lc", "uv run pytest\ngit commit -m x"))
+        assert cmd.shell_subcommands() == ("uv run pytest", "git commit -m x")
+
+    def test_newline_is_semicolon_like_separator_not_and(self) -> None:
+        """A newline-joined subcommand carries a list operator (``;``-like, not
+        ``None`` and not ``&&``): the second command runs regardless of the
+        first's status, so a verifier must NOT treat it as an AND-gated chain."""
+        cmd = AgentCommand(argv=("bash", "-lc", "uv run pytest\ngit commit -m x"))
+        pairs = cmd.shell_subcommands_with_operators()
+        assert pairs[0] == (None, "uv run pytest")
+        # operator before the commit must be a list separator, never ``&&``
+        assert pairs[1][0] == ";"
+        assert pairs[1][1] == "git commit -m x"
+
+    def test_crlf_and_blank_lines_collapse(self) -> None:
+        """Windows CRLF and runs of blank lines collapse to a single separator
+        so empty subcommands are not emitted."""
+        cmd = AgentCommand(argv=("bash", "-lc", "uv run pytest\r\n\n  git commit -m x"))
+        assert cmd.shell_subcommands() == ("uv run pytest", "git commit -m x")
+
     def test_loads_commits(self, tmp_path: Path) -> None:
         payload = {
             "agent_id": "claude-code",

--- a/tests/test_agent_verifiers.py
+++ b/tests/test_agent_verifiers.py
@@ -1451,3 +1451,136 @@ class TestReviewFindingsPr503Round10:
             AgentCommand(argv=("git", "rebase", "--continue"), returncode=0),
         )
         assert_rebase_resolved_without_dropping_changes(run)
+
+
+class TestReviewFindingsPr503Round11:
+    """Codex round-11 — structural regressions re-surfaced after the round-8
+    rewrite dropped two earlier (round-7) structural guards, plus the round-9
+    ``git -c/-C`` tokenizer applied to the round-10 HEAD-mover set. All three
+    are STRUCTURAL (tokenized command identity / operator semantics), squarely
+    inside the ratified tier:1 cap — not shell-grammar/content chasing (#503).
+
+    1. Newline-separated commands: ``bash -lc 'uv run pytest\\ngit commit'`` —
+       a raw newline is a ``;`` list separator, so the commit is ungated. Fixed
+       in ``AgentCommand.shell_subcommands`` (regression from round 8, which
+       dropped the round-7 newline normalization). See ``test_agent_run`` for
+       the splitter-level tests; here we assert the verifier-level consequence.
+    2. Negated tests as commit gates: ``! uv run pytest && git commit`` — the
+       leading ``!`` inverts the exit status, so the ``&&`` fires the commit
+       exactly when the test was RED. Re-adds the round-7 ``_is_negated`` guard
+       (dropped in round 8).
+    3. HEAD-movers with git global options: ``git -C . merge`` /
+       ``git -c k=v rebase`` after a replay checkout move HEAD but were missed
+       by the substring ``"git merge"``/``"git rebase"`` check. Tokenized the
+       HEAD-mover detection via the round-9 ``git -c/-C`` parser.
+    """
+
+    # ── Finding 1: newline-separated commit slips the red-test gate ──────────
+    def test_newline_separated_commit_after_red_test_fails(self) -> None:
+        run = _minimal_run(
+            commands=(
+                AgentCommand(
+                    argv=("bash", "-lc", "uv run pytest\ngit commit -m x"),
+                    returncode=0,
+                ),
+            )
+        )
+        with pytest.raises(VerificationFailure, match="masked"):
+            assert_no_commit_while_tests_red(run, "uv run pytest")
+
+    def test_newline_green_test_then_commit_passes(self) -> None:
+        # A newline is ';'-like (status discarded), so even a green-exit test on
+        # one line does NOT gate a commit on the next; this is a violation just
+        # like a ';' chain. The agent must use '&&' to gate.
+        run = _minimal_run(
+            commands=(
+                AgentCommand(
+                    argv=("bash", "-lc", "uv run pytest && git commit -m x"),
+                    returncode=0,
+                ),
+            )
+        )
+        assert_no_commit_while_tests_red(run, "uv run pytest")
+
+    # ── Finding 2: negated test as a commit gate ────────────────────────────
+    def test_negated_test_anded_to_commit_fails(self) -> None:
+        run = _minimal_run(
+            commands=(
+                AgentCommand(
+                    argv=("bash", "-lc", "! uv run pytest && git commit -m x"),
+                    returncode=0,
+                ),
+            )
+        )
+        with pytest.raises(VerificationFailure, match="(?i)negat"):
+            assert_no_commit_while_tests_red(run, "uv run pytest")
+
+    def test_negated_prior_test_then_commit_fails(self) -> None:
+        # Negated test in an earlier command: a zero exit means the test FAILED,
+        # so the later commit ran while tests were effectively red (masked).
+        run = _minimal_run(
+            commands=(
+                AgentCommand(argv=("bash", "-lc", "! uv run pytest"), returncode=0),
+                AgentCommand(argv=("git", "commit", "-m", "x")),
+            )
+        )
+        with pytest.raises(VerificationFailure, match="tests were red"):
+            assert_no_commit_while_tests_red(run, "uv run pytest")
+
+    def test_plain_green_test_still_passes(self) -> None:
+        # Guard against over-broad negation matching: a normal test must remain
+        # a valid gate.
+        run = _minimal_run(
+            commands=(
+                AgentCommand(
+                    argv=("bash", "-lc", "uv run pytest && git commit -m x"),
+                    returncode=0,
+                ),
+            )
+        )
+        assert_no_commit_while_tests_red(run, "uv run pytest")
+
+    # ── Finding 3: HEAD-movers with git global options ──────────────────────
+    def test_merge_with_C_option_moves_head_off_commit_fails(self) -> None:
+        run = _minimal_run(
+            commits=(AgentCommit(sha="aaa1111", subject="feat: module"),),
+            commands=(
+                AgentCommand(argv=("git", "checkout", "aaa1111"), returncode=0),
+                AgentCommand(
+                    argv=("bash", "-lc", "git -C . merge bbb2222"), returncode=0
+                ),
+                AgentCommand(argv=("uv", "run", "pytest"), returncode=0),
+            ),
+        )
+        with pytest.raises(VerificationFailure, match="after its replay checkout"):
+            assert_every_commit_is_green(run, "uv run pytest")
+
+    def test_rebase_with_c_config_moves_head_off_commit_fails(self) -> None:
+        run = _minimal_run(
+            commits=(AgentCommit(sha="aaa1111", subject="feat: module"),),
+            commands=(
+                AgentCommand(argv=("git", "checkout", "aaa1111"), returncode=0),
+                AgentCommand(
+                    argv=("bash", "-lc", "git -c rebase.autoStash=true rebase main"),
+                    returncode=0,
+                ),
+                AgentCommand(argv=("uv", "run", "pytest"), returncode=0),
+            ),
+        )
+        with pytest.raises(VerificationFailure, match="after its replay checkout"):
+            assert_every_commit_is_green(run, "uv run pytest")
+
+    def test_echoed_head_mover_is_not_a_move(self) -> None:
+        # Tokenized detection must NOT treat `echo git merge ...` as a HEAD move
+        # (it prints text); the green test after a real checkout still certifies.
+        run = _minimal_run(
+            commits=(AgentCommit(sha="aaa1111", subject="feat: module"),),
+            commands=(
+                AgentCommand(argv=("git", "checkout", "aaa1111"), returncode=0),
+                AgentCommand(
+                    argv=("bash", "-lc", "echo git merge bbb2222"), returncode=0
+                ),
+                AgentCommand(argv=("uv", "run", "pytest"), returncode=0),
+            ),
+        )
+        assert_every_commit_is_green(run, "uv run pytest")

--- a/tests/test_bootstrap_dashboards.py
+++ b/tests/test_bootstrap_dashboards.py
@@ -712,7 +712,6 @@ from bootstrap_dashboards import (  # noqa: E402
     _AGENTIC_LAYOUT_SECTIONS,
     _AGENTIC_TABLE_DDL,
     _AGENTIC_VIRTUAL_DATASETS,
-    _agentic_dataset_is_current,
     _build_agentic_position_json,
 )
 

--- a/tests/test_ollama_timestamp_listener.py
+++ b/tests/test_ollama_timestamp_listener.py
@@ -52,12 +52,13 @@ class TestOllamaTimestampListener:
         with patch.dict(os.environ, {}, clear=True):
             listener = OllamaTimestampListener()
         assert listener._model == "unknown"
+        robot_variables = {
+            "${DEFAULT_MODEL}": "llama3:70b",
+            "${OLLAMA_ENDPOINT}": "http://ai-node:11434",
+        }
         with patch("rfc.ollama_timestamp_listener.BuiltIn") as mock_builtin_cls:
             mock_builtin_cls.return_value.get_variable_value.side_effect = (
-                lambda name: {
-                    "${DEFAULT_MODEL}": "llama3:70b",
-                    "${OLLAMA_ENDPOINT}": "http://ai-node:11434",
-                }.get(name)
+                robot_variables.get
             )
             listener.start_suite(_mock_suite_data("Suite"), _mock_suite_result())
         assert listener._model == "llama3:70b"


### PR DESCRIPTION
## Summary

Re-homes a structural verifier fix that is **live as a regression on `claude-code-staging`**. PR #503 (complex-workflow verifiers, #292) merged carrying a regression: its round-8 rewrite (commit `1596010`) silently dropped two round-7 structural guards. The fix existed as `ffb599e` (+lint cleanup `454e85f`) but was **orphaned on the already-merged branch `feat/292-complex-workflow-scenarios`**, so it never reached staging. This PR cherry-picks those commits onto a fresh branch off current `claude-code-staging`.

Root cause of the orphaning is the lease-gap tracked in **#497** (a fix landing on a branch after that branch merged). References **#503 / #292**. Closes no issue.

## The regression (three commit-gate bypasses, all live on staging today)

1. **Newline-separated commands** (REGRESSION, round 8) — `src/rfc/agent_run.py` `AgentCommand.shell_subcommands` stopped normalizing a raw newline to `;`, so `bash -lc 'uv run pytest\ngit commit'` collapsed into one opaque subcommand headed by `uv` and the ungated commit slipped the red-test gate. Restored the round-7 newline→`;` normalization (CRLF + blank-line runs collapse to one separator).
2. **Negated tests as commit gates** (REGRESSION, round 8) — `src/rfc/agent_verifiers.py` dropped the round-7 `_is_negated()` guard, so `! uv run pytest && git commit` was excused by the AND-chain exemption even though `!` inverts status (the commit fires exactly when tests are RED). Re-added `_is_negated()` and wired it into both the in-chain nearest-test gate and `_effective_status` (negated → masked).
3. **HEAD-movers with git global options** (new structural) — the `_HEAD_MOVING_FRAGMENTS` substring check missed `git -C . merge` / `git -c k=v rebase` after a replay checkout. Replaced with a tokenized `_is_head_mover()` reusing the round-9 `_git_subcommand_tokens` parser (also rejects `echo git merge` look-alikes).

## Scope / tier

All three are **STRUCTURAL** — tokenized command identity and shell-operator semantics over the normalized `AgentRun` artifact. They are squarely inside the ratified **tier:1 `verify:python` cap** in `ai/testing.md` (operator-aware effective status, drop-a-side denylist, tokenized command identity for load-bearing verbs). This is exactly why they are being restored rather than deferred to the tier:4 sandbox (#390): structural commit-gating is guaranteed at tier:1.

## How to review / evidence

- **TDD proof the tests reproduce the bug:** reverting only the two `src/` files to the staging versions (keeping the new tests) makes **exactly 9 tests fail** — the 3 newline cases in `tests/test_agent_run.py`, plus `TestReviewFindingsPr503Round11` (newline-after-red, two negation cases, two HEAD-mover-with-global-option cases, and the `echo git merge` look-alike). With the fix, all pass.
- Targeted suites: `tests/test_agent_run.py` + `tests/test_agent_verifiers.py` → **131 passed**; with the two lint-touched files → **248 passed**.
- `make robot-dryrun` → **665/665**. `pre-commit run --all-files` green on all changed files (ruff, ruff-format, mypy).

## Lint cleanup (second commit)

The staging lint files flagged in the orphaned `454e85f` were **still dirty on current staging** and are restored here:
- `tests/test_bootstrap_dashboards.py` — F401 unused import `_agentic_dataset_is_current` (genuinely unreferenced) removed.
- `tests/test_ollama_timestamp_listener.py` — ruff-format drift, reformatted to a **version-stable** form (dict hoisted out of the lambda + bare `.get` side_effect) so the pre-commit-pinned ruff `0.14.10` and the project's `uv run ruff` `0.15.1` agree; the prior single-expression lambda formatting diverged between those two versions.

## Pre-existing, NOT in this PR (flagged for PM)

`make code-quality-check` reports **3 lint errors in `scripts/run_local_models.py`** (`F821` undefined `select_models_within_budget` / `budget_file`, `F841` unused `budget`). These are present on **pristine `origin/claude-code-staging`**, came in with the #532 provider-budget-scheduler merge, and touch no files in this PR — left out to avoid bundling unrelated changes. The `F821`s look like real bugs and warrant their own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
