### PR TITLE
docs: NEVER merge failing tests — red CI is an absolute blocker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,14 @@ Multiple agents may work on this repo simultaneously, so:
 
 ## Rules
 
+- **NEVER merge — or recommend merging — anything with failing tests or failing
+  CI checks.** Red CI is an absolute blocker, no exceptions:
+  - Never tell the owner a PR is "ready" or "merge = publish" before **every**
+    check has run and passed.
+  - "Pre-existing failure" is not an excuse. A red baseline blocks new work:
+    fix the failure (or get the owner's explicit deferral) before building on it.
+  - This applies to generated PRs too (mirror publishes, automation): a publish
+    PR with failing checks gets fixed at source and regenerated — never merged.
 - `src/rfc/` is the single source of truth for all Python code.
 - `robot/` is the single home for all Robot Framework tests.
 - Type hints required on all new Python code. mypy must pass.


### PR DESCRIPTION
Owner directive (2026-07-02): no PR is merged or called ready while any test or check fails — pre-existing failures included; generated mirror-publish PRs held to the same bar. Companion to rfc-monorepo #111 so both CLAUDE.md files carry the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)