### PR TITLE
docs: fix dead ai/GIT.md refs in rfc-worktree skill (#554)

### DIFF
--- a/.claude/skills/rfc-worktree/SKILL.md
+++ b/.claude/skills/rfc-worktree/SKILL.md
@@ -47,9 +47,9 @@ layout and will produce confusing paths elsewhere.
 ## Step 2 — Gather inputs
 
 **Role sessions skip the question.** If you are a role agent (engineering,
-test-design, project-management, design), `ai/GIT.md` already dictates both
-inputs: `BRANCH="<type>/<issue-number>-<slug>"` (no random suffix) and
-`BASE="origin/claude-code-staging"`. Use them and go straight to Step 3 with
+test-design, project-management, design), `CLAUDE.md § Session startup` already
+dictates both inputs: `BRANCH="<type>/<issue-number>-<slug>"` (no random suffix)
+and `BASE="origin/claude-code-staging"`. Use them and go straight to Step 3 with
 plain `git worktree add` (no `-B` — see below).
 
 Otherwise, ask **one** multiple-choice question that bundles both inputs. Use
@@ -95,7 +95,7 @@ erroring out. That's the user's reference command and matches how they like to
 work — collisions on `claude/<slug>-<rand5>` are vanishingly unlikely thanks
 to the random suffix, but `-B` keeps the skill idempotent.
 
-**Exception — role-contract branches (`<type>/<n>-<slug>`, per `ai/GIT.md`):
+**Exception — role-contract branches (`<type>/<n>-<slug>`, per `CLAUDE.md § Session startup`):
 use plain `git worktree add`, never `-B`.** These names are deterministic, so
 a collision means the branch genuinely exists (another session's work);
 `-B` would silently reset it. Let the command fail loudly and investigate.
@@ -134,7 +134,7 @@ uv sync
 #     targets (robot runs, results archiving) assume they exist.
 git submodule update --init
 
-# 4d. Role sessions only: set the worktree-scoped role identity per ai/GIT.md
+# 4d. Role sessions only: set the worktree-scoped role identity per CLAUDE.md § Role system
 #     (plain `git config` here would rewrite the SHARED .git/config and
 #     re-identify every other session — the --worktree flag is mandatory).
 git config extensions.worktreeConfig true


### PR DESCRIPTION
## Summary

Addresses item 2 from the #554 status comment (2026-07-04): `.claude/skills/rfc-worktree/SKILL.md` is mirror-only and hand-maintained, but contains 3 dead references to `ai/GIT.md` which the publisher drops and which does not exist in this public checkout.

**Changes:**
- Step 2 role-agent note: `ai/GIT.md` → `CLAUDE.md § Session startup`
- Step 3 exception note: `per ai/GIT.md` → `per CLAUDE.md § Session startup`
- Step 4d inline comment: `per ai/GIT.md` → `per CLAUDE.md § Role system`

The inline content (branch naming convention `<type>/<issue-number>-<slug>`, no `-B` for role branches) was already correct — only the cross-reference pointers needed updating.

**Not in scope:** Item 1 (`CLAUDE.md` dead link) requires a fix at source in `core/CLAUDE.md` that publishes to this mirror. Item 4 (CODEOWNERS) is owner's call.

## Evidence of testing

| Check | Result |
|---|---|
| `uv run pytest` | 4 pre-existing collection errors (Superset tests, missing env stubs) — **confirmed pre-existing on bare staging HEAD** via stash test; 0 new failures |
| `make code-quality-check` | 19 pre-existing mypy errors (missing type stubs for `requests`/`docker`/`yaml`) — **confirmed pre-existing on bare staging HEAD**; doc-only change cannot affect Python type checking |
| `make robot-dryrun` | **673/673 passed** |

The pre-existing failures existed on `origin/claude-code-staging` before any change in this branch. Please run `pre-commit run --all-files` locally before marking ready (pre-commit not available in the cloud execution environment).

Closes #554 item 2 only — issue should stay open until item 1 is addressed via the core/ publish and item 4 is ruled on.

---
<!-- rfc-monitor:heartbeat -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01NR1RcF1nqhKAnWmZKoEnBR)_