### PR TITLE
fix: reconcile run_local_models + test imports after #536/#537 double-merge (staging red)

### DIFF
--- a/scripts/run_local_models.py
+++ b/scripts/run_local_models.py
@@ -86,7 +86,6 @@ from rfc.providers import (  # noqa: E402
     discover_free_models,
     load_providers,
     resolve_api_key,
-    select_models_within_budget,
 )
 from scripts.discover_ollama import (  # noqa: E402
     _probe_port,
@@ -702,16 +701,6 @@ def run_provider_suites(
     prev_start: float | None = None
     for model, suite in run_list:
         watermark = f"{provider.name}/{model}"
-        # #515 hard-stop: re-read the shared counter and stop dispatching once
-        # the day's budget is reached (catches real overshoot the upfront
-        # estimate misses — retries, 429 re-attempts).
-        if budget.exhausted(provider.name, provider.max_requests_per_day):
-            print(
-                f"  {tag} daily budget reached "
-                f"({provider.max_requests_per_day} requests today) — "
-                f"stopping further {provider.name} jobs (#515)."
-            )
-            return results
         # #525: never run a privacy/context-ineligible suite, even if a caller
         # passes it explicitly in jobs.
         skip_reason = _provider_suite_skip_reason(suite, provider)

--- a/tests/test_bootstrap_dashboards.py
+++ b/tests/test_bootstrap_dashboards.py
@@ -33,6 +33,7 @@ from bootstrap_dashboards import (  # noqa: E402
     _LAYOUT_SECTIONS,
     _TABLE_DDL,
     _VIRTUAL_DATASETS,
+    _agentic_dataset_is_current,
     _build_position_json,
     _probe_columns,
 )

--- a/tests/test_run_local_models.py
+++ b/tests/test_run_local_models.py
@@ -11,13 +11,11 @@ import yaml
 
 from rfc.host_scheduler import HostConfig, HostSpec, SchedulerDefaults
 from scripts.run_local_models import (
-    _EMPTY_ITERATION_IDLE_SECONDS,
     PREFLIGHT_SUITE,
     RunResult,
     _build_robot_command,
     _maybe_audit,
     _nodes_from_host_config,
-    _resolve_budget_file,
     _sanitize_name,
     discover_local_models,
     load_local_config,


### PR DESCRIPTION
## Root cause

`claude-code-staging` went RED because two competing fixes for the same lint failure, **#536** and **#537**, both merged within ~2 minutes of each other. The double-merge left `scripts/run_local_models.py` in a contradictory state:

- **F401** — an unused `select_models_within_budget` import (the pre-filter it referenced was superseded by the #510 planner; nothing calls it anymore).
- **F821** — a merge-garbage `if budget.exhausted(...)` block inside `run_provider_suites()`, which references a bare `budget` name that is never a parameter or local in that scope. Daily-budget enforcement actually lives in the caller via `plan_within_budget` / `ProviderBudget(...).remaining(...)`, so this block was both undefined and redundant.

Two collateral staging lint failures in the test tree are fixed in the same atomic commit so the gate goes fully green:

- `tests/test_bootstrap_dashboards.py` — **F821**: `_agentic_dataset_is_current` used at 6 sites but never imported.
- `tests/test_run_local_models.py` — **F401**: two orphaned imports (`_EMPTY_ITERATION_IDLE_SECONDS`, `_resolve_budget_file`).

## What this removes

- The dead `select_models_within_budget` **import** and the undefined-`budget` block in `run_local_models.py`.
- The missing/orphaned test imports above.

Budget enforcement is unchanged: the planner (`plan_within_budget`, #510) plus the shared per-provider counter (`ProviderBudget`, #515) remain the single path.

## What this deliberately does NOT do

- **Does NOT wire `select_models_within_budget`.** #510 (`18db254`) intentionally superseded that pre-filter with the planner; re-wiring it breaks `test_budget_plans_jobs_and_defers_overflow`. This PR removes only the now-unused import.
- **Does NOT delete the dead `select_models_within_budget` function or its 8 tests.** That full cleanup is tracked separately in **#539** (resolved toward removal) as a follow-up, to keep this unblock minimal.

## Verification (all green)

- `ruff check scripts/run_local_models.py tests/test_bootstrap_dashboards.py tests/test_run_local_models.py` — clean
- `make code-quality-check` — 3830 passed, 4 skipped (88.86% coverage)
- `pre-commit run --all-files` — all hooks Passed (ruff, ruff-format, mypy)
- `make robot-dryrun` — 665 tests, 665 passed
- `TestPrivacyRoutingGuard` — 4 passed; `test_budget_plans_jobs_and_defers_overflow` — passed

Refs #536, #537, #539, #510, #497.

Do NOT merge — staging unblocker, awaiting human merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
