### PR TITLE
chore: v1.17.5 robot coverage audit artifact

### DIFF
--- a/.claude/audits/2026-07-06-v1.17.5-coverage.md
+++ b/.claude/audits/2026-07-06-v1.17.5-coverage.md
@@ -1,0 +1,64 @@
+# Robot coverage audit — v1.17.5
+
+_Generated 2026-07-06 • 1 models × 44 suites • 0/44 cells covered • host(s): ai1_
+
+**Legend** — ✅ ran, ≥50% pass · ⚠️ ran, <50% pass · 🛑 ran, 0 tests · ⬜ not run
+
+## Coverage matrix
+
+| Suite | qwen3:32b |
+|---|:---:|
+| math | ⬜ |
+| accounting | ⬜ |
+| safety | ⬜ |
+| refusal-calibration | ⬜ |
+| docker-python | ⬜ |
+| docker-llm | ⬜ |
+| docker-shell | ⬜ |
+| docker-bash | ⬜ |
+| docker-c | ⬜ |
+| docker-rust | ⬜ |
+| ceo | ⬜ |
+| superset | ⚠️ |
+| legal | ⬜ |
+| task-management | ⬜ |
+| c-interview | ⬜ |
+| benchmark | ⬜ |
+| creativity | ⬜ |
+| multi-turn | ⬜ |
+| adversarial | ⬜ |
+| persona | ⬜ |
+| quantization | ⬜ |
+| consistency | ⬜ |
+| bias | ⬜ |
+| format | ⬜ |
+| gaia | ⬜ |
+| json-schema | ⬜ |
+| ifeval | ⬜ |
+| multilingual | ⬜ |
+| hallucination | ⬜ |
+| swebench | ⬜ |
+| openai-evals | ⬜ |
+| react | ⬜ |
+| meta-learning | ⬜ |
+| tool-hallucination | ⬜ |
+| tool-call-schema | ⬜ |
+| superset-dashboards | ⬜ |
+| github-review | ⬜ |
+| agentic-injection | ⬜ |
+| context-window | ⬜ |
+| extraction | ⬜ |
+| code-review | ⬜ |
+| win-win-win | ⬜ |
+| dialog | ⬜ |
+| hitl | ⬜ |
+
+## Model completion (full suite set)
+
+- [ ] qwen3:32b — 1/44 suites
+
+## Gaps
+
+**Suites no model has run (43):** math, accounting, safety, refusal-calibration, docker-python, docker-llm, docker-shell, docker-bash, docker-c, docker-rust, ceo, legal, task-management, c-interview, benchmark, creativity, multi-turn, adversarial, persona, quantization, consistency, bias, format, gaia, json-schema, ifeval, multilingual, hallucination, swebench, openai-evals, react, meta-learning, tool-hallucination, tool-call-schema, superset-dashboards, github-review, agentic-injection, context-window, extraction, code-review, win-win-win, dialog, hitl
+
+**Fleet models with no v1.17.5 data (14):** qwen3.5:27b, llama3, llama3:latest, llama3.1:latest, llama3.2:latest, llama3.3:latest, mistral:latest, mixtral:latest, codellama:latest, gemma:latest, gemma2:latest, phi3:latest, qwen2:latest, deepseek-coder:latest


### PR DESCRIPTION
## Summary

Rescued commit. This audit artifact (`.claude/audits/2026-07-06-v1.17.5-coverage.md`) was committed at 18:15 by local automation while the checkout happened to be on the #649 PR branch, which made #649 misrepresent its own scope (both sign-off reviewers caught it). It has been removed from #649 and preserved here unchanged.

## Your call

- If you want the audit artifact in the public repo: mark ready + merge.
- If not: close this PR and delete the branch — nothing else references it.

Design review note from #649: the file references host `ai1`, which was verified to be the genericized example hostname already used across the tracked tree (not a leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)