### PR TITLE
refactor: remove dead select_models_within_budget function and tests (#539)

### DIFF
--- a/scripts/run_local_models.py
+++ b/scripts/run_local_models.py
@@ -86,7 +86,6 @@ from rfc.providers import (  # noqa: E402
     discover_free_models,
     load_providers,
     resolve_api_key,
-    select_models_within_budget,
 )
 from scripts.discover_ollama import (  # noqa: E402
     _probe_port,

--- a/src/rfc/provider_budget.py
+++ b/src/rfc/provider_budget.py
@@ -1,14 +1,8 @@
 """File-backed per-provider daily request counter (issue #515).
 
-``select_models_within_budget`` caps an external provider's daily spend by an
-*upfront estimate* (n_suites x requests_per_suite_estimate). That cannot catch
-real overshoot — LLM-judge retries, self-healing retries, and 429 re-attempts
-all make more HTTP calls than the estimate, so a sweep can blow past the
-provider's daily allowance in an uncontrolled order.
-
-This adds the missing primitive: a *runtime* counter, persisted per provider
-per UTC day, that the scheduler reads to hard-stop dispatching new (model,
-suite) jobs once the day's spend reaches the configured budget, and that the
+Budget enforcement uses a *runtime* counter, persisted per provider per UTC
+day, that the scheduler reads to hard-stop dispatching new (model, suite) jobs
+once the day's spend reaches the configured budget, and that the
 OpenAI-compatible client increments on each request.
 
 State is a small JSON document ``{"date": "<UTC date>", "counts": {...}}``.

--- a/src/rfc/providers.py
+++ b/src/rfc/providers.py
@@ -177,34 +177,9 @@ def discover_free_models(
     return free
 
 
-def select_models_within_budget(
-    models: list[str],
-    n_suites: int,
-    *,
-    max_requests_per_day: int,
-    requests_per_suite_estimate: int,
-) -> list[str]:
-    """Keep the longest model prefix whose estimated requests fit the budget.
-
-    Each model is estimated to cost ``n_suites * requests_per_suite_estimate``
-    requests for a full sweep. Order is preserved; models that would push the
-    daily total past ``max_requests_per_day`` are dropped from the tail.
-    """
-    cost_per_model = n_suites * requests_per_suite_estimate
-    kept: list[str] = []
-    spent = 0
-    for model in models:
-        if spent + cost_per_model > max_requests_per_day:
-            break
-        kept.append(model)
-        spent += cost_per_model
-    return kept
-
-
 __all__ = [
     "ProviderConfig",
     "discover_free_models",
     "load_providers",
     "resolve_api_key",
-    "select_models_within_budget",
 ]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -14,7 +14,6 @@ from rfc.providers import (
     discover_free_models,
     load_providers,
     resolve_api_key,
-    select_models_within_budget,
 )
 
 
@@ -154,66 +153,6 @@ class TestDiscoverFreeModels:
         assert discover_free_models("https://openrouter.ai/api/v1", "k") == []
 
 
-class TestSelectModelsWithinBudget:
-    def test_all_fit(self) -> None:
-        # 2 models x 3 suites x 10 req = 60 <= 1000
-        models = ["a:free", "b:free"]
-        kept = select_models_within_budget(
-            models,
-            n_suites=3,
-            max_requests_per_day=1000,
-            requests_per_suite_estimate=10,
-        )
-        assert kept == models
-
-    def test_truncates_preserving_order(self) -> None:
-        # each model costs 3 suites x 100 req = 300; budget 700 -> 2 models
-        models = ["a:free", "b:free", "c:free"]
-        kept = select_models_within_budget(
-            models,
-            n_suites=3,
-            max_requests_per_day=700,
-            requests_per_suite_estimate=100,
-        )
-        assert kept == ["a:free", "b:free"]
-
-    def test_zero_budget_keeps_nothing(self) -> None:
-        kept = select_models_within_budget(
-            ["a:free"],
-            n_suites=1,
-            max_requests_per_day=0,
-            requests_per_suite_estimate=1,
-        )
-        assert kept == []
-
-    def test_empty_models(self) -> None:
-        assert (
-            select_models_within_budget(
-                [],
-                n_suites=5,
-                max_requests_per_day=1000,
-                requests_per_suite_estimate=10,
-            )
-            == []
-        )
-
-    def test_exact_budget_boundary_kept_then_dropped(self) -> None:
-        """The 1,000th estimated request fits; the 1,001st does not (#507).
-
-        Each model costs 2 suites x 100 req = 200. Budget 1000 admits exactly
-        five models (5 x 200 = 1000, equality allowed); a sixth would push
-        the total to 1200 and must be dropped.
-        """
-        models = [f"m{i}:free" for i in range(6)]
-        kept = select_models_within_budget(
-            models,
-            n_suites=2,
-            max_requests_per_day=1000,
-            requests_per_suite_estimate=100,
-        )
-        assert kept == models[:5]
-
-
 class TestMaxContextTokens:
     def test_default_is_unlimited(self) -> None:
         providers = load_providers(
@@ -290,9 +229,6 @@ class TestCerebrasReviewFindings521:
     def _cerebras(self):
         return next(p for p in load_providers(self._config()) if p.name == "cerebras")
 
-    def _groq(self):
-        return next(p for p in load_providers(self._config()) if p.name == "groq")
-
     # Cerebras deprecation dates (inference-docs.cerebras.ai/support/deprecation):
     # llama-3.3-70b 2026-02-16, llama3.1-8b 2026-05-27.
     _DEPRECATED_CEREBRAS = ("llama-3.3-70b", "llama3.1-8b", "llama3.1-70b")
@@ -303,42 +239,6 @@ class TestCerebrasReviewFindings521:
             assert retired not in cerebras.models, f"{retired} is retired"
         # at least one current production model (gpt-oss-120b)
         assert "gpt-oss-120b" in cerebras.models
-
-    def test_groq_scheduled_model_is_not_tpd_starved(self) -> None:
-        # llama-3.3-70b-versatile is capped at 100K tokens/day on Groq free —
-        # far too low for a 630-call sweep — so it must not be the first
-        # (scheduled) model. llama-3.1-8b-instant carries the sweep (#521).
-        from rfc.providers import select_models_within_budget
-
-        cfg = self._config()
-        groq = self._groq()
-        kept = select_models_within_budget(
-            list(groq.models),
-            len(cfg["test_suites"]),
-            max_requests_per_day=groq.max_requests_per_day,
-            requests_per_suite_estimate=groq.requests_per_suite_estimate,
-        )
-        assert kept, "Groq budget must schedule at least one model"
-        assert "llama-3.3-70b-versatile" not in kept, (
-            "the 100K-TPD 70B model can't complete a full sweep; schedule "
-            "llama-3.1-8b-instant instead"
-        )
-
-    def test_budget_schedules_at_least_one_model(self) -> None:
-        from rfc.providers import select_models_within_budget
-
-        cfg = self._config()
-        cerebras = self._cerebras()
-        kept = select_models_within_budget(
-            list(cerebras.models),
-            len(cfg["test_suites"]),
-            max_requests_per_day=cerebras.max_requests_per_day,
-            requests_per_suite_estimate=cerebras.requests_per_suite_estimate,
-        )
-        assert kept, (
-            "Cerebras budget too small to schedule any model — the provider "
-            "would be silently skipped on every run"
-        )
 
 
 class TestProviderModelsCurrent521R3:
@@ -383,25 +283,6 @@ class TestProviderQuotas521R4:
 
     def _provider(self, name: str):
         return next(p for p in load_providers(self._config()) if p.name == name)
-
-    def test_google_uses_sweep_capable_flash_lite_quotas(self) -> None:
-        from rfc.providers import select_models_within_budget
-
-        cfg = self._config()
-        google = self._provider("google-ai-studio")
-        # Gemini 2.5 Flash free tier is only 10 RPM / 250 RPD — too low to
-        # sweep — so the config must use Flash-Lite (15 RPM / 1000 RPD) with
-        # quotas within its real published limits.
-        assert any("flash-lite" in m for m in google.models), google.models
-        assert google.requests_per_minute <= 15
-        assert google.max_requests_per_day <= 1000
-        kept = select_models_within_budget(
-            list(google.models),
-            len(cfg["test_suites"]),
-            max_requests_per_day=google.max_requests_per_day,
-            requests_per_suite_estimate=google.requests_per_suite_estimate,
-        )
-        assert kept, "Google budget must schedule at least one model"
 
     def test_groq_declares_context_cap_to_skip_benchmark(self) -> None:
         groq = self._provider("groq")


### PR DESCRIPTION
## Summary

Closes #539. Decision (b) from the #539 listener comment: the pre-filter function is dead by design, not by accident.

- `select_models_within_budget` was superseded by the #510 planner (`plan_within_budget`) and the #515 runtime counter (`ProviderBudget`). PR #537 removed the last production call site; PR #541 deferred this full cleanup.
- **Zero production call sites** remained (confirmed by grep across `src/` and `scripts/`).

## What changed

| File | Change |
|------|--------|
| `src/rfc/providers.py` | Removed `select_models_within_budget` function and its `__all__` entry |
| `src/rfc/provider_budget.py` | Updated module docstring to remove stale back-reference to removed function |
| `scripts/run_local_models.py` | Removed the now-unused import (F401; same import #541 also removes) |
| `tests/test_providers.py` | Removed all 8 unit tests: `TestSelectModelsWithinBudget` class (5 tests) + `test_groq_scheduled_model_is_not_tpd_starved`, `test_budget_schedules_at_least_one_model`, `test_google_uses_sweep_capable_flash_lite_quotas` (3 tests from other classes) |

## Evidence of testing

- `uv run pytest tests/test_providers.py` — **40 passed**
- `uv run ruff check src/rfc/providers.py src/rfc/provider_budget.py tests/test_providers.py` — **All checks passed**
- `make robot-dryrun` — **665 tests, 665 passed**

## Staging-red note

`make code-quality-check` and the full pytest suite have a pre-existing F821 (`budget.exhausted` in `run_local_models.py:707`) that is tracked by PRs #540/#541 — this is orthogonal to this PR's scope. **Recommend rebasing this PR onto whichever of #540/#541 merges first** to get the full suite green before merging this one.

## Checklist

- [x] One idea per commit; no unrelated changes
- [x] No new files outside `src/rfc/` or `robot/`
- [x] No debug prints or commented-out code
- [x] Type hints unchanged (no new Python added)
- [x] Robot dry-run clean

Do NOT merge — draft, awaiting owner merge gate after staging-red resolution.

<!-- rfc-monitor:heartbeat -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01DLYzsvbsnrGcN6Px58jy7N)_