### PR TITLE
fix: add served_by to canonical harness column list (#328)

### DIFF
--- a/tests/test_harness_provenance_adversarial.py
+++ b/tests/test_harness_provenance_adversarial.py
@@ -41,7 +41,7 @@ NOW = "2026-07-13T00:00:00Z"
 # positional indices. The provenance set occupies indices 12-16; #277's repeat_idx
 # is appended at index 17, after the provenance set, so it never collides with it;
 # #350's verified_local is appended at index 18, after repeat_idx, for the same
-# reason.
+# reason; #328's served_by is appended at index 19, after verified_local.
 _CANONICAL_HARNESS_COLUMNS = [
     "session_id",
     "tool_name",
@@ -62,6 +62,7 @@ _CANONICAL_HARNESS_COLUMNS = [
     "params_json",
     "repeat_idx",
     "verified_local",
+    "served_by",
 ]
 _PROVENANCE_COLUMNS = _CANONICAL_HARNESS_COLUMNS[12:17]
 


### PR DESCRIPTION
## Summary

The `served_by` column was shipped in #328 (RFC-012 MS5) and added to both the SQLite DDL and the SQLAlchemy Table definition in `harness_db.py`, but `_CANONICAL_HARNESS_COLUMNS` in `tests/test_harness_provenance_adversarial.py` was not updated. This caused two CI failures in `TestIndexAlignmentGuard` (the SQLite and SQLAlchemy column-order alignment guards). Fix: add `'served_by'` at index 19 and update the inline comment.

## How to review

**Start here:** `tests/test_harness_provenance_adversarial.py` lines 39–67 — the only change is a one-item addition to `_CANONICAL_HARNESS_COLUMNS` and a one-clause update to the comment documenting the column ordering invariant.

**Key changes:**
- `tests/test_harness_provenance_adversarial.py`: add `'served_by'` to `_CANONICAL_HARNESS_COLUMNS` (index 19), update inline comment to reference #328.

**What to ignore:** Everything else — no production code was changed.

## Evidence of testing

<details>
<summary>pytest output</summary>

```
# Full suite:
4735 passed, 24 skipped, 1 xfailed, 13 warnings in 161.90s (0:02:41)

# File under test (all 13 tests):
13 passed, 1 warning in 2.57s
```
</details>

<details>
<summary>pre-commit output</summary>

```
ruff check: All checks passed!
ruff format: 339 files already formatted
```
</details>

<details>
<summary>code-quality-check output</summary>

```
ruff: All checks passed!
mypy: no errors (pre-existing notes about untyped functions in container_manager.py/docker_keywords.py, unrelated to this change)
```
</details>

<details>
<summary>robot-dryrun output</summary>

```
740 tests, 740 passed, 0 failed
```
</details>

## Critical changes

None. No schema, API, config, or CI behavior changed — this is a test-only update that re-aligns the guard with a column that was already shipped.

## Reflection

- **Did we build the right thing?** The CI failure was `test_sqlalchemy_table_column_order_matches_canonical` and `test_sqlite_physical_column_order_matches_canonical` both asserting that the actual column list == `_CANONICAL_HARNESS_COLUMNS`. The actual list had `served_by` (shipped in #328); the expected list did not. This diff is exactly that gap.
- **Did we even need this?** Yes — the test's whole purpose is to be a structural guard; a guard that doesn't know about a real column is broken. The fix is the minimum needed.
- **Evidence a human can see:** 0 pytest failures locally after the patch; 2 failures before.
- **What would make this better?** A check in the `served_by` PR itself (or a pre-commit hook) that catches when a new column is added to the DDL/Table without updating this canonical list.

## Checklist

- [x] All pytest tests pass
- [x] pre-commit passes
- [x] code-quality-check passes (ruff + mypy)
- [x] robot-dryrun passes
- [x] Self-reviewed diff — no scope creep, no debug prints
- [x] Changes comply with `ai/agents.md` contract
- [x] Changes comply with `ai/testing.md` tier rules
- [ ] New Robot tests have `tier:*` and `verify:*` tags — N/A (no new Robot tests)
- [x] No unresolved `TODO`/`FIXME` in changed files
- [x] Type hints on all new Python code — N/A (test-only change, no new Python)
- [x] Commit history is atomic and bisectable
- [ ] Version bump confirmed with user — patch bump needed; deferring to owner

## Sign-off gate

- [ ] **test-design** signed off
- [ ] **design** signed off
- [ ] `sign-off gate` CI check is green

---
_Generated by [Claude Code](https://claude.ai/code/session_018tTw3ssjbnHrWC1pFJ4M5A)_