### PR TITLE
fix: restore runtime budget hard-stop in run_provider_suites (#555)

### DIFF
--- a/scripts/run_local_models.py
+++ b/scripts/run_local_models.py
@@ -684,6 +684,7 @@ def run_provider_suites(
     # is unset; resolved absolute so the scheduler and the cwd=_project_root
     # subprocess agree on one file (#515).
     budget_file = _resolve_budget_file()
+    budget = ProviderBudget(budget_file)
 
     # Normalize to an explicit (model, suite) run list. ``jobs`` (from the
     # #510 planner) runs an exact, possibly partial, budget-planned subset;
@@ -700,6 +701,15 @@ def run_provider_suites(
     prev_start: float | None = None
     for model, suite in run_list:
         watermark = f"{provider.name}/{model}"
+        # Runtime hard-stop: re-read the shared counter before each dispatch so
+        # retry/429 overshoot that the upfront estimate cannot anticipate is
+        # caught and the provider's remaining jobs are skipped (#515).
+        if budget.exhausted(provider.name, provider.max_requests_per_day):
+            print(
+                f"  {tag} daily budget exhausted — stopping remaining job(s) "
+                f"(skip-and-log, #515)."
+            )
+            break
         # #525: never run a privacy/context-ineligible suite, even if a caller
         # passes it explicitly in jobs.
         skip_reason = _provider_suite_skip_reason(suite, provider)

--- a/tests/test_run_local_models.py
+++ b/tests/test_run_local_models.py
@@ -1270,6 +1270,48 @@ class TestRunProviderSuites:
         assert [r.returncode for r in results] == [1, 0, 0, 0]
         assert results[0].model == "openrouter/a/b:free"
 
+    @patch("scripts.run_local_models.subprocess.run")
+    def test_runtime_budget_exhausted_before_first_job_stops_all(
+        self, mock_run: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Budget already exhausted → no subprocess launched, skip-and-log (#515)."""
+        with patch("scripts.run_local_models.ProviderBudget") as mock_cls:
+            inst = MagicMock()
+            inst.exhausted.return_value = True
+            mock_cls.return_value = inst
+            results = run_provider_suites(
+                _provider_config(),
+                _provider(max_requests_per_day=10),
+                "sk-or-abc",
+                ["a/b:free", "c/d:free"],
+                sleep_fn=lambda _s: None,
+            )
+        mock_run.assert_not_called()
+        assert results == []
+        assert "budget exhausted" in capsys.readouterr().out.lower()
+
+    @patch("scripts.run_local_models.subprocess.run")
+    def test_runtime_budget_exhausted_mid_run_stops_remaining(
+        self, mock_run: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Budget exhausted after first job → remaining jobs not dispatched (#515)."""
+        mock_run.return_value = MagicMock(returncode=0)
+        with patch("scripts.run_local_models.ProviderBudget") as mock_cls:
+            inst = MagicMock()
+            # First check passes; all subsequent checks see exhaustion.
+            inst.exhausted.side_effect = [False, True, True, True]
+            mock_cls.return_value = inst
+            results = run_provider_suites(
+                _provider_config(),
+                _provider(max_requests_per_day=10),
+                "sk-or-abc",
+                ["a/b:free", "c/d:free"],
+                sleep_fn=lambda _s: None,
+            )
+        assert mock_run.call_count == 1
+        assert len(results) == 1
+        assert "budget exhausted" in capsys.readouterr().out.lower()
+
 
 class TestRunProviderRuns:
     def test_no_providers_configured_is_noop(self) -> None:


### PR DESCRIPTION
## Summary

Closes the functional regression tracked in #555.

PR #558 correctly removed the dead `budget = ProviderBudget(budget_file)` assignment (F841 Ruff), but the *runtime hard-stop* that assignment was supposed to drive was never re-wired. Without it, `run_provider_suites` dispatches all pre-planned jobs even when the shared counter shows the day's limit has already been hit mid-run — the gap #515 was built to close (retry/429 overshoot the upfront `plan_within_budget` estimate cannot anticipate).

## Changes

**`scripts/run_local_models.py`**
- Instantiate `budget = ProviderBudget(budget_file)` once, right after `_resolve_budget_file()`, before the dispatch loop.
- At the top of each `for model, suite in run_list:` iteration, check `budget.exhausted(provider.name, provider.max_requests_per_day)`; if exhausted, print a skip-and-log message and `break` — matching the CLAUDE.md skip-and-log pattern.
- No change to the subprocess env wiring (`BUDGET_FILE_ENV`/`PROVIDER_NAME_ENV`) — that path is unchanged.

**`tests/test_run_local_models.py`**
- `test_runtime_budget_exhausted_before_first_job_stops_all`: mocks `ProviderBudget.exhausted` → `True` from the start; asserts `subprocess.run` is never called and "budget exhausted" appears in stdout.
- `test_runtime_budget_exhausted_mid_run_stops_remaining`: `exhausted` returns `False` once then `True`; asserts exactly 1 subprocess call (first job runs, rest stopped).

## Evidence of testing

```
uv run pytest tests/test_run_local_models.py tests/test_provider_budget.py -q
# 98 passed in 0.38s

uv run ruff check scripts/run_local_models.py tests/test_run_local_models.py
# All checks passed!

make robot-dryrun
# 665 tests, 665 passed, 0 failed
```

Pre-existing environment failures (`test_answer_cache.py` — `fakeredis` not installed; `test_submodule_ownership_integration.py` — git fixture limitations; `test_harness_cli_kw.py` — sidecar socket) are unrelated to this change and present on `claude-code-staging` HEAD before this branch.

## How to review

Diff is 52 lines across 2 files. Focus on:
1. `scripts/run_local_models.py` lines ~686–710: `budget` instantiation + loop-top exhaustion check
2. `tests/test_run_local_models.py`: the two new test methods in `TestRunProviderSuites`

**Never mark ready / merge** — promotion is the owner's call.

Refs: #555, #515, #558

---
_Generated by [Claude Code](https://claude.ai/code/session_015W6eFfuTbCdisaT523oimo)_