### PR TITLE
fix: remove duplicate _agentic_dataset_is_current import (F811, #544)

### DIFF
--- a/tests/test_bootstrap_dashboards.py
+++ b/tests/test_bootstrap_dashboards.py
@@ -713,7 +713,6 @@ from bootstrap_dashboards import (  # noqa: E402
     _AGENTIC_LAYOUT_SECTIONS,
     _AGENTIC_TABLE_DDL,
     _AGENTIC_VIRTUAL_DATASETS,
-    _agentic_dataset_is_current,
     _build_agentic_position_json,
 )
 


### PR DESCRIPTION
## Summary
Fixes the `F811` in #544: `tests/test_bootstrap_dashboards.py` imported `_agentic_dataset_is_current` twice (line 36 and again in the agentic import block), reddening CI **Lint & Typecheck → Ruff check** for every PR. Removes the duplicate from the second block; the symbol stays imported at line 36 and all usages resolve.

## How to review
Diff is one deleted line. `git diff` shows only the duplicate import removed.

## Evidence of testing
- `uv run ruff check tests/test_bootstrap_dashboards.py` → All checks passed (F811 gone)
- `uv run pytest tests/test_bootstrap_dashboards.py -q` → 85 passed

## ⚠️ CI will still be red — second blocker
The whole-repo lint gate (`ruff check .`) has a **second** error this PR does not touch: `F841 unused 'budget'` in `scripts/run_local_models.py:687` — a dropped #515 runtime budget hard-stop regression, filed as **#555**. **Staging CI greens only when both #544 and #555 land.** Recommend merging this together with the #555 fix.

Closes #544. No version bump (test-file lint hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)