### PR TITLE
feat: OpenAI Evals scaffold — dataset loader, llm_judge, schema columns (#621)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ AGENT_VARS  = $(VAR_BASE) --variable MODEL_HARNESS:$(or $(MODEL_HARNESS),unknown
         robot-review \
         robot-bash robot-c robot-rust robot-computer-skills \
         robot robot-math robot-accounting robot-docker robot-safety robot-superset robot-multilingual robot-dryrun \
-        robot-swebench swebench-discover \
+        robot-swebench swebench-discover robot-openai-evals \
         retry-failed retry-skipped \
         rebot-merge rebot-merge-all \
         discover-local-nodes discover-local-models run-local-models run-all-external \
@@ -134,6 +134,9 @@ robot-multilingual: ## Run multilingual instruction-following tests (Robot Frame
 
 robot-swebench: ## Run SWE-bench evaluation (Robot Framework)
 	$(ROBOT) -d $(call LLM_RUN_DIR,swebench) $(call LLM_META,swebench) $(LLM_VARS) $(LISTENER) $(ARGS) robot/swebench/
+
+robot-openai-evals: ## Run OpenAI Evals harness (Robot Framework)
+	$(ROBOT) -d $(call LLM_RUN_DIR,openai-evals) $(call LLM_META,openai-evals) $(LLM_VARS) $(LISTENER) $(ARGS) robot/openai_evals/
 
 swebench-discover: ## List available SWE-bench instances
 	uv run python scripts/run_swebench.py --discover

--- a/config/local_models.yaml
+++ b/config/local_models.yaml
@@ -186,6 +186,11 @@ test_suites:
     description: "SWE-bench patch generation and validation"
     timeout_seconds: 7200
 
+  - name: "openai-evals"
+    path: "robot/openai_evals/"
+    description: "OpenAI Evals harness scaffolding — dataset loader and llm_judge grader integration"
+    timeout_seconds: 600
+
   - name: "react"
     path: "robot/react/"
     description: "ReAct reasoning loop tests — multi-step think/tool-call/observe/conclude chains"

--- a/config/test_suites.yaml
+++ b/config/test_suites.yaml
@@ -209,6 +209,11 @@ test_suites:
     path: "robot/swebench"
     description: "SWE-bench patch generation and validation against real GitHub issues"
 
+  openai-evals:
+    label: "OpenAI Evals"
+    path: "robot/openai_evals"
+    description: "OpenAI Evals harness scaffolding — dataset loader and llm_judge grader integration"
+
   react:
     label: "ReAct Loop"
     path: "robot/react"

--- a/robot/openai_evals/openai_evals.robot
+++ b/robot/openai_evals/openai_evals.robot
@@ -1,0 +1,14 @@
+*** Settings ***
+Documentation    OpenAI Evals harness scaffold — Issue #621.
+...              Real eval cases live in a future issue once the external
+...              dataset dependency is available in CI.
+
+*** Variables ***
+${PLACEHOLDER}    stub
+
+*** Test Cases ***
+Scaffold Placeholder
+    [Documentation]    Stub test to keep the suite runnable until real eval
+    ...                cases are wired up.
+    [Tags]    tier:1    verify:functional
+    Log    OpenAI Evals suite loaded — no live cases yet

--- a/src/rfc/eval_datasets.py
+++ b/src/rfc/eval_datasets.py
@@ -1,0 +1,33 @@
+"""Shared Hugging Face dataset loader for OpenAI Evals and AIEFS harnesses (#621)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def load_hf_dataset(dataset: str, split: str) -> List[Dict[str, Any]]:
+    """Load a Hugging Face dataset split. Isolated for mocking in tests.
+
+    Raises MissingDependencyError when the ``datasets`` package is absent so
+    callers see a clear actionable message rather than a bare ImportError.
+    """
+    try:
+        from datasets import load_dataset  # type: ignore[import-untyped]
+    except ImportError as e:
+        from .exceptions import MissingDependencyError
+
+        raise MissingDependencyError(
+            package="datasets",
+            install_hint="uv pip install 'robotframework-chat[swebench]'",
+        ) from e
+    ds = load_dataset(dataset, split=split)
+    return list(ds)
+
+
+def iter_instances(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return rows as a new list.
+
+    A no-op today; the indirection gives future transforms (filtering,
+    field normalisation) a single place to land without changing callers.
+    """
+    return list(rows)

--- a/src/rfc/eval_graders.py
+++ b/src/rfc/eval_graders.py
@@ -1,0 +1,34 @@
+"""Shared grader functions for OpenAI Evals and AIEFS harnesses (#621).
+
+Wraps ``Grader.grade()`` as a module-level callable so downstream harnesses
+import a stable function, not a class internals contract.  ``exec_judge``
+(Docker sandbox grading) lives in the Docker-touching slice of #562.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .grader import Grader
+    from .models import GradeResult
+
+
+def llm_judge(
+    grader: "Grader",
+    question: str,
+    expected: str,
+    actual: str,
+) -> "GradeResult":
+    """LLM-judge grader — delegates to ``Grader.grade()``.
+
+    Args:
+        grader: A ``Grader`` instance backed by an LLM client.
+        question: The question posed to the model under test.
+        expected: The reference / gold-standard answer.
+        actual: The model's actual answer to evaluate.
+
+    Returns:
+        ``GradeResult`` with ``score`` (0.0–1.0) and ``reason``.
+    """
+    return grader.grade(question, expected, actual)

--- a/src/rfc/swebench_keywords.py
+++ b/src/rfc/swebench_keywords.py
@@ -45,18 +45,10 @@ def _filter_by_slice(
 
 
 def _load_dataset(dataset: str, split: str) -> List[Dict[str, Any]]:
-    """Load SWE-bench dataset.  Isolated for easy mocking in tests."""
-    try:
-        from datasets import load_dataset  # type: ignore[import-untyped]
-    except ImportError as e:
-        from .exceptions import MissingDependencyError
+    """Load SWE-bench dataset.  Delegates to the shared eval_datasets loader."""
+    from .eval_datasets import load_hf_dataset
 
-        raise MissingDependencyError(
-            package="datasets",
-            install_hint="uv pip install 'robotframework-chat[swebench]'",
-        ) from e
-    ds = load_dataset(dataset, split=split)
-    return list(ds)
+    return load_hf_dataset(dataset, split=split)
 
 
 class SWEBenchKeywords:

--- a/src/rfc/test_database.py
+++ b/src/rfc/test_database.py
@@ -100,6 +100,13 @@ class TestResult:
     # cached answer rather than measuring a fresh model call.
     cache_hit: bool = False
     thinking_tokens: int = 0
+    # Issue #621: eval-harness provenance columns.
+    benchmark: str = ""
+    split: str = ""
+    instance_id: str = ""
+    grader_model: str = ""
+    wall_seconds: float = 0.0
+    cost_usd: float = 0.0
     id: int = -1
 
 
@@ -204,6 +211,12 @@ SELECT
     tr.eval_count,
     tr.cache_hit,
     tr.thinking_tokens,
+    tr.benchmark,
+    tr.split,
+    tr.instance_id,
+    tr.grader_model,
+    tr.wall_seconds,
+    tr.cost_usd,
     r.timestamp,
     r.model_name,
     r.test_suite,
@@ -319,6 +332,12 @@ class _SQLiteBackend(_Backend):
         eval_count INTEGER,
         cache_hit INTEGER DEFAULT 0,
         thinking_tokens INTEGER,
+        benchmark TEXT DEFAULT '',
+        split TEXT DEFAULT '',
+        instance_id TEXT DEFAULT '',
+        grader_model TEXT DEFAULT '',
+        wall_seconds REAL DEFAULT 0,
+        cost_usd REAL DEFAULT 0,
         FOREIGN KEY (run_id) REFERENCES test_runs(id) ON DELETE CASCADE
     );
 
@@ -406,6 +425,13 @@ class _SQLiteBackend(_Backend):
         "ALTER TABLE test_runs ADD COLUMN prompt_tokens INTEGER DEFAULT 0",
         "ALTER TABLE test_runs ADD COLUMN completion_tokens INTEGER DEFAULT 0",
         "ALTER TABLE test_runs ADD COLUMN estimated_cost_usd REAL DEFAULT 0",
+        # Issue #621: eval-harness provenance columns.
+        "ALTER TABLE test_results ADD COLUMN benchmark TEXT DEFAULT ''",
+        "ALTER TABLE test_results ADD COLUMN split TEXT DEFAULT ''",
+        "ALTER TABLE test_results ADD COLUMN instance_id TEXT DEFAULT ''",
+        "ALTER TABLE test_results ADD COLUMN grader_model TEXT DEFAULT ''",
+        "ALTER TABLE test_results ADD COLUMN wall_seconds REAL DEFAULT 0",
+        "ALTER TABLE test_results ADD COLUMN cost_usd REAL DEFAULT 0",
     ]
 
     def __init__(self, db_path: str):
@@ -469,8 +495,10 @@ class _SQLiteBackend(_Backend):
                     INSERT INTO test_results
                     (run_id, test_name, test_status, score, tags,
                      tag_severity, tag_tier, tag_verify,
-                     eval_count, cache_hit, thinking_tokens)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     eval_count, cache_hit, thinking_tokens,
+                     benchmark, split, instance_id,
+                     grader_model, wall_seconds, cost_usd)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         r.run_id,
@@ -484,6 +512,12 @@ class _SQLiteBackend(_Backend):
                         r.eval_count,
                         1 if r.cache_hit else 0,
                         r.thinking_tokens,
+                        r.benchmark,
+                        r.split,
+                        r.instance_id,
+                        r.grader_model,
+                        r.wall_seconds,
+                        r.cost_usd,
                     ),
                 )
                 row_id = cursor.lastrowid
@@ -760,6 +794,13 @@ class _SQLAlchemyBackend(_Backend):
         "INTEGER DEFAULT 0",
         "ALTER TABLE test_runs ADD COLUMN IF NOT EXISTS estimated_cost_usd "
         "REAL DEFAULT 0",
+        # Issue #621: eval-harness provenance columns.
+        "ALTER TABLE test_results ADD COLUMN IF NOT EXISTS benchmark TEXT DEFAULT ''",
+        "ALTER TABLE test_results ADD COLUMN IF NOT EXISTS split TEXT DEFAULT ''",
+        "ALTER TABLE test_results ADD COLUMN IF NOT EXISTS instance_id TEXT DEFAULT ''",
+        "ALTER TABLE test_results ADD COLUMN IF NOT EXISTS grader_model TEXT DEFAULT ''",
+        "ALTER TABLE test_results ADD COLUMN IF NOT EXISTS wall_seconds REAL DEFAULT 0",
+        "ALTER TABLE test_results ADD COLUMN IF NOT EXISTS cost_usd REAL DEFAULT 0",
         # Joined view for Superset — lean columns + archive LEFT JOIN.
         f"CREATE VIEW test_results_full AS {TEST_RESULTS_FULL_VIEW_BODY}",
     ]
@@ -824,6 +865,12 @@ class _SQLAlchemyBackend(_Backend):
             Column("eval_count", Integer),
             Column("cache_hit", Boolean, server_default=text("false")),
             Column("thinking_tokens", Integer),
+            Column("benchmark", Text, server_default=text("''")),
+            Column("split", Text, server_default=text("''")),
+            Column("instance_id", Text, server_default=text("''")),
+            Column("grader_model", Text, server_default=text("''")),
+            Column("wall_seconds", Float, server_default=text("0")),
+            Column("cost_usd", Float, server_default=text("0")),
             Index("idx_test_results_run_id", "run_id"),
         )
 
@@ -921,6 +968,12 @@ class _SQLAlchemyBackend(_Backend):
                 "eval_count": r.eval_count,
                 "cache_hit": bool(r.cache_hit),
                 "thinking_tokens": r.thinking_tokens,
+                "benchmark": r.benchmark,
+                "split": r.split,
+                "instance_id": r.instance_id,
+                "grader_model": r.grader_model,
+                "wall_seconds": r.wall_seconds,
+                "cost_usd": r.cost_usd,
             }
             for r in results
         ]

--- a/tests/test_eval_datasets.py
+++ b/tests/test_eval_datasets.py
@@ -1,0 +1,54 @@
+"""Tests for eval_datasets — shared HF dataset loader abstraction (#621)."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rfc.exceptions import MissingDependencyError
+
+
+class TestLoadHfDataset:
+    def test_returns_list_of_rows(self) -> None:
+        rows: List[Dict[str, Any]] = [{"id": "a"}, {"id": "b"}]
+        with patch.dict("sys.modules", {"datasets": MagicMock()}):
+            sys.modules["datasets"].load_dataset = MagicMock(return_value=iter(rows))
+            from rfc.eval_datasets import load_hf_dataset
+
+            result = load_hf_dataset("org/repo", "test")
+        assert isinstance(result, list)
+        assert result == rows
+
+    def test_missing_package_raises_missing_dependency_error(self) -> None:
+        # Temporarily remove eval_datasets from cache to force re-import.
+        sys.modules.pop("rfc.eval_datasets", None)
+        with patch.dict("sys.modules", {"datasets": None}):
+            from rfc.eval_datasets import load_hf_dataset
+
+            with pytest.raises(MissingDependencyError):
+                load_hf_dataset("org/repo", "test")
+        sys.modules.pop("rfc.eval_datasets", None)
+
+
+class TestIterInstances:
+    def test_passthrough_returns_same_rows(self) -> None:
+        from rfc.eval_datasets import iter_instances
+
+        rows = [{"instance_id": "x"}, {"instance_id": "y"}]
+        assert list(iter_instances(rows)) == rows
+
+    def test_empty_input(self) -> None:
+        from rfc.eval_datasets import iter_instances
+
+        assert list(iter_instances([])) == []
+
+    def test_returns_new_list(self) -> None:
+        from rfc.eval_datasets import iter_instances
+
+        rows = [{"a": 1}]
+        result = iter_instances(rows)
+        # Must be list, not the same object
+        assert isinstance(result, list)

--- a/tests/test_eval_graders.py
+++ b/tests/test_eval_graders.py
@@ -1,0 +1,38 @@
+"""Tests for eval_graders — llm_judge wrapper over Grader (#621)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from rfc.eval_graders import llm_judge
+from rfc.models import GradeResult
+
+
+class TestLLMJudge:
+    def _make_grader(self, score: float = 0.9, reason: str = "correct") -> MagicMock:
+        grader = MagicMock()
+        grader.grade.return_value = GradeResult(score=score, reason=reason)
+        return grader
+
+    def test_delegates_to_grader_grade(self) -> None:
+        grader = self._make_grader()
+        llm_judge(grader, "q", "expected", "actual")
+        grader.grade.assert_called_once_with("q", "expected", "actual")
+
+    def test_returns_grade_result(self) -> None:
+        grader = self._make_grader(score=1.0, reason="perfect")
+        result = llm_judge(grader, "q", "expected", "actual")
+        assert isinstance(result, GradeResult)
+        assert result.score == 1.0
+        assert result.reason == "perfect"
+
+    def test_zero_score_passes_through(self) -> None:
+        grader = self._make_grader(score=0.0, reason="wrong")
+        result = llm_judge(grader, "q", "expected", "actual")
+        assert result.score == 0.0
+
+    def test_raises_on_none_grader(self) -> None:
+        with pytest.raises((AttributeError, TypeError)):
+            llm_judge(None, "q", "expected", "actual")  # type: ignore[arg-type]

--- a/tests/test_test_database_migration.py
+++ b/tests/test_test_database_migration.py
@@ -379,3 +379,122 @@ class TestCacheHitColumn:
             if "CREATE VIEW test_results_full" in sql
         )
         assert add_idx < view_idx
+
+
+class TestBenchmarkColumns:
+    """Issue #621: benchmark/split/instance_id/grader_model/wall_seconds/cost_usd."""
+
+    _NEW_COLS = [
+        "benchmark",
+        "split",
+        "instance_id",
+        "grader_model",
+        "wall_seconds",
+        "cost_usd",
+    ]
+
+    def test_fresh_db_has_benchmark_columns(self, tmp_path):
+        db_file = tmp_path / "test.db"
+        TestDatabase(db_path=str(db_file))
+        with sqlite3.connect(str(db_file)) as conn:
+            cols = {row[1] for row in conn.execute("PRAGMA table_info(test_results)")}
+        for col in self._NEW_COLS:
+            assert col in cols, f"Expected column {col!r} in test_results"
+
+    def test_columns_added_to_existing_db(self, tmp_path):
+        db_file = tmp_path / "test.db"
+        # Build a pre-#621 database lacking these columns.
+        with sqlite3.connect(str(db_file)) as conn:
+            conn.execute(
+                """
+                CREATE TABLE test_runs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp DATETIME NOT NULL,
+                    model_name TEXT NOT NULL,
+                    test_suite TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE test_results (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    run_id INTEGER NOT NULL,
+                    test_name TEXT NOT NULL,
+                    test_status TEXT NOT NULL
+                )
+                """
+            )
+        TestDatabase(db_path=str(db_file))
+        with sqlite3.connect(str(db_file)) as conn:
+            cols = {row[1] for row in conn.execute("PRAGMA table_info(test_results)")}
+        for col in self._NEW_COLS:
+            assert col in cols, f"Migration should have added {col!r}"
+
+    def test_round_trip_persists_benchmark_fields(self, tmp_path):
+        db_file = tmp_path / "test.db"
+        db = TestDatabase(db_path=str(db_file))
+        run = TestRun(
+            timestamp=datetime(2026, 6, 18, 0, 0, 0),
+            model_name="gpt-4o",
+            test_suite="openai-evals",
+            total_tests=1,
+            passed=1,
+            failed=0,
+            skipped=0,
+            duration_seconds=1.5,
+        )
+        run_id = db.add_test_run(run)
+        db.add_test_results(
+            [
+                TestResult(
+                    run_id=run_id,
+                    test_name="eval_001",
+                    test_status="PASS",
+                    score=0.85,
+                    benchmark="openai/evals",
+                    split="test",
+                    instance_id="001",
+                    grader_model="gpt-4o-mini",
+                    wall_seconds=1.23,
+                    cost_usd=0.0004,
+                )
+            ]
+        )
+        with sqlite3.connect(str(db_file)) as conn:
+            row = conn.execute(
+                "SELECT benchmark, split, instance_id, grader_model, wall_seconds, cost_usd "
+                "FROM test_results WHERE test_name = 'eval_001'"
+            ).fetchone()
+        assert row[0] == "openai/evals"
+        assert row[1] == "test"
+        assert row[2] == "001"
+        assert row[3] == "gpt-4o-mini"
+        assert abs(row[4] - 1.23) < 1e-6
+        assert abs(row[5] - 0.0004) < 1e-9
+
+    def test_dataclass_defaults(self):
+        r = TestResult(run_id=1, test_name="t", test_status="PASS")
+        assert r.benchmark == ""
+        assert r.split == ""
+        assert r.instance_id == ""
+        assert r.grader_model == ""
+        assert r.wall_seconds == 0.0
+        assert r.cost_usd == 0.0
+
+    def test_pg_migrations_add_benchmark_cols_before_view(self):
+        migrations = _SQLAlchemyBackend._PG_MIGRATIONS
+        view_idx = next(
+            i
+            for i, sql in enumerate(migrations)
+            if "CREATE VIEW test_results_full" in sql
+        )
+        for col in self._NEW_COLS:
+            add_idx = next(
+                i
+                for i, sql in enumerate(migrations)
+                if f"ADD COLUMN IF NOT EXISTS {col}" in sql
+            )
+            assert add_idx < view_idx, (
+                f"Migration for {col!r} must appear before CREATE VIEW"
+            )


### PR DESCRIPTION
<!-- rfc-monitor:heartbeat -->

## Summary

Fleet-doable-now slice of #562 per the design audit (June 18). Implements the pure-Python scaffolding with no external Docker or dataset dependencies.

- **`src/rfc/eval_datasets.py`** — shared `load_hf_dataset()` + `iter_instances()` loader, isolated for mocking
- **`src/rfc/eval_graders.py`** — `llm_judge()` wrapper delegating to `Grader.grade()`
- **`src/rfc/test_database.py`** — 6 new eval-provenance columns on `test_results`: `benchmark`, `split`, `instance_id`, `grader_model`, `wall_seconds`, `cost_usd` — in SCHEMA, both migrations lists, view, dataclass (concrete defaults per coding rules), and both `add_test_results()` implementations
- **`src/rfc/swebench_keywords.py`** — `_load_dataset()` now delegates to `eval_datasets.load_hf_dataset()` (eliminates duplication)
- **`config/test_suites.yaml`** + **`config/local_models.yaml`** — `openai-evals` suite registered
- **`Makefile`** — `robot-openai-evals` target added
- **`robot/openai_evals/openai_evals.robot`** — stub suite (real eval cases land in a future issue once the external dataset is available in CI)

## Test plan

- [ ] `uv run pytest tests/test_eval_datasets.py tests/test_eval_graders.py tests/test_test_database_migration.py` — 33 tests, all pass
- [ ] `uv run pytest --ignore=tests/test_answer_cache.py` — 1182 passed (pre-existing fakeredis skip + pre-existing dialog_e2e failure unrelated to this PR)
- [ ] `make robot-dryrun` — 666 tests, 666 passed
- [ ] `make code-quality-check` — lint clean; 19 mypy errors are pre-existing (missing type stubs for yaml/requests/docker, unchanged from baseline)

## Notes

- **Do not merge** — this is a draft; promotion to ready is the owner's call.
- Closes #621 once the owner promotes and merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSRL9c5sVweHaXMaUKKDSe

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSRL9c5sVweHaXMaUKKDSe)_