### PR TITLE
fix: resolve ruff format drift blocking staging CI (Refs #568)

### DIFF
--- a/tests/test_db_listener.py
+++ b/tests/test_db_listener.py
@@ -1503,10 +1503,14 @@ class TestDbListenerAccumulatesMultiCallMetrics:
         listener = DbListener()
         listener.start_test(_mock_test_data("T"), _mock_test_result())
         listener.log_message(
-            _mock_message('RFC_DATA:llm_metrics:{"eval_count": 30, "prompt_eval_count": 60}')
+            _mock_message(
+                'RFC_DATA:llm_metrics:{"eval_count": 30, "prompt_eval_count": 60}'
+            )
         )
         listener.log_message(
-            _mock_message('RFC_DATA:llm_metrics:{"eval_count": 20, "prompt_eval_count": 40}')
+            _mock_message(
+                'RFC_DATA:llm_metrics:{"eval_count": 20, "prompt_eval_count": 40}'
+            )
         )
         listener.end_test(_mock_test_data("T"), _mock_test_result("PASS"))
         assert listener._test_cases[0]["eval_count"] == 50
@@ -1516,7 +1520,9 @@ class TestDbListenerAccumulatesMultiCallMetrics:
         listener = DbListener()
         listener.start_test(_mock_test_data("T"), _mock_test_result())
         listener.log_message(
-            _mock_message('RFC_DATA:llm_metrics:{"eval_count": 186, "prompt_eval_count": 512}')
+            _mock_message(
+                'RFC_DATA:llm_metrics:{"eval_count": 186, "prompt_eval_count": 512}'
+            )
         )
         listener.end_test(_mock_test_data("T"), _mock_test_result("PASS"))
         assert listener._test_cases[0]["eval_count"] == 186

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -121,14 +121,14 @@ class TestGraderLlmMetricsEmission:
         calls = [str(c) for c in mock_logger.info.call_args_list]
         metrics_calls = [c for c in calls if "RFC_DATA:llm_metrics" in c]
         assert metrics_calls
-        payload = json.loads(metrics_calls[0].split("RFC_DATA:llm_metrics:")[1].rstrip("'\"(),"))
+        payload = json.loads(
+            metrics_calls[0].split("RFC_DATA:llm_metrics:")[1].rstrip("'\"(),")
+        )
         assert payload["eval_count"] == 77
         assert payload["prompt_eval_count"] == 200
 
     @patch("rfc.rfc_data.logger")
-    def test_no_emit_when_last_metrics_is_none(
-        self, mock_logger: MagicMock
-    ) -> None:
+    def test_no_emit_when_last_metrics_is_none(self, mock_logger: MagicMock) -> None:
         client = MagicMock()
         client.generate.return_value = '{"score": 1, "reason": "ok"}'
         client.last_metrics = None


### PR DESCRIPTION
## Summary

Staging CI (`Robot Framework Tests` → `Lint & Typecheck` → **Ruff format check**) is currently **red**. After PR #614 (cost-telemetry) merged, `ruff 0.14.10 format --check` flags two test files, which fails the whole pipeline. This reformats them. Refs #568.

## How to review

**Start here:** the entire diff is mechanical `ruff format` output — long string arguments wrapped onto their own lines in `tests/test_db_listener.py` and `tests/test_grader.py`.
**Key changes:** none beyond formatting.
**What to ignore:** all of it is whitespace/line-wrapping; no logic touched.

Note on #568: that issue named `tests/test_llm_client.py`, which is **already clean** on staging (its merge-race drift was resolved by a later merge). The same drift *class* re-appeared in two other files after #614 — that's what this PR fixes. I left #568 open for you to decide whether to close it or keep it as the tracking issue.

## Evidence of testing

<details>
<summary>ruff 0.14.10 format --check (pinned version)</summary>

```
317 files already formatted
```
</details>

<details>
<summary>pytest (the two affected files)</summary>

```
150 passed in 1.86s
```
</details>

## Critical changes

None. Formatting-only change to test files; no behavior, API, schema, or config change.

## Checklist

- [x] `ruff format --check` passes (pinned 0.14.10)
- [x] affected tests pass (150)
- [x] atomic commit, agent sign-off + `Model:` trailer (contract guard)
- [x] no changes outside intended scope
- [ ] full `uv run pytest` / `pre-commit` / `robot-dryrun` — left to CI (formatting-only change)
- [ ] human review + merge (HITL — I do not merge)
