### PR TITLE
chore: switch all role agents to claude-opus-4-8 (fable blocked)

### DIFF
--- a/.claude/agents/design.md
+++ b/.claude/agents/design.md
@@ -2,7 +2,7 @@
 name: design
 description: Design space — not a loop. An open-ended thinking partner with full awareness of the codebase, issues, PRs, test plans, and the other three role loops. Use for design chats, architecture vibes, exploring directions, and proposing system-wide improvements to any part of the system or the process itself.
 tools: Read, Write, Edit, Grep, Glob, Bash, WebFetch, WebSearch
-model: claude-fable-5
+model: claude-opus-4-8
 ---
 
 You are the **design** role. You are not a loop and you have no queue. You are

--- a/.claude/agents/engineering.md
+++ b/.claude/agents/engineering.md
@@ -2,7 +2,7 @@
 name: engineering
 description: Engineering loop. Picks up status:ready GitHub issues in priority order, implements them on a branch, and opens pull requests. Use for any implementation work, bug fixes, or feature builds driven by the issue queue.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: claude-fable-5
+model: claude-opus-4-8
 ---
 
 You are the **engineering** role. Your loop converts `status:ready` issues into

--- a/.claude/agents/project-management.md
+++ b/.claude/agents/project-management.md
@@ -2,7 +2,7 @@
 name: project-management
 description: Project management loop. Triages issues, sets priorities, promotes issues to status:ready in resolution order for engineering, reviews testing and quality health, monitors systems and CI, and files issues for anything falling through the cracks. Use for backlog grooming, prioritization, and program health checks.
 tools: Read, Grep, Glob, Bash
-model: claude-fable-5
+model: claude-opus-4-8
 ---
 
 You are the **project-management** role. You are the only role allowed to decide

--- a/.claude/agents/test-design.md
+++ b/.claude/agents/test-design.md
@@ -2,7 +2,7 @@
 name: test-design
 description: Test design loop. Reviews open pull requests, writes test plans for them, executes the plans, posts PASS/FAIL verdicts, and files issues for failures or coverage gaps. Use for PR verification, test planning, and quality gating.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: claude-fable-5
+model: claude-opus-4-8
 ---
 
 You are the **test-design** role. Your loop is the quality gate: no PR merges

--- a/ai/GIT.md
+++ b/ai/GIT.md
@@ -101,7 +101,7 @@ mandatory on agent-authored commits:
 ```bash
 git -C "$WT" commit -s --trailer "Model:<model-id>" -m "..."
 # produces:  Signed-off-by: rfc-design-agent <design@agents.rfc>
-#            Model: claude-fable-5
+#            Model: claude-opus-4-8
 ```
 
 `commit -s` derives `Signed-off-by:` from the identity in effect, so the

--- a/scripts/check_agent_signoffs.py
+++ b/scripts/check_agent_signoffs.py
@@ -5,7 +5,7 @@ Per ai/GIT.md, every agent-authored commit (author email *@agents.rfc) must
 carry BOTH trailers:
 
   Signed-off-by: rfc-<role>-agent <<role>@agents.rfc>
-  Model: <model-id>            (e.g. claude-fable-5)
+  Model: <model-id>            (e.g. claude-opus-4-8)
 
 so the history records which role *and* which model produced each change.
 Human-authored commits (any non-@agents.rfc author) are exempt. CI only


### PR DESCRIPTION
## Summary

The Claude Fable 5 service was **blocked by the government**, so every role session fails to launch — all four role definitions pin `model: claude-fable-5`. This switches them to the best available Opus model, **`claude-opus-4-8`**.

Confirmed live this session: a `design` role subagent failed with *"Claude Fable 5 is currently unavailable"* and only ran once I overrode the model to opus.

## Changes
- `.claude/agents/{design,engineering,project-management,test-design}.md` — `model: claude-fable-5` → `model: claude-opus-4-8`
- `ai/GIT.md` + `scripts/check_agent_signoffs.py` — the two doc comments that illustrate the `Model:` trailer updated to the new example (fable is dead).
- **Left untouched:** `tests/fixtures/dialog_imports/*` and signoff/dialog tests that carry `claude-fable-5` as *recorded-session data* — they simulate captured transcripts, not role config; changing them would churn tests for no reason.

## How to review
- `grep '^model:' .claude/agents/*.md` → all four read `claude-opus-4-8`.
- No logic change. The agent-signoff CI guard (`check_agent_signoffs.py`) checks for the *presence* of a `Model:` trailer, not its value.

## Evidence of testing
- `uv run ruff check scripts/check_agent_signoffs.py` → All checks passed
- `uv run pytest tests/test_agent_signoffs.py -q` → 7 passed
- `python3 scripts/check_agent_signoffs.py` runs clean

## Known unrelated CI red
Staging is currently RED on the lint gate due to a **pre-existing** F811 duplicate import in `tests/test_bootstrap_dashboards.py` (tracked in **#544**), unrelated to this change. This PR's `Ruff check` job will inherit that failure until #544 is fixed/merged. Nothing in this diff touches that file.

No version bump (role-config + doc comments only, per the skip-for-docs/CI policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)