### PR TITLE
fix(ci): scope checkpoint concurrency by event type — stops self-cancelled red checks

### DIFF
--- a/.github/workflows/claude-checkpoints.yml
+++ b/.github/workflows/claude-checkpoints.yml
@@ -22,9 +22,14 @@ permissions:
   issues: write
   pull-requests: write
 
-# One checkpoint per item at a time; newer events supersede in-flight runs.
+# One checkpoint per item PER EVENT TYPE; newer same-type events supersede
+# in-flight runs. The group must include the event name: an issue_comment run
+# (e.g. the auto-assign bot commenting seconds after a PR opens) previously
+# cancelled the pull_request_target run sharing the bare group — and the
+# cancelled run showed as a permanent red "Raise review checkpoint" check on
+# every PR.
 concurrency:
-  group: checkpoint-${{ github.event.issue.number || github.event.pull_request.number }}
+  group: checkpoint-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

Root cause of the recurring red "Raise review checkpoint" check (#636, #637): the workflow's concurrency group is keyed only by issue/PR number with `cancel-in-progress: true`. The auto-assign bot comments seconds after every PR opens, so its `issue_comment` run **cancels the in-flight `pull_request_target` run** sharing the group — and GitHub renders the cancelled run as a failed check on the PR, permanently. Run history on #637 shows exactly this: `pull_request_target → cancelled` at :57, `issue_comment → success` at :01/:14.

Fix: include `github.event_name` in the group so only same-type events supersede each other. Comment storms still coalesce; PR-event runs are no longer collateral.

Same change goes to the monorepo's `core/.github/workflows/` (source of truth) so the next publish carries it — this direct PR just stops every open PR from showing a false red immediately.

## Evidence

`gh run list --workflow=claude-checkpoints.yml`: the failed check on #637 is the cancelled `pull_request_target` run; both `issue_comment` runs succeeded. No script logic changed — two-line concurrency edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)