### PR TITLE
docs: clarify run-local-models host sourcing in audit-robot-reports skill

### DIFF
--- a/.claude/skills/audit-robot-reports/SKILL.md
+++ b/.claude/skills/audit-robot-reports/SKILL.md
@@ -20,11 +20,12 @@ when_to_use: >-
 ## What this is
 
 `make run-local-models` runs every suite in `config/local_models.yaml` against
-every model discovered on the local Ollama fleet, writing one `output.xml` per
-(model, suite, host, session) under the `results/` submodule. After enough runs
-pile up the useful question is **coverage**: which models have actually been
-measured against which suites for the current rfc version, and where are the
-gaps?
+every model available on the curated hosts listed in `host-config.toml`
+(git-ignored, machine-local — see `host-config.toml.example`), writing one
+`output.xml` per (model, suite, host, session) under the `results/` submodule.
+After enough runs pile up the useful question is **coverage**: which models have
+actually been measured against which suites for the current rfc version, and
+where are the gaps?
 
 This skill answers that. The real parsing/matrix/markdown logic lives in
 `scripts/audit_robot_reports.py` (tested, type-hinted) so the Makefile pipeline


### PR DESCRIPTION
## Summary

Updated `.claude/skills/audit-robot-reports/SKILL.md` to clarify that `make run-local-models` reads host configuration from `host-config.toml` (a git-ignored, machine-local file), not from `.env`'s `OLLAMA_ENDPOINT`. This fixes a documentation gap introduced by issue #306's curated-host design — the skill doc was still describing "every model discovered on the local Ollama fleet" without mentioning the actual host-targeting mechanism.

## How to review

**Start here:** Read the single diff in `.claude/skills/audit-robot-reports/SKILL.md` lines 22–29 — it's the "## What this is" introductory section.

**Key changes:**
- `.claude/skills/audit-robot-reports/SKILL.md` — Updated framing from "every model on local fleet" to "every model on curated hosts from host-config.toml"

**What to ignore:** Nothing to ignore — pure docs reflow, no functional changes.

## Evidence of testing

This is a pure documentation change (no Python, no Robot tests affected).

<details>
<summary>robot-dryrun output (unaffected; baseline passes)</summary>

\`\`\`
Robot.Tier4                                                           | PASS |
87 tests, 87 passed, 0 failed
==============================================================================
DryRunListener: 673 tests, 673 passed, 0 failed
Robot                                                                 | PASS |
673 tests, 673 passed, 0 failed
\`\`\`
</details>

## Critical changes

None — pure documentation.

## Reflection (fill in before requesting review)

- **Did we build the right thing?** Yes. The user reported that audit-robot-reports SKILL.md was a step behind the curated-host design (issue #306). This diff clarifies the actual host-targeting mechanism. It reads naturally and is consistent with the rest of the document.
- **Did we even need this?** Yes. The discrepancy between the doc ("every model on fleet") and reality ("every model on curated hosts from host-config.toml") was confusing. A future user trying to understand how `make run-local-models` routes work would hit this doc and get the wrong mental model. The fix is minimal and surgical.
- **Evidence a human can see** The diff itself is the evidence — a 6-line reflow that adds `host-config.toml` mention and removes the misleading "discovered on local fleet" phrasing.
- **What would make this better?** Nothing specific to this change. The overall SKILL.md could cross-link to `host-config.toml.example` or ai/ROLES.md for discovery mechanics, but that's out of scope here.

## Checklist

- [x] All pytest tests pass (baseline has pre-existing failures unrelated to this docs change)
- [x] pre-commit passes (baseline has pre-existing failures unrelated to this docs change)
- [x] code-quality-check passes (baseline has pre-existing failures unrelated to this docs change)
- [x] robot-dryrun passes (673 tests)
- [x] Self-reviewed diff — no scope creep, single-file change
- [x] Changes comply with \`ai/agents.md\` contract (docs only)
- [x] Changes comply with \`ai/testing.md\` tier rules (docs only, no tests affected)
- [x] New Robot tests have \`tier:*\` and \`verify:*\` tags (N/A — no Robot tests)
- [x] No unresolved \`TODO\`/\`FIXME\` in changed files
- [x] Type hints on all new Python code (N/A — docs only)
- [x] Commit history is atomic and bisectable (one commit)
- [x] Version bump confirmed with user — **none needed** (pure docs per CLAUDE.md)

## Sign-off gate (engineering PRs — both required before a human merges)

- [ ] **test-design** signed off — \`TEST-PLAN: PASS\` + \`signoff:test-design\` label (no tests changed)
- [ ] **design** signed off — \`DESIGN: PASS\` + \`signoff:design\` label (doc clarification)