### PR TITLE
chore: scrub identifiers from mirror-only files + drop duplicate root PNGs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,11 +39,9 @@ venv.bak/
 *.swo
 *~
 
-# Robot Framework results live in the `results/` submodule
-# (github.com/tkarcheski/robotframework-chat-results). output.xml is LFS-tracked
-# there; heavy HTML / logs are ignored by the submodule's own .gitignore.
-# When the submodule is not initialized (e.g. CI / cloud sessions), ignore the
-# whole directory so dryrun / local run artifacts don't appear as untracked.
+# Robot Framework results are archived externally (output.xml via LFS);
+# ignore the whole directory so dryrun / local run artifacts don't appear
+# as untracked.
 results/
 *.log
 !pilots/**/*.log

--- a/ai/test-plans/PR-432.md
+++ b/ai/test-plans/PR-432.md
@@ -39,7 +39,7 @@ manual command, result recorded in the verdict comment.
 |---|---|---|---|---|
 | H1 | Full unit suite | `uv run pytest -q` in the PR worktree | all pass | E |
 | H2 | Owner bumps own submodule | synthetic repo: commit gitlink bump of `results` as `test-design@agents.rfc`; run script | exit 0 | N |
-| H3 | Human bumps any submodule | same, author `tyler.karcheski@gmail.com` | exit 0 | N |
+| H3 | Human bumps any submodule | same, author `tkarcheski@users.noreply.github.com` | exit 0 | N |
 | H4 | No gitlink changes on branch | run script on this PR worktree with `--base origin/experimental-prompts-fabel` | exit 0, "0 pointer change(s)" | M |
 | H5 | Docs/table consistency | ownership table in `scripts/check_submodule_ownership.py` matches `ai/GIT.md` and `.gitmodules` paths | identical paths + owners | E (TestOwnershipTable) + M (`.gitmodules` cross-check) |
 

--- a/tests/test_agent_signoffs.py
+++ b/tests/test_agent_signoffs.py
@@ -28,7 +28,9 @@ class TestEvaluateCommits:
         assert evaluate_commits([_commit()]) == []
 
     def test_human_commit_exempt(self) -> None:
-        commit = _commit(email="tyler.karcheski@gmail.com", signoffs=[], model="")
+        commit = _commit(
+            email="tkarcheski@users.noreply.github.com", signoffs=[], model=""
+        )
         assert evaluate_commits([commit]) == []
 
     def test_missing_signoff_fails(self) -> None:

--- a/tests/test_submodule_ownership.py
+++ b/tests/test_submodule_ownership.py
@@ -38,7 +38,11 @@ class TestIsAgentEmail:
 
     @pytest.mark.parametrize(
         "email",
-        ["tyler.karcheski@gmail.com", "someone@example.com", "noreply@anthropic.com"],
+        [
+            "tkarcheski@users.noreply.github.com",
+            "someone@example.com",
+            "noreply@anthropic.com",
+        ],
     )
     def test_human_identities(self, email: str) -> None:
         assert not is_agent_email(email)
@@ -70,7 +74,7 @@ class TestEvaluateChanges:
             GitlinkChange(
                 path="results",
                 commit="abc1234",
-                author_email="tyler.karcheski@gmail.com",
+                author_email="tkarcheski@users.noreply.github.com",
             ),
             GitlinkChange(
                 path="monitoring/logs",

--- a/tests/test_submodule_ownership_integration.py
+++ b/tests/test_submodule_ownership_integration.py
@@ -24,7 +24,7 @@ SCRIPT = (
 
 OWNER = "test-design@agents.rfc"
 NON_OWNER = "engineering@agents.rfc"
-HUMAN = "tyler.karcheski@gmail.com"
+HUMAN = "tkarcheski@users.noreply.github.com"
 
 # Arbitrary valid object ids to use as fake submodule pointers.
 SHA_A = "a" * 40


### PR DESCRIPTION
## Summary

v2 clean-public-repo, Phase 2c (mirror-only half). Companion to monorepo PRs #102–#104. These files exist only on the flat public repo — they're carried forward by the non-destructive publisher and no longer sourced from the monorepo, so they need direct fixes here:

- **Email scrub**: `tyler.karcheski@gmail.com` → `tkarcheski@users.noreply.github.com` in `tests/test_agent_signoffs.py`, `tests/test_submodule_ownership.py`, `tests/test_submodule_ownership_integration.py`, and `ai/test-plans/PR-432.md` (identical replacement to monorepo PR #103; preserves the "human, non-`@agents.rfc`" semantics the guards assert).
- **`.gitignore`**: the comment named the private results repo (`github.com/tkarcheski/robotframework-chat-results`) — reworded without the URL; the `results/` ignore pattern is unchanged.
- **Duplicate PNGs**: root-level `superset_example_dashboard.png` / `superset_example_dashboard_2_27.png` deleted — byte-identical (md5-verified) to the `docs/` copies and referenced nowhere.

## How to review

`git grep tyler.karcheski@gmail` on the branch → 0 hits. The PNG deletions are pure dupes; `docs/` copies remain.

## Evidence of testing

- `uv run pytest`: 3905 passed, 4 skipped, **1 pre-existing failure** (`tests/test_bootstrap_dashboards.py::TestResultsFullViewConsistency::test_bootstrap_view_matches_canonical_body`) — fails identically on clean `origin/claude-code-staging` with this diff stashed; unrelated to this change and left for its own fix.
- `uv run ruff check` + `ruff format --check` on tracked dirs: clean (a stale `.claude/worktrees/` checkout trips repo-wide ruff; those worktrees are being pruned separately).
- `uv run mypy src`: no issues in 131 files.
- `make robot-dryrun`: 666/666.

## Version bump

Deliberately skipped: the monorepo is canonical for versions and sits at 1.17.5; the v2.0.0 bump arrives via the Phase 4 release publish. A mirror-side bump here would just create new reverse drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)