### PR TITLE
fix: raise multi-turn Test Timeout above OLLAMA_TIMEOUT ceiling (#625)

### DIFF
--- a/robot/multi_turn/test_context_retention.robot
+++ b/robot/multi_turn/test_context_retention.robot
@@ -3,7 +3,7 @@ Documentation     Hold a 5-message conversation where a fact is established
 ...               in turn 1, then probed in turns 3 and 5. Asserts the model
 ...               does not contradict itself (turn-level consistency metric).
 Resource          multi_turn.resource
-Test Timeout      150 minutes
+Test Timeout      360 minutes
 
 *** Test Cases ***
 Birthday Fact Retention

--- a/robot/multi_turn/test_topic_handoff.robot
+++ b/robot/multi_turn/test_topic_handoff.robot
@@ -3,7 +3,7 @@ Documentation     Switch topics abruptly mid-conversation and verify the model
 ...               does not bleed prior context into the new topic. Uses sliding
 ...               window evaluation over post-switch responses.
 Resource          multi_turn.resource
-Test Timeout      150 minutes
+Test Timeout      360 minutes
 
 *** Test Cases ***
 Cooking To Astronomy Handoff


### PR DESCRIPTION
## Summary

Fixes #625. Context-retention and topic-handoff multi-turn suites had `Test Timeout 150 minutes`, which is below the legitimate runtime ceiling when `OLLAMA_TIMEOUT=5400s (90 min)`.

Each test makes up to **4 LLM calls** (3 conversation turns + 1 grading call via `Grade Fact Consistency` / `Grade Topic Isolation Sliding Window`). At 90 min per call the theoretical ceiling is **360 min** — well above the 150 min wall-clock limit. On slow Ollama hardware, even two 80-min responses breach the test timeout before any failure in the model itself, producing spurious FAILED results.

This enforces the documented invariant from `CLAUDE.md § Timeouts`:
> **Invariant: `Test Timeout` >= `OLLAMA_TIMEOUT`.**

## Changes

| File | Before | After | Reason |
|------|--------|-------|--------|
| `robot/multi_turn/test_context_retention.robot` | `Test Timeout 150 minutes` | `Test Timeout 360 minutes` | 4 LLM calls × 90 min = 360 min ceiling |
| `robot/multi_turn/test_topic_handoff.robot` | `Test Timeout 150 minutes` | `Test Timeout 360 minutes` | 5 turns × 90 min, 360 min is reasonable floor |

`test_instruction_following_drift.robot` (`Test Timeout 250 minutes`, 10 turns) is intentionally out of scope — the issue body specifically calls out "the 150-minute timeout" and that file is a separate follow-on.

## Evidence of testing

```
make robot-dryrun  →  666/666 tests parse, 0 failed
uv run ruff check .  →  All checks passed
uv run ruff format --check .  →  322 files already formatted
uv tool run pre-commit run --all-files  →  All hooks passed
uv run pytest (baseline, unchanged)  →  5 pre-existing failures on staging HEAD,
                                         3698 passed, 26 skipped — no regressions
```

Baseline pytest failures (5) are pre-existing on `claude-code-staging` and unrelated to these Robot-file-only changes:
- `test_dialog_e2e_keywords.py::TestDeleteDialogRecording` (×2)
- `test_keywords.py::TestLLMKeywordsThroughCacheWrapper` (×3)

## How to review

1. Confirm `Test Timeout` values in the two changed files are now ≥ `OLLAMA_TIMEOUT` (5400s = 90 min)
2. Verify no logic changes — only the timeout setting line changed in each file
3. Mark ready and merge when satisfied; `test_instruction_following_drift.robot` can be addressed in a follow-on

<!-- rfc-monitor:heartbeat -->
🤖 Draft opened by heartbeat sweep — promotion to ready is the owner's call.

---
_Generated by [Claude Code](https://claude.ai/code/session_0193dwKEEpVB3XGxSa6dtriw)_