### PR TITLE
fix: strip provider prefix in estimate_cost for watermarked IDs (#612)

### DIFF
--- a/src/rfc/cost_estimator.py
+++ b/src/rfc/cost_estimator.py
@@ -80,8 +80,18 @@ def estimate_cost(
     completion_tokens: int,
     pricing: dict[str, ModelPrice],
 ) -> float:
-    """Estimated USD for one request. Unlisted (free-tier) models cost 0."""
-    price_in, price_out = pricing.get(model, (0.0, 0.0))
+    """Estimated USD for one request. Unlisted (free-tier) models cost 0.
+
+    Provider-prefixed watermark IDs (e.g. ``openrouter/openai/gpt-4o``) are
+    normalised by stripping the leading segment so they match pricing table
+    keys (e.g. ``openai/gpt-4o``). Exact match is preferred. (#612)
+    """
+    if model in pricing:
+        price_in, price_out = pricing[model]
+    elif "/" in model:
+        price_in, price_out = pricing.get(model.split("/", 1)[1], (0.0, 0.0))
+    else:
+        price_in, price_out = 0.0, 0.0
     return (max(0, prompt_tokens) / 1e6) * price_in + (
         max(0, completion_tokens) / 1e6
     ) * price_out

--- a/tests/test_cost_estimator.py
+++ b/tests/test_cost_estimator.py
@@ -49,6 +49,29 @@ def test_estimate_cost_zero_tokens() -> None:
     assert estimate_cost("m", 0, 0, {"m": (2.0, 6.0)}) == 0.0
 
 
+def test_estimate_cost_strips_provider_prefix() -> None:
+    # Watermarked OpenRouter IDs include a provider prefix ("openrouter/openai/gpt-4o")
+    # but the pricing table keys by raw model ID ("openai/gpt-4o"). #612
+    pricing = {"openai/gpt-4o": (2.5, 10.0)}
+    cost = estimate_cost("openrouter/openai/gpt-4o", 1_000_000, 1_000_000, pricing)
+    assert cost == 2.5 + 10.0
+
+
+def test_estimate_cost_exact_match_preferred_over_prefix_strip() -> None:
+    # If the full watermarked ID is in the table, use it directly. #612
+    pricing = {
+        "openrouter/openai/gpt-4o": (1.0, 2.0),
+        "openai/gpt-4o": (2.5, 10.0),
+    }
+    assert estimate_cost("openrouter/openai/gpt-4o", 1_000_000, 0, pricing) == 1.0
+
+
+def test_estimate_cost_prefix_strip_fallback_only_strips_one_segment() -> None:
+    # Stripping only the first segment: "a/b/c" → lookup "b/c", not "c". #612
+    pricing = {"b/c": (4.0, 0.0)}
+    assert estimate_cost("a/b/c", 1_000_000, 0, pricing) == 4.0
+
+
 # ── load_pricing_table (file loader) ──────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Fixes #612 — all OpenRouter runs recorded $0 cost because the pricing lookup key
(watermarked as `openrouter/openai/gpt-4o`) never matched the pricing table
entry (keyed as `openai/gpt-4o`).

## Root cause

`db_listener.on_suite_end()` passes `model_name` — which may include a provider
prefix set by `RFC_MODEL_NAME` (e.g. `openrouter/openai/gpt-4o`) — directly to
`estimate_cost()`. The pricing table in `config/local_models.yaml` keys by the
**raw** model ID (`openai/gpt-4o`), so the dict lookup always missed and
silently returned $0.00.

## Fix

`cost_estimator.estimate_cost()` now normalises before the lookup:
1. Try the exact model string first.
2. If not found **and** the ID contains `/`, try the suffix after the first `/`
   (`openrouter/openai/gpt-4o` → `openai/gpt-4o`).
3. Fall back to $0.00 (free-tier default, fail-open discipline).

Exact match is always preferred, so table entries that use the full watermarked
ID will still work correctly.

## How to review

- `src/rfc/cost_estimator.py`: 10-line change to `estimate_cost()`.
- `tests/test_cost_estimator.py`: 3 new tests — provider prefix stripped,
  exact match preferred, only first segment stripped.

## Evidence of testing

```
uv run pytest tests/test_cost_estimator.py -v   →  18 passed
uv run ruff check + format --check              →  All checks passed
uv run mypy src/rfc/cost_estimator.py           →  Pre-existing PyYAML stub warning only (unrelated)
make robot-dryrun                               →  665/665 passed
uv run pytest --ignore=tests/test_answer_cache.py  →  pre-existing 9 fail / 40 err baseline unchanged; +3 new passes
```

Pre-existing failures (9 failed, 40 errors) are in `test_submodule_ownership_integration.py`
and `test_answer_cache.py` (missing `fakeredis`) — confirmed present on clean staging HEAD
before this branch.

## Critical changes

None. This is a pure normalisation fix in the pricing lookup path — no schema
changes, no data loss risk, no behavioural change for free-tier (unlisted) models.
The monthly-budget alarm accuracy improves once paid OpenRouter entries are added
to `config/local_models.yaml`.

## Checklist

- [x] TDD: failing tests committed before fix
- [x] `uv run pytest` passes (new tests green, baseline unchanged)
- [x] ruff lint + format clean
- [x] mypy: no new errors introduced
- [x] `make robot-dryrun` 665/665
- [x] No changes outside `src/rfc/` and `tests/`
- [x] Type hints present on modified function
- [ ] Owner review and promotion to ready (never merged by agents)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2kCDa2orbVA2jJUX1Xnep)_