### PR TITLE
feat: add subagent role taxonomy config (#599)

### DIFF
--- a/config/claude_code_roles.yaml
+++ b/config/claude_code_roles.yaml
@@ -1,0 +1,162 @@
+# Subagent role taxonomy for the Claude Code multi-host sweep (Goal 2, issue #594).
+#
+# Each role defines the task class a subagent is assigned during a sweep run.
+# The `primary_graders` list names grader keys defined in the `graders` section
+# below; the sweep harness uses them to score model-role fitness.
+#
+# Consumed by: robot/claude_code/ harnesses (issues #596–#601), sweep reporter.
+
+roles:
+  planner:
+    description: "Decomposes a high-level goal into an ordered, dependency-aware task plan."
+    inputs:
+      - goal_description
+      - codebase_context
+    outputs:
+      - task_list
+      - dependency_graph
+    primary_graders:
+      - plan_completeness
+      - step_ordering
+      - dependency_accuracy
+
+  coder:
+    description: "Implements a single task from a plan, producing a passing, clean diff."
+    inputs:
+      - task_description
+      - codebase_context
+      - test_requirements
+    outputs:
+      - code_diff
+      - commit_message
+    primary_graders:
+      - tests_pass
+      - lint_clean
+      - type_check_clean
+
+  reviewer:
+    description: "Reviews a code diff for correctness and adherence to project standards."
+    inputs:
+      - code_diff
+      - project_standards
+    outputs:
+      - findings_list
+      - verdict
+    primary_graders:
+      - bug_detection_rate
+      - false_positive_rate
+      - standards_coverage
+
+  test-author:
+    description: "Authors a failing test suite for a feature or bug before implementation."
+    inputs:
+      - feature_description
+      - existing_tests
+      - framework_conventions
+    outputs:
+      - test_file
+      - coverage_report
+    primary_graders:
+      - test_runnable
+      - test_fails_before_impl
+      - tier_correct
+      - tags_correct
+
+  search:
+    description: "Locates relevant code, files, or documentation for a given query."
+    inputs:
+      - query
+      - codebase_context
+    outputs:
+      - file_paths
+      - line_references
+      - summary
+    primary_graders:
+      - precision
+      - recall
+      - false_negative_rate
+
+# ---------------------------------------------------------------------------
+# Grader definitions
+# ---------------------------------------------------------------------------
+# type: llm_judge  — scored by an LLM judge at sweep-report time
+# type: command    — pass/fail derived from a shell command exit code
+# type: yaml_check — structural assertion on the produced YAML artifact
+# ---------------------------------------------------------------------------
+
+graders:
+  # planner graders
+  plan_completeness:
+    type: llm_judge
+    metric: fraction_of_required_steps_present
+
+  step_ordering:
+    type: llm_judge
+    metric: topological_sort_violations
+
+  dependency_accuracy:
+    type: llm_judge
+    metric: fraction_of_dependencies_correctly_identified
+
+  # coder graders
+  tests_pass:
+    type: command
+    command: "uv run pytest"
+    success_criterion: exit_code_0
+
+  lint_clean:
+    type: command
+    command: "uv run ruff check ."
+    success_criterion: exit_code_0
+
+  type_check_clean:
+    type: command
+    command: "uv run mypy src/rfc/"
+    success_criterion: exit_code_0
+
+  # reviewer graders
+  bug_detection_rate:
+    type: llm_judge
+    metric: fraction_of_introduced_bugs_flagged
+
+  false_positive_rate:
+    type: llm_judge
+    metric: fraction_of_correct_code_flagged_as_buggy
+
+  standards_coverage:
+    type: llm_judge
+    metric: fraction_of_relevant_standards_checked
+
+  # test-author graders
+  test_runnable:
+    type: command
+    command: "uv run pytest {test_file} --collect-only"
+    success_criterion: exit_code_0
+
+  test_fails_before_impl:
+    type: command
+    command: "uv run pytest {test_file}"
+    success_criterion: exit_code_nonzero
+
+  tier_correct:
+    type: yaml_check
+    field: tags
+    constraint: "contains_one_of(tier:0, tier:1, tier:2, tier:3, tier:4)"
+
+  tags_correct:
+    type: yaml_check
+    field: tags
+    constraint: "contains_one_of(verify:robot, verify:python, verify:llm, verify:human)"
+
+  # search graders
+  precision:
+    type: llm_judge
+    metric: fraction_of_returned_items_that_are_relevant
+
+  recall:
+    type: llm_judge
+    metric: fraction_of_relevant_items_returned
+
+  false_negative_rate:
+    type: llm_judge
+    metric: fraction_of_relevant_items_missed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "robotframework-chat"
-version = "1.17.4"
+version = "1.17.5"
 description = "Robot Framework-based test harness for systematically testing LLMs"
 license = "Apache-2.0"
 readme = "readme.md"

--- a/tests/test_claude_code_roles.py
+++ b/tests/test_claude_code_roles.py
@@ -1,0 +1,68 @@
+"""Validates structure of config/claude_code_roles.yaml (issue #599)."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROLES_CONFIG = Path(__file__).parent.parent / "config" / "claude_code_roles.yaml"
+
+REQUIRED_ROLES = {"planner", "coder", "reviewer", "test-author", "search"}
+REQUIRED_ROLE_FIELDS = {"description", "inputs", "outputs", "primary_graders"}
+
+
+def _load() -> dict:
+    with ROLES_CONFIG.open() as fh:
+        return yaml.safe_load(fh)
+
+
+class TestRolesConfigExists:
+    def test_file_present(self) -> None:
+        assert ROLES_CONFIG.exists(), f"Missing {ROLES_CONFIG}"
+
+
+class TestRolesStructure:
+    def test_all_required_roles_present(self) -> None:
+        cfg = _load()
+        assert "roles" in cfg
+        missing = REQUIRED_ROLES - set(cfg["roles"].keys())
+        assert not missing, f"Missing roles: {missing}"
+
+    @pytest.mark.parametrize("role", sorted(REQUIRED_ROLES))
+    def test_role_has_required_fields(self, role: str) -> None:
+        cfg = _load()
+        role_def = cfg["roles"][role]
+        for field in REQUIRED_ROLE_FIELDS:
+            assert field in role_def, f"Role {role!r} missing field {field!r}"
+
+    @pytest.mark.parametrize("role", sorted(REQUIRED_ROLES))
+    def test_role_has_at_least_one_grader(self, role: str) -> None:
+        cfg = _load()
+        graders = cfg["roles"][role].get("primary_graders", [])
+        assert graders, f"Role {role!r} has empty primary_graders"
+
+    def test_graders_section_defined(self) -> None:
+        cfg = _load()
+        assert "graders" in cfg
+        assert len(cfg["graders"]) > 0
+
+    def test_all_referenced_graders_are_defined(self) -> None:
+        cfg = _load()
+        defined = set(cfg.get("graders", {}).keys())
+        for role_name, role_def in cfg["roles"].items():
+            for grader in role_def.get("primary_graders", []):
+                assert grader in defined, (
+                    f"Role {role_name!r} references undefined grader {grader!r}"
+                )
+
+    @pytest.mark.parametrize("role", sorted(REQUIRED_ROLES))
+    def test_role_inputs_is_nonempty_list(self, role: str) -> None:
+        cfg = _load()
+        inputs = cfg["roles"][role].get("inputs", [])
+        assert isinstance(inputs, list) and inputs, f"Role {role!r} has empty inputs"
+
+    @pytest.mark.parametrize("role", sorted(REQUIRED_ROLES))
+    def test_role_outputs_is_nonempty_list(self, role: str) -> None:
+        cfg = _load()
+        outputs = cfg["roles"][role].get("outputs", [])
+        assert isinstance(outputs, list) and outputs, f"Role {role!r} has empty outputs"


### PR DESCRIPTION
## Summary

Adds `config/claude_code_roles.yaml` defining the 5 subagent role labels
(planner, coder, reviewer, test-author, search) with per-role inputs, outputs,
and primary graders for the Goal 2 multi-host sweep (issue #594). Closes #599.
The taxonomy is the shared contract that sweep harnesses (#596–#601) and the
comparison report (#601) will use to tag each run by role and compare
model-role fitness scores.

## How to review

**Start here:** `config/claude_code_roles.yaml` — the entire deliverable is
this file. The Python test file validates its structure; no application code
was added.

**Key changes:**
- `config/claude_code_roles.yaml` — 5 roles × (description, inputs, outputs,
  primary_graders), plus a graders section with type (llm_judge | command |
  yaml_check) and metric/command/constraint per grader.
- `tests/test_claude_code_roles.py` — 24 parametrized tests asserting all
  required roles, fields, and grader cross-references are present and non-empty.

**What to ignore:** The version bump (`1.17.4 → 1.17.5` in `pyproject.toml`)
is mechanical.

## Evidence of testing

<details>
<summary>pytest output (new tests only)</summary>

```
tests/test_claude_code_roles.py::TestRolesConfigExists::test_file_present PASSED
tests/test_claude_code_roles.py::TestRolesStructure::test_all_required_roles_present PASSED
tests/test_claude_code_roles.py::TestRolesStructure::test_role_has_required_fields[coder] PASSED
tests/test_claude_code_roles.py::TestRolesStructure::test_role_has_required_fields[planner] PASSED
tests/test_claude_code_roles.py::TestRolesStructure::test_role_has_required_fields[reviewer] PASSED
tests/test_claude_code_roles.py::TestRolesStructure::test_role_has_required_fields[search] PASSED
tests/test_claude_code_roles.py::TestRolesStructure::test_role_has_required_fields[test-author] PASSED
tests/test_claude_code_roles.py::TestRolesStructure::test_role_has_at_least_one_grader[coder] PASSED
tests/test_claude_code_roles.py::TestRolesStructure::test_role_has_at_least_one_grader[planner] PASSED
tests/test_claude_code_roles.py::TestRolesStructure::test_role_has_at_least_one_grader[reviewer] PASSED
tests/test_claude_code_roles.py::TestRolesStructure::test_role_has_at_least_one_grader[search] PASSED
tests/test_claude_code_roles.py::TestRolesStructure::test_role_has_at_least_one_grader[test-author] PASSED
tests/test_claude_code_roles.py::TestRolesStructure::test_graders_section_defined PASSED
tests/test_claude_code_roles.py::TestRolesStructure::test_all_referenced_graders_are_defined PASSED
tests/test_claude_code_roles.py::TestRolesStructure::test_role_inputs_is_nonempty_list[coder] PASSED
... (all 24 passed in 0.26s)
```
</details>

<details>
<summary>pre-commit output</summary>

```
pre-commit not installed in this cloud execution environment (pre-existing
baseline constraint — noted in prior PRs #527, #533). ruff check + ruff
format confirmed clean on the Python test file:
  uv run ruff check tests/test_claude_code_roles.py  → All checks passed!
  uv run ruff format --check tests/test_claude_code_roles.py → 1 file already formatted
```
</details>

<details>
<summary>code-quality-check output</summary>

```
Pre-existing mypy failures (import-untyped for yaml, requests, docker stubs)
unrelated to this PR — identical to baseline on staging. No new mypy or ruff
errors introduced by this change.
```
</details>

<details>
<summary>robot-dryrun output</summary>

```
665 tests, 665 passed, 0 failed
```
</details>

## Critical changes

`config/claude_code_roles.yaml` is a new config file with no existing
consumers — the harness code that will read it is part of issues #596–#601
(not yet built). The schema is not frozen; the sweep harness authors should
align their loader with this structure and propose adjustments via PR if needed.

## Checklist

- [x] All pytest tests pass (24/24 for new tests; pre-existing baseline
  failures in env unrelated to this change)
- [ ] pre-commit passes (not available in cloud env — ruff/format manually confirmed clean)
- [ ] code-quality-check passes (pre-existing mypy stub failures in env)
- [x] robot-dryrun passes (665/665)
- [x] Self-reviewed diff — no scope creep, no debug prints
- [x] Changes comply with `ai/agents.md` contract
- [x] Changes comply with `ai/testing.md` tier rules
- [x] No Robot tests added (config + test only)
- [x] No unresolved `TODO`/`FIXME` in changed files
- [x] Type hints on all new Python code (`tests/test_claude_code_roles.py` fully typed)
- [x] Commit history is atomic and bisectable (3 commits: test → config → version bump)
- [x] Version bump: `1.17.4 → 1.17.5` in `pyproject.toml`

---
_Generated by [Claude Code](https://claude.ai/code/session_016C5k3hvc2QJfxWE45zDY7J)_