### PR TITLE
feat: upgrade SWE-bench to Verified dataset + SWEBENCH_SLICE filter (#563)

### DIFF
--- a/robot/swebench/swebench.robot
+++ b/robot/swebench/swebench.robot
@@ -9,6 +9,7 @@ Library           Collections
 
 *** Variables ***
 ${SWEBENCH_SPLIT}       test
+${SWEBENCH_SLICE}       %{SWEBENCH_SLICE=all}
 ${MAX_INSTANCES}        10
 ${DEFAULT_MODEL}        %{DEFAULT_MODEL}
 
@@ -17,7 +18,7 @@ SWE-bench Patch Generation And Validation
     [Documentation]    Iterate over SWE-bench instances, generate patches, and validate.
     ...               Per-instance failures are recorded but do not abort the loop.
     [Tags]    tier:4    verify:llm    swebench
-    ${instances}=    Load SWEBench Instances    split=${SWEBENCH_SPLIT}    max_instances=${MAX_INSTANCES}
+    ${instances}=    Load SWEBench Instances    split=${SWEBENCH_SPLIT}    max_instances=${MAX_INSTANCES}    swebench_slice=${SWEBENCH_SLICE}
     ${failures}=    Create List
     FOR    ${instance}    IN    @{instances}
         ${status}=    Run Keyword And Return Status    Run SWEBench Instance    ${instance}

--- a/src/rfc/swebench_keywords.py
+++ b/src/rfc/swebench_keywords.py
@@ -16,10 +16,32 @@ from .docker_config import ContainerConfig, ContainerNetwork, ContainerResources
 from .rfc_data import emit_rfc_data
 from .swebench_models import PatchResult, SWEBenchInstance
 
-_SWEBENCH_DATASET = "princeton-nlp/SWE-bench"
+_SWEBENCH_DATASET = "princeton-nlp/SWE-bench_Verified"
 _DEFAULT_DOCKER_IMAGE = "python:3.11-slim"
 _PATCH_APPLY_CMD = "git apply --allow-empty /tmp/patch.diff"
 _TEST_RUN_CMD = "python -m pytest --tb=short -q"
+
+
+def _filter_by_slice(
+    rows: List[Dict[str, Any]], swebench_slice: str
+) -> List[Dict[str, Any]]:
+    """Filter dataset rows by difficulty slice (easy/hard).
+
+    Rows without a 'difficulty' field, or where no rows match, fall back to
+    returning all rows (skip-and-log behaviour).
+    """
+    filtered = [
+        r for r in rows if str(r.get("difficulty", "")).lower() == swebench_slice
+    ]
+    if not filtered:
+        from robot.api import logger as _logger  # type: ignore[import-untyped]
+
+        _logger.warn(
+            f"SWEBENCH_SLICE={swebench_slice!r}: no rows matched difficulty={swebench_slice!r}; "
+            "returning all rows (dataset may lack a 'difficulty' field)"
+        )
+        return rows
+    return filtered
 
 
 def _load_dataset(dataset: str, split: str) -> List[Dict[str, Any]]:
@@ -56,13 +78,16 @@ class SWEBenchKeywords:
         split: str = "test",
         max_instances: int = 10,
         dataset: str = _SWEBENCH_DATASET,
+        swebench_slice: str = "all",
     ) -> List[SWEBenchInstance]:
         """Load SWE-bench instances from the HuggingFace dataset.
 
         Args:
             split: Dataset split (test, dev, train).
             max_instances: Maximum number of instances to load.
-            dataset: HuggingFace dataset name (e.g. princeton-nlp/SWE-bench_Lite).
+            dataset: HuggingFace dataset name (e.g. princeton-nlp/SWE-bench_Verified).
+            swebench_slice: Difficulty filter — all | easy | hard. Falls back to all
+                when the dataset lacks a 'difficulty' field or no rows match.
 
         Returns:
             List of SWEBenchInstance objects.
@@ -70,9 +95,11 @@ class SWEBenchKeywords:
         max_instances = int(max_instances)
         logger.info(
             f"Loading SWE-bench instances: dataset={dataset}, "
-            f"split={split}, max={max_instances}"
+            f"split={split}, slice={swebench_slice}, max={max_instances}"
         )
         rows = _load_dataset(dataset, split=split)
+        if swebench_slice != "all":
+            rows = _filter_by_slice(rows, swebench_slice)
         instances = [SWEBenchInstance.from_dict(row) for row in rows[:max_instances]]
         logger.info(f"Loaded {len(instances)} SWE-bench instances")
         return instances

--- a/tests/test_swebench_keywords.py
+++ b/tests/test_swebench_keywords.py
@@ -74,11 +74,13 @@ class TestLoadInstances:
         assert instances == []
 
     @patch("rfc.swebench_keywords._load_dataset")
-    def test_load_defaults_to_swebench_dataset(self, mock_load: MagicMock) -> None:
+    def test_load_defaults_to_swebench_verified(self, mock_load: MagicMock) -> None:
         mock_load.return_value = [_SAMPLE_DATASET_ROW]
         kw = SWEBenchKeywords()
         kw.load_swebench_instances(split="test", max_instances=1)
-        mock_load.assert_called_once_with("princeton-nlp/SWE-bench", split="test")
+        mock_load.assert_called_once_with(
+            "princeton-nlp/SWE-bench_Verified", split="test"
+        )
 
     @patch("rfc.swebench_keywords._load_dataset")
     def test_load_accepts_dataset_override(self, mock_load: MagicMock) -> None:
@@ -91,6 +93,66 @@ class TestLoadInstances:
         )
         mock_load.assert_called_once_with("princeton-nlp/SWE-bench_Lite", split="test")
         assert len(instances) == 1
+
+
+# ---------------------------------------------------------------------------
+# SWEBENCH_SLICE filtering
+# ---------------------------------------------------------------------------
+
+_EASY_ROW: Dict[str, Any] = {**_SAMPLE_DATASET_ROW, "difficulty": "easy"}
+_HARD_ROW: Dict[str, Any] = {
+    **_SAMPLE_DATASET_ROW,
+    "difficulty": "hard",
+    "instance_id": "django__django-99999",
+}
+
+
+class TestSWEBenchSlice:
+    @patch("rfc.swebench_keywords._load_dataset")
+    def test_slice_all_returns_all_instances(self, mock_load: MagicMock) -> None:
+        mock_load.return_value = [_EASY_ROW, _HARD_ROW]
+        kw = SWEBenchKeywords()
+        instances = kw.load_swebench_instances(
+            split="test", max_instances=10, swebench_slice="all"
+        )
+        assert len(instances) == 2
+
+    @patch("rfc.swebench_keywords._load_dataset")
+    def test_slice_easy_returns_only_easy_instances(self, mock_load: MagicMock) -> None:
+        mock_load.return_value = [_EASY_ROW, _HARD_ROW]
+        kw = SWEBenchKeywords()
+        instances = kw.load_swebench_instances(
+            split="test", max_instances=10, swebench_slice="easy"
+        )
+        assert len(instances) == 1
+        assert instances[0].instance_id == "django__django-11099"
+
+    @patch("rfc.swebench_keywords._load_dataset")
+    def test_slice_hard_returns_only_hard_instances(self, mock_load: MagicMock) -> None:
+        mock_load.return_value = [_EASY_ROW, _HARD_ROW]
+        kw = SWEBenchKeywords()
+        instances = kw.load_swebench_instances(
+            split="test", max_instances=10, swebench_slice="hard"
+        )
+        assert len(instances) == 1
+        assert instances[0].instance_id == "django__django-99999"
+
+    @patch("rfc.swebench_keywords._load_dataset")
+    def test_slice_no_match_falls_back_to_all(self, mock_load: MagicMock) -> None:
+        rows = [{**_SAMPLE_DATASET_ROW}]  # no difficulty field
+        mock_load.return_value = rows
+        kw = SWEBenchKeywords()
+        instances = kw.load_swebench_instances(
+            split="test", max_instances=10, swebench_slice="easy"
+        )
+        assert len(instances) == 1
+
+    @patch("rfc.swebench_keywords._load_dataset")
+    def test_slice_default_is_all(self, mock_load: MagicMock) -> None:
+        mock_load.return_value = [_EASY_ROW, _HARD_ROW]
+        kw = SWEBenchKeywords()
+        instances = kw.load_swebench_instances(split="test", max_instances=10)
+        assert len(instances) == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the remaining scope of #563 (the description fix already landed on `claude-code-staging` per `config/test_suites.yaml:210`).

- Switch default dataset from `princeton-nlp/SWE-bench` → `princeton-nlp/SWE-bench_Verified` (`_SWEBENCH_DATASET` constant in `src/rfc/swebench_keywords.py`)
- Add `SWEBENCH_SLICE` env var (`all` / `easy` / `hard`) passed as `swebench_slice=` to `Load SWEBench Instances` — filters by the dataset's `difficulty` field; falls back to all instances with a `logger.warn` when no rows match (skip-and-log, per `ai/agents.md` contract)
- `${MAX_INSTANCES}` override is unchanged
- Existing `dataset=` override parameter still works for Lite / full benchmarks

## How to review

**Start here:** `src/rfc/swebench_keywords.py`
- `_SWEBENCH_DATASET` (line 19): constant change
- `_filter_by_slice` (lines 25–44): new module function — skip-and-log when `difficulty` field is absent or unmatched
- `load_swebench_instances` (line 76): `swebench_slice` parameter wired in

**Robot side:** `robot/swebench/swebench.robot` — one new variable `${SWEBENCH_SLICE}` with `%{SWEBENCH_SLICE=all}` default; passed to the keyword.

**Tests:** `tests/test_swebench_keywords.py` — updated `test_load_defaults_to_swebench_verified` + new `TestSWEBenchSlice` class (5 tests: all, easy, hard, no-match fallback, default).

## Evidence of testing

```
uv run pytest tests/test_swebench_keywords.py -q
20 passed in 0.24s  ← 15 original + 5 new slice tests

uv run ruff check src/rfc/swebench_keywords.py tests/test_swebench_keywords.py
All checks passed!

uv run mypy src/rfc/swebench_keywords.py --ignore-missing-imports
Success: no issues found in 1 source file

make robot-dryrun
665 tests, 665 passed, 0 failed
```

Pre-existing failures (test_answer_cache.py — missing fakeredis; test_submodule_ownership_integration.py — environment setup; test_harness_cli_kw.py, test_keywords.py — sidecar/LLM not available) are unrelated to this change.

## Critical changes

**Behaviour change:** the default dataset for new `robot-dryrun`-free runs switches from `SWE-bench` (full) to `SWE-bench_Verified` (500 curated instances). Runs using the existing `SWEBENCH_SPLIT=test` default will now pull from the verified set. Override with `dataset=princeton-nlp/SWE-bench` to restore the old default.

## Checklist

- [x] All pytest tests pass (20 swebench tests, no new failures)
- [x] ruff check passes on changed files
- [x] mypy passes on changed files (`--ignore-missing-imports`)
- [x] robot-dryrun passes (665/665)
- [x] Self-reviewed diff — no scope creep, no debug prints
- [x] Changes comply with `ai/agents.md` contract (skip-and-log)
- [x] Type hints on all new Python
- [x] Commit history is atomic and bisectable
- [x] Version bump: n/a (no public keyword signature change — `swebench_slice` is additive with a default)

*Draft only — promotion to ready is the owner's call.*

https://claude.ai/code/session_01UZWvdzE4Wv8PxXHuA4fZdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZWvdzE4Wv8PxXHuA4fZdX)_