### PR TITLE
fix(ci): clear the red Lint & Typecheck job on staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ Provenance notes:
   published here via a PR-mode mirror publisher (see the readme's
   Contributing section).
 
+## [1.19.0] — Unreleased
+
+### Added
+
+- **RSI-model priority test lane** (#648): `rfc.rsi_priority` update-detection
+  module (`extract_digest` / `needs_retest` over Ollama `/api/tags` digests)
+  and `scripts/rsi_priority_watcher.py`, which polls the RSI tag and runs a
+  curated fast suite set immediately when the model is re-published, reusing
+  the run-local-models command builder so results archive through the same
+  listeners.
+
 ## [1.18.0] — Unreleased
 
 The clean-public-repo wave: everything that ships to the public mirror was

--- a/scripts/rsi_priority_watcher.py
+++ b/scripts/rsi_priority_watcher.py
@@ -156,15 +156,11 @@ def _run_rsi_suites(
 def _parse_endpoint(spec: str) -> tuple[str, str]:
     """Parse a ``NAME=URL`` --endpoint value into a (name, url) pair."""
     if "=" not in spec:
-        raise argparse.ArgumentTypeError(
-            f"--endpoint must be NAME=URL, got: {spec!r}"
-        )
+        raise argparse.ArgumentTypeError(f"--endpoint must be NAME=URL, got: {spec!r}")
     name, url = spec.split("=", 1)
     name, url = name.strip(), url.strip()
     if not name or not url:
-        raise argparse.ArgumentTypeError(
-            f"--endpoint must be NAME=URL, got: {spec!r}"
-        )
+        raise argparse.ArgumentTypeError(f"--endpoint must be NAME=URL, got: {spec!r}")
     return name, url
 
 
@@ -184,9 +180,7 @@ def _resolve_hosts(args: argparse.Namespace) -> list[tuple[str, str]]:
 def watch(args: argparse.Namespace) -> int:
     """Main poll/react loop. Returns a process exit code."""
     config = load_local_config()
-    suites = _select_suites(
-        config, names=args.suites, all_suites=args.all_suites
-    )
+    suites = _select_suites(config, names=args.suites, all_suites=args.all_suites)
     if not suites:
         _log("no suites selected; nothing to do")
         return 1


### PR DESCRIPTION
## Summary

Restores a green `claude-code-staging` baseline. Two independent breaks landed via #648: `scripts/rsi_priority_watcher.py` fails `ruff format --check`, and pyproject was bumped to 1.19.0 without a CHANGELOG top section, failing `test_changelog_top_section_matches_pyproject_version`. Red baseline blocks all of today's v2 burndown merges.

## How to review

**Start here:** the two commits are independent and each self-explanatory.

**Key changes:**
- `scripts/rsi_priority_watcher.py` — mechanical `ruff format`, 3+/9−, no behavior change
- `CHANGELOG.md` — new `## [1.19.0] — Unreleased` section documenting the #648 RSI priority lane

**What to ignore:** nothing else is touched.

## Evidence of testing

<details>
<summary>pytest output</summary>

```
1 failed, 3936 passed, 4 skipped in 61.21s   # before (test_changelog_top_section_matches_pyproject_version)
19 passed in 0.08s                           # tests/test_release.py after the CHANGELOG fix
```
</details>

<details>
<summary>ruff / mypy</summary>

```
uv run ruff format --check .   # clean after commit 1 (worktree-local noise excluded — untracked)
uv run ruff check .            # clean on tracked files
uv run mypy src/               # Success: no issues found in 140 source files
```
</details>

## Critical changes

None — style + docs only.

## Reflection (fill in before requesting review)

- **Did we build the right thing?** The ask is a green CI baseline before the v2 burndown day; this diff is the minimal set of fixes for the only two failing steps.
- **Did we even need this?** Yes — CLAUDE.md forbids merging on a red baseline, so everything today queues behind this.
- **Evidence a human can see** — pytest/ruff/mypy output above; the PR's own Lint & Typecheck run is the end-to-end proof.
- **What would make this better?** The root cause is mirror-only drift: #648's files have no monorepo source, so the publish overlay can never fix them. A monorepo backport PR (in flight today) + a staged-tree ruff gate in mirror-publish.yml close that hole permanently.

## Checklist

- [x] All pytest tests pass
- [x] pre-commit passes
- [x] code-quality-check passes (ruff + mypy)
- [x] robot-dryrun passes (no .robot changes)
- [x] Self-reviewed diff — no scope creep, no debug prints
- [x] Changes comply with `ai/agents.md` contract
- [x] Changes comply with `ai/testing.md` tier rules
- [x] New Robot tests have `tier:*` and `verify:*` tags (n/a)
- [x] No unresolved `TODO`/`FIXME` in changed files
- [x] Type hints on all new Python code (n/a)
- [x] Commit history is atomic and bisectable
- [x] Version bump confirmed with user (n/a — style/docs only; version stays 1.19.0)

## Sign-off gate (engineering PRs — both required before a human merges)

- [ ] **test-design** signed off — `TEST-PLAN: PASS` + `signoff:test-design` label (coverage incl. integration verified)
- [ ] **design** signed off — `DESIGN: PASS` + `signoff:design` label (right thing, right shape, promotion-safe)
- [ ] `sign-off gate` CI check is green (both labels present, no stale verdict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)