### PR TITLE
fix: use openai-evals (hyphenated) as suite metadata ID (#624)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ robot-swebench: ## Run SWE-bench evaluation (Robot Framework)
 	$(ROBOT) -d $(call LLM_RUN_DIR,swebench) $(call LLM_META,swebench) $(LLM_VARS) $(LISTENER) $(ARGS) robot/swebench/
 
 robot-openai-evals: ## Run the OpenAI-Evals umbrella suite (scaffolding stub until child suites land — #621)
-	$(ROBOT) -d $(call LLM_RUN_DIR,openai_evals) $(call LLM_META,openai_evals) $(LLM_VARS) $(LISTENER) $(ARGS) robot/openai_evals/
+	$(ROBOT) -d $(call LLM_RUN_DIR,openai-evals) $(call LLM_META,openai-evals) $(LLM_VARS) $(LISTENER) $(ARGS) robot/openai_evals/
 
 swebench-discover: ## List available SWE-bench instances
 	uv run python scripts/run_swebench.py --discover

--- a/tests/test_audit_robot_reports.py
+++ b/tests/test_audit_robot_reports.py
@@ -253,6 +253,30 @@ def test_load_suites_includes_known_suites() -> None:
     assert len(suites) >= 30
 
 
+def test_openai_evals_suite_id_is_hyphenated() -> None:
+    """The LLM_META call for the openai-evals suite must use hyphens, not underscores.
+
+    scripts/audit_robot_reports.py reads test_suite from output.xml metadata
+    and compares it against config/local_models.yaml suite names. The canonical
+    name there is openai-evals (hyphen). If the Makefile passes
+    openai_evals (underscore) to LLM_META, runs recorded under that name are
+    never matched and always appear as MISSING in the coverage matrix.
+    """
+    makefile = Path(__file__).parent.parent / "Makefile"
+    content = makefile.read_text()
+    # The LLM_META call for the openai-evals target must pass the hyphenated name.
+    assert "LLM_META,openai-evals)" in content, (
+        "Makefile LLM_META call for the openai-evals suite must use "
+        "'openai-evals' (hyphen), not 'openai_evals' (underscore). "
+        "Found content: see Makefile robot-openai-evals target."
+    )
+    # The underscore variant must NOT appear as a metadata ID.
+    assert "LLM_META,openai_evals)" not in content, (
+        "Makefile still contains 'LLM_META,openai_evals)' — "
+        "replace it with 'LLM_META,openai-evals)' to match the canonical suite name."
+    )
+
+
 def test_load_master_models_includes_known_model() -> None:
     models = load_master_models()
     assert "llama3" in models


### PR DESCRIPTION
## Summary

- The `robot-openai-evals` Makefile target was passing `openai_evals` (underscore) to both `LLM_META` and `LLM_RUN_DIR`, while the canonical suite name in `config/local_models.yaml:189` and `config/test_suites.yaml:212` is `openai-evals` (hyphen).
- `scripts/audit_robot_reports.py` reads `test_suite` from `output.xml` metadata and compares it against configured suite names — so every run recorded under `openai_evals` appeared as MISSING for `openai-evals` in the coverage matrix.
- Fix: changed `LLM_META,openai_evals)` → `LLM_META,openai-evals)` and `LLM_RUN_DIR,openai_evals)` → `LLM_RUN_DIR,openai-evals)` in the Makefile. The filesystem directory `robot/openai_evals/` is unchanged.

## How to review

Check `Makefile` line 139: both `LLM_RUN_DIR` and `LLM_META` now use `openai-evals` (hyphen). The `robot/openai_evals/` directory path argument is intentionally left with underscores (filesystem path).

## Evidence of testing

- Added `test_openai_evals_suite_id_is_hyphenated` to `tests/test_audit_robot_reports.py` — confirmed it FAILED before the fix and PASSES after.
- Full `uv run pytest --ignore=tests/test_answer_cache.py`: 3698 passed, 26 skipped (5 pre-existing failures from missing `fakeredis` module, all present on `claude-code-staging` before this change).
- `make robot-dryrun`: 666 tests, 666 passed.
- `make code-quality-check`: 19 pre-existing mypy errors (missing type stubs), all present on `claude-code-staging` before this change.

## Critical changes

- `Makefile` line 139: `openai_evals` → `openai-evals` in both macro calls (metadata identifier only; directory path unchanged)
- `tests/test_audit_robot_reports.py`: new regression test `test_openai_evals_suite_id_is_hyphenated`

## Checklist

- [x] TDD: failing test written first, then fix applied
- [x] Only metadata identifier changed; filesystem directory name preserved
- [x] No new test failures introduced
- [x] `make robot-dryrun` passes
- [x] Atomic commit: one logical change

Closes #624

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8ivJwNVnFbAuFYTr8qrsn)_