### PR TITLE
fix: CachingProvider.__class__ delegates to wrapped type — isinstance transparent (#531)

### DIFF
--- a/src/rfc/answer_cache.py
+++ b/src/rfc/answer_cache.py
@@ -289,6 +289,15 @@ class CachingProvider:
 
     # ── Transparent proxying ────────────────────────────────────────────
 
+    @property  # type: ignore[misc]
+    def __class__(self) -> type:
+        # Delegate the virtual class to the wrapped client so that
+        # isinstance(caching_provider, OllamaClient) returns True (#531).
+        # Python's isinstance() checks obj.__class__ when type(obj) does not
+        # match — this satisfies the PEP 3119 virtual-subclassing path without
+        # altering type() or the MRO.
+        return type(self._client)
+
     def __getattr__(self, name: str) -> Any:
         # __getattr__ only fires for names not found normally, so this never
         # shadows generate / _client / _cache.

--- a/tests/test_answer_cache.py
+++ b/tests/test_answer_cache.py
@@ -323,20 +323,16 @@ def test_caching_provider_exposes_full_llm_provider_surface():
     assert callable(wrapped.generate)
 
 
-def test_caching_provider_breaks_ollamaclient_isinstance():
-    """A wrapped OllamaClient is (correctly) NOT an ``OllamaClient`` itself.
+def test_caching_provider_isinstance_transparent():
+    """CachingProvider.__class__ delegates to the wrapped type, making
+    isinstance() transparent to callers (#531).
 
-    ``CachingProvider`` proxies rather than subclasses, so a direct
-    ``isinstance(wrapped, OllamaClient)`` is False — by design. The five
-    Ollama-management keywords (Wait For LLM, Unload Model, Get Running
-    Models, LLM Is Busy, Set LLM Endpoint) used to gate on that direct check
-    and silently degraded when ``ANSWER_CACHE_ENABLED=1`` wrapped the
-    provider (#523, the linked ``from:testing`` defect). The fix unwraps at
-    the seam (``rfc.llm_client.as_ollama`` — see
-    ``test_as_ollama_sees_through_wrapper`` and the wrapper keyword tests in
-    ``test_keywords.py``), so the keywords now reach the concrete client
-    through the proxy. This test pins the proxy's intentional structural
-    distinction: unwrap, don't subclass.
+    When ``ANSWER_CACHE_ENABLED=1``, ``create_provider()`` returns a
+    ``CachingProvider`` wrapper. Direct ``isinstance(p, OllamaClient)`` checks
+    in test assertions (and any production code that hasn't migrated to
+    ``as_ollama()``) were silently broken. Fixing ``__class__`` to delegate to
+    the inner type makes the wrapper invisible to isinstance without altering
+    the real ``type()`` or the ``as_ollama()`` unwrap path.
     """
     from rfc.ollama import OllamaClient
 
@@ -344,11 +340,14 @@ def test_caching_provider_breaks_ollamaclient_isinstance():
     inner = OllamaClient(base_url="http://localhost:11434", model="m")
     wrapped = CachingProvider(inner, cache)
 
-    # The wrapper is deliberately NOT an OllamaClient; callers that need the
-    # concrete type unwrap via as_ollama() rather than relying on this check.
-    assert not isinstance(wrapped, OllamaClient)
-    # ...even though the underlying client is one (proxying is structural only).
-    assert isinstance(wrapped._client, OllamaClient)
+    # isinstance() sees through the wrapper after the __class__ fix.
+    assert isinstance(wrapped, OllamaClient)
+    # type() still returns CachingProvider — __class__ is a virtual class only.
+    assert type(wrapped) is CachingProvider
+    # as_ollama() continues to work and returns the concrete inner client.
+    from rfc.llm_client import as_ollama
+
+    assert as_ollama(wrapped) is inner
 
 
 # ── Finding 1: cache-hit metrics are honest, not inherited (#523) ────────

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,7 +1,7 @@
 """Tests for rfc.llm_client — LLMProvider protocol and create_provider factory."""
 
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -101,6 +101,49 @@ class TestCreateProvider:
         assert isinstance(client, OpenAIClient)
         assert client.timeout == 30
         assert client.max_retries == 3
+
+
+class TestCreateProviderWithCache:
+    """Tests for create_provider() when ANSWER_CACHE_ENABLED=1 (#531)."""
+
+    @patch("rfc.answer_cache.AnswerCache.from_env")
+    @patch.dict(os.environ, {"ANSWER_CACHE_ENABLED": "1"})
+    def test_isinstance_transparent_when_cache_enabled(
+        self, mock_from_env: MagicMock
+    ) -> None:
+        """CachingProvider.__class__ must delegate to the inner type so that
+        isinstance(create_provider(), OllamaClient) is True even with caching
+        enabled (#531).
+        """
+        mock_from_env.return_value = MagicMock()
+        client = create_provider(provider="ollama", model="test-model")
+        assert isinstance(client, OllamaClient)
+
+    @patch("rfc.answer_cache.AnswerCache.from_env")
+    @patch.dict(os.environ, {"ANSWER_CACHE_ENABLED": "1"})
+    def test_type_still_caching_provider_when_cache_enabled(
+        self, mock_from_env: MagicMock
+    ) -> None:
+        """type() returns CachingProvider — __class__ is a virtual delegation only."""
+        from rfc.answer_cache import CachingProvider
+
+        mock_from_env.return_value = MagicMock()
+        client = create_provider(provider="ollama", model="test-model")
+        assert type(client) is CachingProvider
+
+    @patch("rfc.answer_cache.AnswerCache.from_env")
+    @patch.dict(
+        os.environ, {"ANSWER_CACHE_ENABLED": "1", "OPENAI_API_KEY": "sk-test"}
+    )
+    def test_openai_isinstance_transparent_when_cache_enabled(
+        self, mock_from_env: MagicMock
+    ) -> None:
+        """isinstance(create_provider('openai'), OpenAIClient) is True with cache."""
+        from rfc.openai_client import OpenAIClient
+
+        mock_from_env.return_value = MagicMock()
+        client = create_provider(provider="openai")
+        assert isinstance(client, OpenAIClient)
 
 
 class TestLLMClientAlias:


### PR DESCRIPTION
## Summary

Closes #531.

With `ANSWER_CACHE_ENABLED=1`, `create_provider()` returns a `CachingProvider` wrapper. `isinstance(p, OllamaProvider)` / `isinstance(p, OpenAIProvider)` was silently `False` because `CachingProvider` is not a subclass of either. This broke 6 tests in `TestCreateProvider` and posed a runtime correctness risk in any production branch that dispatches on provider type.

**Fix:** add `@property __class__` to `CachingProvider` returning `type(self._client)`. Python's `isinstance()` checks `obj.__class__` when `type(obj)` doesn't match (PEP 3119 virtual-subclassing path), making the wrapper invisible to isinstance callers.

- `type()` still returns `CachingProvider` — not a subclass, just a virtual delegation
- `as_ollama()` / `unwrap_provider()` continue to work unchanged
- `type: ignore[misc]` on the decorator (mypy: read-only property overriding read-write `object.__class__` is intentional; CachingProvider does not support `__class__` assignment)

## How to review

Three changed files:
- `src/rfc/answer_cache.py:292` — the `@property __class__` on `CachingProvider`
- `tests/test_answer_cache.py` — replaced `test_caching_provider_breaks_ollamaclient_isinstance` (documented old broken behaviour) with `test_caching_provider_isinstance_transparent` (documents new transparent behaviour; also verifies `as_ollama()` is unaffected)
- `tests/test_llm_client.py` — added `TestCreateProviderWithCache` with 3 tests: Ollama isinstance, type() check, and OpenAI isinstance, all under mocked `AnswerCache.from_env` with `ANSWER_CACHE_ENABLED=1`

## Evidence of testing

- `uv run pytest tests/test_llm_client.py` — **15 passed** (12 original + 3 new)
- `uv run pytest tests/test_answer_cache.py` — **39 passed** (replaces the 1 isinstance test, 38 others unchanged)
- `uv run mypy src/rfc/answer_cache.py` — **no issues**
- `uv run ruff check` — **clean**
- `make robot-dryrun` — **665/665 passed**
- Pre-existing failures (git-signing infra, `test_harness_snapshot`): unrelated, present on `claude-code-staging` baseline

## Critical changes

- `ANSWER_CACHE_ENABLED=1` path now returns a provider that passes `isinstance(p, OllamaClient)` — any code that previously silently branched wrong with caching enabled now branches correctly.
- No behaviour change when cache is disabled (the common case); `_maybe_wrap_with_cache` returns the unwrapped client directly.

## Grep for production isinstance-on-provider

Only one production `isinstance(*, OllamaClient)` exists (`llm_client.py:as_ollama`) and it already unwraps first — not affected.

https://claude.ai/code/session_016hVLqvgnsALNnGYzb2JWo6

---
_Generated by [Claude Code](https://claude.ai/code/session_016hVLqvgnsALNnGYzb2JWo6)_