### PR TITLE
feat: add commit-graph data layer for git-history visualization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ AGENT_VARS  = $(VAR_BASE) --variable MODEL_HARNESS:$(or $(MODEL_HARNESS),unknown
         code-quality-check code-quality-coverage code-quality-audit live-leg-gate \
         docker-up docker-down docker-restart docker-logs bootstrap \
         cache-flush sync-metrics superset-sanitize superset-export superset-import superset-diagnose \
+        commit-graph-backfill \
         model-cards \
         opencode-audit-markdown \
         build-check docker-build-app docker-test-app version
@@ -317,6 +318,9 @@ superset-export: ## Export Superset dashboards + DB dump to backups/ (timestampe
 
 superset-diagnose: ## Diagnose Superset database connectivity and data pipeline
 	uv run python scripts/diagnose_superset_db.py
+
+commit-graph-backfill: ## Backfill the commit_graph table from git history (git-history viz)
+	uv run python -m rfc.commit_graph
 
 superset-import: ## Import Superset dashboards from ZIP: make superset-import FILE=backups/export.zip
 	$(COMPOSE) cp $(FILE) superset:/tmp/superset_import.zip

--- a/src/rfc/commit_graph.py
+++ b/src/rfc/commit_graph.py
@@ -1,0 +1,114 @@
+"""Collect the git commit DAG for visualization.
+
+Walks the repository's commit graph — all branches, full history by default —
+and returns one :class:`~rfc.test_database.CommitGraphNode` per commit, each
+carrying its parent SHAs so a downstream consumer can reconstruct the edges.
+Feeds the ``commit_graph`` / ``commit_edges`` tables that Superset renders as
+a tree.
+
+Two entry points:
+
+* :func:`walk_commit_graph` — the git-invoking walker (backfill + incremental).
+* :func:`parse_commit_log` — the pure parser, split out so it is unit-testable
+  without a repository.
+
+The parser is deliberately separate from I/O: subprocess failures (git absent,
+not a repo) degrade to an empty list rather than raising, matching the
+skip-and-log contract for optional/external dependencies.
+"""
+
+import subprocess
+from typing import List, Optional
+
+from .test_database import CommitGraphNode
+
+# ASCII unit/record separators. git commit metadata never contains 0x1f/0x1e,
+# so a subject with spaces, pipes, commas or other punctuation still parses
+# unambiguously — unlike a comma/pipe/tab-delimited format.
+_FIELD_SEP = "\x1f"
+_RECORD_SEP = "\x1e"
+
+# %H sha, %P parent shas (space-separated), %an author, %ae email,
+# %aI author date (strict ISO-8601), %D ref names, %s subject.
+_LOG_FORMAT = (
+    _FIELD_SEP.join(["%H", "%P", "%an", "%ae", "%aI", "%D", "%s"]) + _RECORD_SEP
+)
+
+
+def parse_commit_log(raw: str) -> List[CommitGraphNode]:
+    """Parse ``git log`` output formatted with :data:`_LOG_FORMAT`.
+
+    Records are split on the ASCII record separator and fields on the unit
+    separator. Malformed or empty records are skipped rather than raising.
+    """
+    nodes: List[CommitGraphNode] = []
+    for record in raw.split(_RECORD_SEP):
+        record = record.strip("\n")
+        if not record:
+            continue
+        fields = record.split(_FIELD_SEP)
+        if len(fields) < 7:
+            continue
+        sha, parents, author, author_email, timestamp, refs, subject = fields[:7]
+        parent_shas = parents.split()
+        nodes.append(
+            CommitGraphNode(
+                sha=sha,
+                parent_shas=parent_shas,
+                author=author,
+                author_email=author_email,
+                commit_timestamp=timestamp,
+                subject=subject,
+                refs=refs.strip(),
+                is_merge=len(parent_shas) > 1,
+            )
+        )
+    return nodes
+
+
+def _run_git(args: List[str], cwd: Optional[str], timeout: float) -> str:
+    """Run a git command, returning stdout or ``""`` on any failure."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=cwd,
+        )
+        if result.returncode == 0:
+            return result.stdout
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+    return ""
+
+
+def walk_commit_graph(
+    *,
+    all_refs: bool = True,
+    limit: Optional[int] = None,
+    ref: Optional[str] = None,
+    cwd: Optional[str] = None,
+    timeout: float = 30.0,
+) -> List[CommitGraphNode]:
+    """Walk the repository's commit graph into ``CommitGraphNode`` rows.
+
+    Args:
+        all_refs: Include every branch/tag (``git log --all``). Ignored when
+            ``ref`` is given.
+        limit: Cap the number of commits (``-n``). ``None`` = full history.
+        ref: Walk from a specific ref/SHA instead of ``--all`` — used for the
+            per-run incremental capture (``ref=HEAD``, small ``limit``).
+        cwd: Repository directory. Defaults to the process working directory.
+        timeout: Per-invocation git timeout in seconds.
+
+    Returns an empty list when git is unavailable or ``cwd`` is not a repo.
+    """
+    args = ["log", f"--pretty=format:{_LOG_FORMAT}"]
+    if limit is not None:
+        args += ["-n", str(limit)]
+    if ref:
+        args.append(ref)
+    elif all_refs:
+        args.append("--all")
+    return parse_commit_log(_run_git(args, cwd=cwd, timeout=timeout))

--- a/src/rfc/commit_graph.py
+++ b/src/rfc/commit_graph.py
@@ -17,10 +17,12 @@ not a repo) degrade to an empty list rather than raising, matching the
 skip-and-log contract for optional/external dependencies.
 """
 
+import argparse
+import os
 import subprocess
 from typing import List, Optional
 
-from .test_database import CommitGraphNode
+from .test_database import CommitGraphNode, TestDatabase
 
 # ASCII unit/record separators. git commit metadata never contains 0x1f/0x1e,
 # so a subject with spaces, pipes, commas or other punctuation still parses
@@ -112,3 +114,51 @@ def walk_commit_graph(
     elif all_refs:
         args.append("--all")
     return parse_commit_log(_run_git(args, cwd=cwd, timeout=timeout))
+
+
+def backfill_commit_graph(
+    db: TestDatabase,
+    *,
+    limit: Optional[int] = None,
+    cwd: Optional[str] = None,
+) -> int:
+    """Walk full history (all branches) into the commit_graph table.
+
+    Idempotent — safe to re-run. Returns the number of commits upserted.
+    """
+    nodes = walk_commit_graph(all_refs=True, limit=limit, cwd=cwd)
+    return db.upsert_commit_nodes(nodes)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """CLI entry point: ``python -m rfc.commit_graph`` (see ``make
+    commit-graph-backfill``). Scans the repo's git history into the
+    commit_graph / commit_edges tables for Superset to visualize.
+    """
+    parser = argparse.ArgumentParser(
+        description="Backfill the commit_graph table from git history."
+    )
+    parser.add_argument(
+        "--database-url",
+        default=os.environ.get("DATABASE_URL"),
+        help="Target database (defaults to $DATABASE_URL).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap commits walked (default: full history).",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.database_url:
+        parser.error("no database: pass --database-url or set DATABASE_URL")
+
+    db = TestDatabase(database_url=args.database_url)
+    count = backfill_commit_graph(db, limit=args.limit)
+    print(f"commit_graph: upserted {count} commit(s) from git history")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - thin CLI wrapper
+    raise SystemExit(main())

--- a/src/rfc/db_listener.py
+++ b/src/rfc/db_listener.py
@@ -25,6 +25,7 @@ from robot.libraries.BuiltIn import BuiltIn  # type: ignore
 
 from . import __version__
 from .base_listener import BaseListener
+from .commit_graph import walk_commit_graph
 from .cost_estimator import estimate_cost, load_pricing_table
 from .git_metadata import collect_ci_metadata
 from .harness_cli import active_session_id
@@ -54,6 +55,12 @@ from .test_database import (
     TestRunArtifact,
     build_result_artifacts,
 )
+
+
+# How many recent ancestors of HEAD to (re)capture into the commit_graph
+# table on each run. Keeps the deployed git-history view fresh between full
+# backfills without walking the entire DAG every suite.
+COMMIT_GRAPH_INCREMENTAL_DEPTH = 50
 
 
 def resolve_session_id(robot_variable: Optional[str]) -> str:
@@ -318,6 +325,7 @@ class DbListener(BaseListener):
             db = self._get_db()
             run_id = db.add_test_run(run)
             self._last_run_id = run_id
+            self._capture_commit_graph(db)
 
             # Record the source path immediately so Superset drill-down can
             # show where the XML lives even before close() compresses it.
@@ -363,6 +371,22 @@ class DbListener(BaseListener):
             error_msg = f"DbListener: FAILED to archive results: {e}"
             logger.warn(error_msg)
             logger.console(error_msg)
+
+    def _capture_commit_graph(self, db: TestDatabase) -> None:
+        """Best-effort: refresh the commit_graph table with HEAD's recent DAG.
+
+        Fully self-contained — a missing git binary, a detached checkout, or a
+        DB hiccup must never fail the result archive, so every error is
+        swallowed and logged (skip-and-log, per the optional-dependency
+        contract). Full history is loaded by the ``commit-graph-backfill``
+        entry point; this just keeps the deployed view current.
+        """
+        try:
+            nodes = walk_commit_graph(ref="HEAD", limit=COMMIT_GRAPH_INCREMENTAL_DEPTH)
+            if nodes:
+                db.upsert_commit_nodes(nodes)
+        except Exception as e:  # noqa: BLE001 - never fail the archive on this
+            logger.warn(f"DbListener: commit-graph capture skipped: {e}")
 
     def close(self) -> None:
         """Read output.xml after Robot has flushed it and update the DB row.

--- a/src/rfc/test_database.py
+++ b/src/rfc/test_database.py
@@ -13,7 +13,7 @@ import json
 import logging
 import os
 import sqlite3
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -99,6 +99,27 @@ class TestResult:
     wall_seconds: float = 0.0
     cost_usd: float = 0.0
     id: int = -1
+
+
+@dataclass
+class CommitGraphNode:
+    """One commit in the git DAG.
+
+    ``parent_shas`` carries the edges — a commit with two parents is a merge.
+    Lands in the ``commit_graph`` table (one row per commit) and is normalised
+    into ``commit_edges`` (one row per parent) so Superset can render the tree.
+    Concrete defaults only (never ``Optional``): a root commit records an empty
+    parent list, not NULL.
+    """
+
+    sha: str
+    parent_shas: List[str] = field(default_factory=list)
+    author: str = ""
+    author_email: str = ""
+    commit_timestamp: str = ""
+    subject: str = ""
+    refs: str = ""
+    is_merge: bool = False
 
 
 @dataclass
@@ -261,6 +282,17 @@ class _Backend(abc.ABC):
     @abc.abstractmethod
     def update_output_xml(self, run_id: int, output_xml_gz: bytes) -> None: ...
 
+    @abc.abstractmethod
+    def upsert_commit_nodes(self, nodes: List["CommitGraphNode"]) -> int: ...
+
+    @abc.abstractmethod
+    def get_commit_graph_nodes(
+        self, limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]: ...
+
+    @abc.abstractmethod
+    def get_commit_edges(self) -> List[Dict[str, Any]]: ...
+
 
 class _SQLiteBackend(_Backend):
     """SQLite backend using the stdlib sqlite3 module."""
@@ -336,10 +368,32 @@ class _SQLiteBackend(_Backend):
         family TEXT
     );
 
+    CREATE TABLE IF NOT EXISTS commit_graph (
+        sha TEXT PRIMARY KEY,
+        parent_shas TEXT DEFAULT '',
+        author TEXT DEFAULT '',
+        author_email TEXT DEFAULT '',
+        commit_timestamp TEXT DEFAULT '',
+        subject TEXT DEFAULT '',
+        refs TEXT DEFAULT '',
+        is_merge INTEGER DEFAULT 0
+    );
+
+    CREATE TABLE IF NOT EXISTS commit_edges (
+        child_sha TEXT NOT NULL,
+        parent_sha TEXT NOT NULL,
+        parent_index INTEGER DEFAULT 0,
+        PRIMARY KEY (child_sha, parent_sha)
+    );
+
     CREATE INDEX IF NOT EXISTS idx_test_runs_model ON test_runs(model_name);
     CREATE INDEX IF NOT EXISTS idx_test_runs_timestamp ON test_runs(timestamp);
     CREATE INDEX IF NOT EXISTS idx_test_runs_suite ON test_runs(test_suite);
     CREATE INDEX IF NOT EXISTS idx_test_results_run_id ON test_results(run_id);
+    CREATE INDEX IF NOT EXISTS idx_commit_graph_timestamp
+        ON commit_graph(commit_timestamp);
+    CREATE INDEX IF NOT EXISTS idx_commit_edges_parent
+        ON commit_edges(parent_sha);
     """
 
     _VIEW_SQL = (
@@ -640,6 +694,77 @@ class _SQLiteBackend(_Backend):
             ).fetchone()
             return int(row[0]) if row else 0
 
+    def upsert_commit_nodes(self, nodes: List["CommitGraphNode"]) -> int:
+        if not nodes:
+            return 0
+        with sqlite3.connect(self.db_path) as conn:
+            for n in nodes:
+                conn.execute(
+                    """
+                    INSERT INTO commit_graph
+                    (sha, parent_shas, author, author_email,
+                     commit_timestamp, subject, refs, is_merge)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(sha) DO UPDATE SET
+                        parent_shas = excluded.parent_shas,
+                        author = excluded.author,
+                        author_email = excluded.author_email,
+                        commit_timestamp = excluded.commit_timestamp,
+                        subject = excluded.subject,
+                        refs = excluded.refs,
+                        is_merge = excluded.is_merge
+                    """,
+                    (
+                        n.sha,
+                        " ".join(n.parent_shas),
+                        n.author,
+                        n.author_email,
+                        n.commit_timestamp,
+                        n.subject,
+                        n.refs,
+                        1 if n.is_merge else 0,
+                    ),
+                )
+                # Re-derive this commit's edges: delete then re-insert so a
+                # history rewrite (rebase/amend) can't leave stale parents.
+                conn.execute("DELETE FROM commit_edges WHERE child_sha = ?", (n.sha,))
+                for idx, parent in enumerate(n.parent_shas):
+                    conn.execute(
+                        """
+                        INSERT INTO commit_edges
+                        (child_sha, parent_sha, parent_index)
+                        VALUES (?, ?, ?)
+                        ON CONFLICT(child_sha, parent_sha) DO UPDATE SET
+                            parent_index = excluded.parent_index
+                        """,
+                        (n.sha, parent, idx),
+                    )
+            return len(nodes)
+
+    def get_commit_graph_nodes(
+        self, limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        sql = (
+            "SELECT sha, parent_shas, author, author_email, commit_timestamp, "
+            "subject, refs, is_merge FROM commit_graph "
+            "ORDER BY commit_timestamp DESC"
+        )
+        params: tuple[Any, ...] = ()
+        if limit is not None:
+            sql += " LIMIT ?"
+            params = (limit,)
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            return [dict(row) for row in conn.execute(sql, params).fetchall()]
+
+    def get_commit_edges(self) -> List[Dict[str, Any]]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                "SELECT child_sha, parent_sha, parent_index FROM commit_edges"
+            ).fetchall()
+            return [dict(row) for row in rows]
+
 
 class _SQLAlchemyBackend(_Backend):
     """PostgreSQL backend using SQLAlchemy."""
@@ -878,6 +1003,31 @@ class _SQLAlchemyBackend(_Backend):
             Column("family", Text),
         )
 
+        # Git DAG: one row per commit (parents give the edges), normalised
+        # into commit_edges so Superset can render the tree.
+        self._commit_graph = Table(
+            "commit_graph",
+            self.metadata,
+            Column("sha", Text, primary_key=True),
+            Column("parent_shas", Text, server_default=text("''")),
+            Column("author", Text, server_default=text("''")),
+            Column("author_email", Text, server_default=text("''")),
+            Column("commit_timestamp", Text, server_default=text("''")),
+            Column("subject", Text, server_default=text("''")),
+            Column("refs", Text, server_default=text("''")),
+            Column("is_merge", Boolean, server_default=text("false")),
+            Index("idx_commit_graph_timestamp", "commit_timestamp"),
+        )
+
+        self._commit_edges = Table(
+            "commit_edges",
+            self.metadata,
+            Column("child_sha", Text, primary_key=True),
+            Column("parent_sha", Text, primary_key=True),
+            Column("parent_index", Integer, server_default=text("0")),
+            Index("idx_commit_edges_parent", "parent_sha"),
+        )
+
     def _run_migrations(self) -> None:
         for sql in self._PG_MIGRATIONS:
             try:
@@ -1079,6 +1229,64 @@ class _SQLAlchemyBackend(_Backend):
             result = conn.execute(text(f"SELECT COUNT(*) FROM {table_name}"))  # noqa: S608
             return int(result.scalar() or 0)
 
+    def upsert_commit_nodes(self, nodes: List["CommitGraphNode"]) -> int:
+        if not nodes:
+            return 0
+        # Dialect-agnostic upsert: delete-then-insert per commit inside one
+        # transaction. Idempotent, and a rewritten commit's edges can't go
+        # stale because they are rebuilt from the current parent list.
+        with self.engine.begin() as conn:
+            for n in nodes:
+                conn.execute(
+                    self._commit_graph.delete().where(self._commit_graph.c.sha == n.sha)
+                )
+                conn.execute(
+                    self._commit_graph.insert().values(
+                        sha=n.sha,
+                        parent_shas=" ".join(n.parent_shas),
+                        author=n.author,
+                        author_email=n.author_email,
+                        commit_timestamp=n.commit_timestamp,
+                        subject=n.subject,
+                        refs=n.refs,
+                        is_merge=bool(n.is_merge),
+                    )
+                )
+                conn.execute(
+                    self._commit_edges.delete().where(
+                        self._commit_edges.c.child_sha == n.sha
+                    )
+                )
+                if n.parent_shas:
+                    conn.execute(
+                        self._commit_edges.insert(),
+                        [
+                            {
+                                "child_sha": n.sha,
+                                "parent_sha": parent,
+                                "parent_index": idx,
+                            }
+                            for idx, parent in enumerate(n.parent_shas)
+                        ],
+                    )
+            return len(nodes)
+
+    def get_commit_graph_nodes(
+        self, limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        with self.engine.connect() as conn:
+            query = self._commit_graph.select().order_by(
+                self._commit_graph.c.commit_timestamp.desc()
+            )
+            if limit is not None:
+                query = query.limit(limit)
+            return [dict(row._mapping) for row in conn.execute(query)]
+
+    def get_commit_edges(self) -> List[Dict[str, Any]]:
+        with self.engine.connect() as conn:
+            result = conn.execute(self._commit_edges.select())
+            return [dict(row._mapping) for row in result]
+
 
 class TestDatabase:
     """Facade that selects the correct backend at construction time.
@@ -1162,3 +1370,14 @@ class TestDatabase:
 
     def get_table_row_count(self, table_name: str) -> int:
         return self._backend.get_table_row_count(table_name)
+
+    def upsert_commit_nodes(self, nodes: List[CommitGraphNode]) -> int:
+        return self._backend.upsert_commit_nodes(nodes)
+
+    def get_commit_graph_nodes(
+        self, limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        return self._backend.get_commit_graph_nodes(limit)
+
+    def get_commit_edges(self) -> List[Dict[str, Any]]:
+        return self._backend.get_commit_edges()

--- a/superset/bootstrap_dashboards.py
+++ b/superset/bootstrap_dashboards.py
@@ -193,6 +193,33 @@ CREATE INDEX IF NOT EXISTS idx_coverage_reports_timestamp
 CREATE INDEX IF NOT EXISTS idx_coverage_reports_git_commit
     ON coverage_reports(git_commit);
 
+-- Git commit DAG for the Git History dashboard. One row per commit, with
+-- parents normalised into commit_edges (child then parent). Kept in sync
+-- with rfc.test_database (the canonical schema) and populated by
+-- rfc.commit_graph (make commit-graph-backfill plus per-run capture).
+CREATE TABLE IF NOT EXISTS commit_graph (
+    sha VARCHAR(64) PRIMARY KEY,
+    parent_shas TEXT NOT NULL DEFAULT '',
+    author TEXT NOT NULL DEFAULT '',
+    author_email TEXT NOT NULL DEFAULT '',
+    commit_timestamp TEXT NOT NULL DEFAULT '',
+    subject TEXT NOT NULL DEFAULT '',
+    refs TEXT NOT NULL DEFAULT '',
+    is_merge BOOLEAN NOT NULL DEFAULT false
+);
+
+CREATE TABLE IF NOT EXISTS commit_edges (
+    child_sha VARCHAR(64) NOT NULL,
+    parent_sha VARCHAR(64) NOT NULL,
+    parent_index INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (child_sha, parent_sha)
+);
+
+CREATE INDEX IF NOT EXISTS idx_commit_graph_timestamp
+    ON commit_graph(commit_timestamp);
+CREATE INDEX IF NOT EXISTS idx_commit_edges_parent
+    ON commit_edges(parent_sha);
+
 CREATE OR REPLACE VIEW test_results_full AS
 SELECT
     tr.id AS result_id,
@@ -567,6 +594,48 @@ _VIRTUAL_DATASETS: dict[str, str] = {
         WHERE module_name = ''
         ORDER BY timestamp DESC
         LIMIT 50
+    """,
+    # Git History: commits decorated with the pass/fail of the test runs that
+    # ran at that exact commit (test_runs.git_commit = commit_graph.sha). Feeds
+    # the commit table and the pass-rate-by-commit bar (the visual bisect).
+    "commit_graph_decorated": """
+        SELECT
+            cg.sha,
+            LEFT(cg.sha, 8) AS short_sha,
+            cg.subject,
+            cg.author,
+            cg.refs,
+            cg.is_merge,
+            cg.commit_timestamp,
+            NULLIF(cg.commit_timestamp, '')::timestamptz AS committed_at,
+            COALESCE(SUM(r.passed), 0) AS passed,
+            COALESCE(SUM(r.failed), 0) AS failed,
+            COALESCE(SUM(r.total_tests), 0) AS total_tests,
+            COUNT(DISTINCT r.id) AS run_count,
+            ROUND(
+                100.0 * SUM(r.passed) / NULLIF(SUM(r.total_tests), 0), 1
+            ) AS pass_rate_pct
+        FROM commit_graph cg
+        LEFT JOIN test_runs r ON r.git_commit = cg.sha
+        GROUP BY cg.sha, cg.subject, cg.author, cg.refs, cg.is_merge,
+                 cg.commit_timestamp
+        ORDER BY cg.commit_timestamp DESC
+    """,
+    # Git History: the DAG edge list (child -> parent) with short SHAs and
+    # subjects, for the interim native Graph chart. The custom git-lane plugin
+    # (robotframework-superset) consumes the same shape.
+    "commit_dag_edges": """
+        SELECT
+            e.child_sha,
+            e.parent_sha,
+            LEFT(e.child_sha, 8) AS child_short,
+            LEFT(e.parent_sha, 8) AS parent_short,
+            e.parent_index,
+            c.subject AS child_subject,
+            p.subject AS parent_subject
+        FROM commit_edges e
+        LEFT JOIN commit_graph c ON c.sha = e.child_sha
+        LEFT JOIN commit_graph p ON p.sha = e.parent_sha
     """,
 }
 
@@ -2623,6 +2692,7 @@ def bootstrap() -> None:
         _create_agentic_datasets(db_id)
         _create_agentic_dashboard(db_id)
         _create_harness_scoreboard_dashboard(db_id)
+        _create_git_history_dashboard(db_id)
 
     log.info("Bootstrap complete.")
 
@@ -3247,6 +3317,193 @@ def _create_harness_scoreboard_dashboard(db_id: int) -> None:
     superset_db.session.add(dashboard)
     superset_db.session.commit()
     log.info(f"Created dashboard: Harness Scoreboard (id={dashboard.id})")
+
+
+# ---------------------------------------------------------------------------
+# Git History Dashboard — the commit DAG + pass/fail decoration (bisect view)
+# ---------------------------------------------------------------------------
+# Phase 2 (interim, stock viz types): a native Graph chart scaffolds the DAG
+# while the custom git-lane plugin (robotframework-superset) is built. The
+# commit table and pass-rate-by-commit bar are the pragmatic wins that fit
+# stock Superset — the bar IS the visual bisect (scan for where green flips
+# to red across the commit axis).
+_GIT_HISTORY_CHART_DEFS: list[dict[str, Any]] = [
+    {
+        # INTERIM SCAFFOLD: stock ECharts Graph renders nodes+edges as a
+        # force-directed network, not true git lanes. Replaced by the custom
+        # git-lane viz plugin in Phase 3; kept so the DAG data is visible now.
+        "slice_name": "Commit DAG (interim)",
+        "viz_type": "graph_chart",
+        "datasource_id_key": "commit_dag_edges",
+        "params": {
+            "source": "child_short",
+            "target": "parent_short",
+            "metric": {
+                "expressionType": "SQL",
+                "sqlExpression": "COUNT(*)",
+                "label": "edges",
+            },
+            "row_limit": 5000,
+        },
+    },
+    {
+        "slice_name": "Pass Rate by Commit",
+        "viz_type": "echarts_timeseries_bar",
+        "datasource_id_key": "commit_graph_decorated",
+        "params": {
+            "metrics": [
+                {
+                    "expressionType": "SQL",
+                    "sqlExpression": "MAX(pass_rate_pct)",
+                    "label": "Pass Rate %",
+                },
+            ],
+            "x_axis": "committed_at",
+            "time_column": "committed_at",
+            "granularity_sqla": "committed_at",
+            "y_axis_bounds": [0, 100],
+        },
+    },
+    {
+        "slice_name": "Commit History",
+        "viz_type": "table",
+        "datasource_id_key": "commit_graph_decorated",
+        "params": {
+            "columns": [
+                "commit_timestamp",
+                "short_sha",
+                "subject",
+                "author",
+                "is_merge",
+                "run_count",
+                "passed",
+                "failed",
+                "pass_rate_pct",
+            ],
+            "order_desc": True,
+            "row_limit": 500,
+        },
+    },
+]
+
+_GIT_HISTORY_LAYOUT_SECTIONS: list[dict[str, Any]] = [
+    {
+        "label": "Commit DAG",
+        "charts": [
+            {"name": "Commit DAG (interim)", "width": 12, "height": 60},
+        ],
+    },
+    {
+        "label": "Regression / Bisect",
+        "charts": [
+            {"name": "Pass Rate by Commit", "width": 12, "height": 50},
+        ],
+    },
+    {
+        "label": "Commits",
+        "charts": [
+            {"name": "Commit History", "width": 12, "height": 60},
+        ],
+    },
+]
+
+
+def _create_git_history_dashboard(db_id: int) -> None:
+    """Create charts and the Git History dashboard (commit DAG + bisect view).
+
+    Self-contained equivalent of _create_charts_and_dashboard, keyed on its
+    own datasets (commit_graph_decorated, commit_dag_edges) and slug so it
+    upserts independently of the other dashboards.
+    """
+    from superset import db as superset_db  # type: ignore[attr-defined]
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.models.dashboard import Dashboard
+    from superset.models.slice import Slice
+
+    dataset_keys = {"commit_graph_decorated", "commit_dag_edges"}
+    datasets: dict[str, int] = {}
+    for table_name in dataset_keys:
+        ds = (
+            superset_db.session.query(SqlaTable)
+            .filter_by(table_name=table_name, database_id=db_id)
+            .first()
+        )
+        if ds:
+            datasets[table_name] = ds.id
+
+    if not datasets:
+        log.warning("Git History: no commit-graph datasets found; skipping.")
+        return
+
+    chart_id_map: dict[str, int] = {}
+    for chart_def in _GIT_HISTORY_CHART_DEFS:
+        ds_key = chart_def["datasource_id_key"]
+        if ds_key not in datasets:
+            log.warning(
+                f"Skipping chart '{chart_def['slice_name']}': "
+                f"dataset '{ds_key}' not found."
+            )
+            continue
+
+        slice_name = chart_def["slice_name"]
+        existing = (
+            superset_db.session.query(Slice).filter_by(slice_name=slice_name).first()
+        )
+        if existing:
+            chart_id_map[slice_name] = existing.id
+            log.info(f"Chart already exists: {slice_name}")
+            continue
+
+        chart = Slice(
+            slice_name=slice_name,
+            viz_type=chart_def["viz_type"],
+            datasource_id=datasets[ds_key],
+            datasource_type="table",
+            params=json.dumps(chart_def["params"]),
+        )
+        superset_db.session.add(chart)
+        superset_db.session.commit()
+        chart_id_map[slice_name] = chart.id
+        log.info(f"Created chart: {slice_name} (id={chart.id})")
+
+    position = _build_sectioned_position_json(
+        _GIT_HISTORY_LAYOUT_SECTIONS, "Git History", chart_id_map
+    )
+    metadata = {
+        "native_filter_configuration": [],
+        "chart_configuration": {},
+        "cross_filters_enabled": True,
+    }
+
+    slug = "git-history"
+    existing_dash = superset_db.session.query(Dashboard).filter_by(slug=slug).first()
+    if existing_dash:
+        existing_dash.position_json = json.dumps(position)
+        existing_dash.json_metadata = json.dumps(metadata)
+        existing_dash.slices = [
+            superset_db.session.query(Slice).get(cid)
+            for cid in chart_id_map.values()
+            if superset_db.session.query(Slice).get(cid)
+        ]
+        superset_db.session.commit()
+        log.info(f"Updated dashboard: Git History (id={existing_dash.id})")
+        return
+
+    dashboard = Dashboard(
+        dashboard_title="Git History",
+        slug=slug,
+        published=True,
+        position_json=json.dumps(position),
+        json_metadata=json.dumps(metadata),
+    )
+    dashboard.slices = [
+        superset_db.session.query(Slice).get(cid)
+        for cid in chart_id_map.values()
+        if superset_db.session.query(Slice).get(cid)
+    ]
+    superset_db.session.add(dashboard)
+    superset_db.session.commit()
+    log.info(f"Created dashboard: Git History (id={dashboard.id})")
 
 
 if __name__ == "__main__":

--- a/tests/test_bootstrap_dashboards.py
+++ b/tests/test_bootstrap_dashboards.py
@@ -31,6 +31,8 @@ from bootstrap_dashboards import (  # noqa: E402
     STATUS_COLORS,
     _CHART_DEFS,
     _FILTER_CONFIGS,
+    _GIT_HISTORY_CHART_DEFS,
+    _GIT_HISTORY_LAYOUT_SECTIONS,
     _LAYOUT_SECTIONS,
     _TABLE_DDL,
     _VIRTUAL_DATASETS,
@@ -130,6 +132,9 @@ class TestVirtualDatasets:
         "coverage_timeseries",
         "coverage_by_module",
         "coverage_by_commit",
+        # Git History dashboard (commit DAG + bisect view)
+        "commit_graph_decorated",
+        "commit_dag_edges",
     }
 
     def test_all_expected_keys_present(self) -> None:
@@ -149,7 +154,13 @@ class TestVirtualDatasets:
 
     def test_all_sql_references_core_tables(self) -> None:
         """Every SQL references at least one of the core tables."""
-        core_tables = {"TEST_RUNS", "TEST_RESULTS", "COVERAGE_REPORTS"}
+        core_tables = {
+            "TEST_RUNS",
+            "TEST_RESULTS",
+            "COVERAGE_REPORTS",
+            "COMMIT_GRAPH",
+            "COMMIT_EDGES",
+        }
         for key, sql in _VIRTUAL_DATASETS.items():
             sql_upper = sql.upper()
             found = any(t in sql_upper for t in core_tables)
@@ -2474,3 +2485,40 @@ class TestScoreboardPostgresValidity:
         # Split semantics on the production backend: the mixed cell becomes a
         # pure Tier-A sub-cell (token row only) and a Tier-B sub-cell.
         assert cells == {("A", 1), ("B", 1)}
+
+
+# ---------------------------------------------------------------------------
+# Git History dashboard (commit DAG + bisect view)
+# ---------------------------------------------------------------------------
+
+
+class TestGitHistoryDashboard:
+    """Structural guards for the Git History dashboard defs."""
+
+    def test_ddl_creates_commit_tables(self) -> None:
+        ddl = _TABLE_DDL.upper()
+        assert "CREATE TABLE IF NOT EXISTS COMMIT_GRAPH" in ddl
+        assert "CREATE TABLE IF NOT EXISTS COMMIT_EDGES" in ddl
+
+    def test_chart_datasets_exist(self) -> None:
+        """Every Git History chart points at a defined virtual dataset."""
+        for chart in _GIT_HISTORY_CHART_DEFS:
+            assert chart["datasource_id_key"] in _VIRTUAL_DATASETS, (
+                f"{chart['slice_name']} references unknown dataset "
+                f"{chart['datasource_id_key']}"
+            )
+
+    def test_layout_names_match_chart_defs(self) -> None:
+        """Every chart referenced in the layout is defined (and vice versa)."""
+        defined = {c["slice_name"] for c in _GIT_HISTORY_CHART_DEFS}
+        laid_out = {
+            chart["name"]
+            for section in _GIT_HISTORY_LAYOUT_SECTIONS
+            for chart in section["charts"]
+        }
+        assert laid_out == defined
+
+    def test_chart_defs_have_required_fields(self) -> None:
+        required = {"slice_name", "viz_type", "datasource_id_key", "params"}
+        for chart in _GIT_HISTORY_CHART_DEFS:
+            assert required <= set(chart), f"{chart} missing required keys"

--- a/tests/test_commit_graph.py
+++ b/tests/test_commit_graph.py
@@ -136,3 +136,56 @@ class TestCommitGraphDataLayer:
         db = TestDatabase(db_path=str(tmp_path / "t.db"))
         assert db.upsert_commit_nodes([]) == 0
         assert db.get_commit_graph_nodes() == []
+
+
+class TestBackfill:
+    def test_backfill_populates_from_git(self, tmp_path: Path) -> None:
+        from rfc.commit_graph import backfill_commit_graph
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        def git(*args: str) -> None:
+            subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+        git("init", "-q")
+        git("config", "user.email", "ada@example.com")
+        git("config", "user.name", "Ada")
+        (repo / "a.txt").write_text("one")
+        git("add", ".")
+        git("commit", "-q", "-m", "first")
+        (repo / "a.txt").write_text("two")
+        git("commit", "-q", "-am", "second")
+
+        db = TestDatabase(db_path=str(tmp_path / "t.db"))
+        count = backfill_commit_graph(db, cwd=str(repo))
+        assert count == 2
+        assert db.get_table_row_count("commit_graph") == 2
+        assert db.get_table_row_count("commit_edges") == 1  # second -> first
+
+
+class TestIncrementalCapture:
+    """DbListener._capture_commit_graph is best-effort: it upserts on the
+    happy path and swallows every error so it can never fail a run archive."""
+
+    def _listener(self):  # type: ignore[no-untyped-def]
+        from rfc.db_listener import DbListener
+
+        return DbListener()
+
+    def test_capture_upserts_walked_nodes(self, monkeypatch, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+        nodes = [CommitGraphNode(sha="aaa", subject="root")]
+        monkeypatch.setattr("rfc.db_listener.walk_commit_graph", lambda **kw: nodes)
+        db = TestDatabase(db_path=str(tmp_path / "t.db"))
+        self._listener()._capture_commit_graph(db)
+        assert db.get_table_row_count("commit_graph") == 1
+
+    def test_capture_swallows_walk_errors(self, monkeypatch, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+        def boom(**kw: object) -> list:
+            raise RuntimeError("git exploded")
+
+        monkeypatch.setattr("rfc.db_listener.walk_commit_graph", boom)
+        db = TestDatabase(db_path=str(tmp_path / "t.db"))
+        # Must not raise — the archive path depends on this being harmless.
+        self._listener()._capture_commit_graph(db)
+        assert db.get_table_row_count("commit_graph") == 0

--- a/tests/test_commit_graph.py
+++ b/tests/test_commit_graph.py
@@ -1,0 +1,138 @@
+"""Tests for rfc.commit_graph (git DAG collector) and the commit_graph /
+commit_edges data layer in rfc.test_database.
+
+The pure parser (``parse_commit_log``) is tested without a repo; the git
+walker and the database round-trip are exercised against a throwaway repo /
+in-memory SQLite so the whole suite stays fast and offline.
+"""
+
+import subprocess
+from pathlib import Path
+
+from rfc.commit_graph import (
+    _FIELD_SEP,
+    _RECORD_SEP,
+    parse_commit_log,
+    walk_commit_graph,
+)
+from rfc.test_database import CommitGraphNode, TestDatabase
+
+
+def _record(sha: str, parents: str, subject: str) -> str:
+    fields = [
+        sha,
+        parents,
+        "Ada",
+        "ada@example.com",
+        "2024-01-01T00:00:00+00:00",
+        "",
+        subject,
+    ]
+    return _FIELD_SEP.join(fields)
+
+
+class TestParseCommitLog:
+    def test_parses_single_commit(self) -> None:
+        raw = _record("aaa", "", "initial commit") + _RECORD_SEP
+        nodes = parse_commit_log(raw)
+        assert len(nodes) == 1
+        assert nodes[0].sha == "aaa"
+        assert nodes[0].parent_shas == []
+        assert nodes[0].subject == "initial commit"
+        assert nodes[0].is_merge is False
+
+    def test_parses_parents_and_flags_merge(self) -> None:
+        raw = _record("ccc", "aaa bbb", "merge branch") + _RECORD_SEP
+        nodes = parse_commit_log(raw)
+        assert nodes[0].parent_shas == ["aaa", "bbb"]
+        assert nodes[0].is_merge is True
+
+    def test_subject_with_field_like_chars_survives(self) -> None:
+        # A subject containing spaces, pipes and unit-like punctuation must
+        # not break parsing — that's why we use ASCII 0x1f/0x1e separators.
+        raw = _record("aaa", "", "fix: a | b, c (d) e") + _RECORD_SEP
+        nodes = parse_commit_log(raw)
+        assert nodes[0].subject == "fix: a | b, c (d) e"
+
+    def test_empty_input_yields_no_nodes(self) -> None:
+        assert parse_commit_log("") == []
+
+
+class TestWalkCommitGraph:
+    def test_walks_real_repo(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        def git(*args: str) -> None:
+            subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+        git("init", "-q")
+        git("config", "user.email", "ada@example.com")
+        git("config", "user.name", "Ada")
+        (repo / "a.txt").write_text("one")
+        git("add", ".")
+        git("commit", "-q", "-m", "first commit")
+        (repo / "a.txt").write_text("two")
+        git("commit", "-q", "-am", "second commit")
+
+        nodes = walk_commit_graph(cwd=str(repo))
+        assert len(nodes) == 2
+        subjects = {n.subject for n in nodes}
+        assert subjects == {"first commit", "second commit"}
+        # Newest first; the second commit lists the first as its parent.
+        assert nodes[0].subject == "second commit"
+        assert nodes[0].parent_shas == [nodes[1].sha]
+        assert nodes[1].parent_shas == []
+
+    def test_non_repo_returns_empty(self, tmp_path: Path) -> None:
+        assert walk_commit_graph(cwd=str(tmp_path)) == []
+
+
+class TestCommitGraphDataLayer:
+    def _nodes(self) -> list[CommitGraphNode]:
+        return [
+            CommitGraphNode(sha="aaa", parent_shas=[], subject="root"),
+            CommitGraphNode(sha="bbb", parent_shas=["aaa"], subject="feature"),
+            CommitGraphNode(
+                sha="ccc",
+                parent_shas=["aaa", "bbb"],
+                subject="merge",
+                is_merge=True,
+            ),
+        ]
+
+    def test_upsert_and_read_nodes(self, tmp_path: Path) -> None:
+        db = TestDatabase(db_path=str(tmp_path / "t.db"))
+        written = db.upsert_commit_nodes(self._nodes())
+        assert written == 3
+        nodes = db.get_commit_graph_nodes()
+        by_sha = {n["sha"]: n for n in nodes}
+        assert set(by_sha) == {"aaa", "bbb", "ccc"}
+        assert by_sha["ccc"]["is_merge"] in (1, True)
+        assert by_sha["aaa"]["is_merge"] in (0, False)
+
+    def test_edges_are_derived_from_parents(self, tmp_path: Path) -> None:
+        db = TestDatabase(db_path=str(tmp_path / "t.db"))
+        db.upsert_commit_nodes(self._nodes())
+        edges = {(e["child_sha"], e["parent_sha"]) for e in db.get_commit_edges()}
+        assert edges == {("bbb", "aaa"), ("ccc", "aaa"), ("ccc", "bbb")}
+
+    def test_upsert_is_idempotent(self, tmp_path: Path) -> None:
+        db = TestDatabase(db_path=str(tmp_path / "t.db"))
+        db.upsert_commit_nodes(self._nodes())
+        db.upsert_commit_nodes(self._nodes())
+        assert db.get_table_row_count("commit_graph") == 3
+        assert db.get_table_row_count("commit_edges") == 3
+
+    def test_upsert_updates_changed_metadata(self, tmp_path: Path) -> None:
+        db = TestDatabase(db_path=str(tmp_path / "t.db"))
+        db.upsert_commit_nodes([CommitGraphNode(sha="aaa", subject="old")])
+        db.upsert_commit_nodes([CommitGraphNode(sha="aaa", subject="new")])
+        nodes = db.get_commit_graph_nodes()
+        assert len(nodes) == 1
+        assert nodes[0]["subject"] == "new"
+
+    def test_empty_upsert_is_noop(self, tmp_path: Path) -> None:
+        db = TestDatabase(db_path=str(tmp_path / "t.db"))
+        assert db.upsert_commit_nodes([]) == 0
+        assert db.get_commit_graph_nodes() == []


### PR DESCRIPTION
Introduce the DAG data model that a Superset git-history/tree view will
render. Nothing in the repo stored commit parentage before this — only a
lone git_commit SHA per test_run — so there was no edge data to draw from.

- CommitGraphNode dataclass + commit_graph / commit_edges tables in both
  the SQLite and SQLAlchemy backends. One row per commit; parents are
  normalised into commit_edges (child_sha, parent_sha, parent_index) so a
  chart can query a plain source/target edge list.
- rfc.commit_graph collector: walk_commit_graph() (all branches, full
  history by default; ref+limit for per-run incremental capture) and a pure
  parse_commit_log() split out for unit testing without a repo. Uses ASCII
  0x1f/0x1e separators so commit subjects never break parsing.
- Idempotent upsert (delete-then-insert edges) survives rebase/amend.

Tests cover parsing, a real-repo walk, DB round-trip, edge derivation,
merge flagging, and upsert idempotency.