### PR TITLE
feat: add canary session-degradation engine and live keyword library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ Provenance notes:
   published here via a PR-mode mirror publisher (see the readme's
   Contributing section).
 
+## [1.29.0] — 2026-07-25
+
+### Added
+
+- **Canary session-degradation suite (`axis:model`, tier:4) + engine.** A
+  "canary" pins one standing instruction on a session — *include the token
+  `<name>` in every reply* — then drives a long multi-turn conversation and
+  records how many turns / response tokens / wall-clock the session survives
+  before the model first drops the token (the degradation point; first-miss
+  policy). The engine (`rfc.canary`) is responder-agnostic: the live LLM-session
+  responder lives in `rfc.canary_keywords.SessionCanaryKeywords`, and the same
+  engine is meant to back a future `axis:harness` leg (a coding-agent harness
+  session as the responder) with no engine change. New Robot keywords: `Run
+  Canary Session`, `Default Canary Prompts`, `Run Scripted Canary Session`,
+  `Canary Response Hits`, `Session Should Not Degrade`, `Session Should Degrade
+  At Turn`. Two suites: the deterministic `robot/10__tier1/canary` logic suite
+  (`axis:none`, scripted responses, no model — always green in CI) and the live
+  `robot/40__tier4/canary` measurement suite (opt-in via `CANARY_LIVE=1`,
+  registered in `config/local_models.yaml` for the per-model sweep). Per-turn
+  and summary metrics are emitted as `RFC_DATA` for the spine. Deterministic
+  twins: `tests/test_canary.py`, `tests/test_canary_keywords.py`.
+
 ## [1.28.0] — Unreleased
 
 ### Added

--- a/config/local_models.yaml
+++ b/config/local_models.yaml
@@ -161,6 +161,11 @@ test_suites:
     description: "GAIA-style tool-use tests for LLM tool selection and invocation"
     timeout_seconds: 300
 
+  - name: "canary-session"
+    path: "robot/40__tier4/canary/"
+    description: "Canary session-degradation: turns/tokens/wall-clock to the first dropped standing-instruction token (needs CANARY_LIVE=1)"
+    timeout_seconds: 36000
+
   - name: "json-schema"
     path: "robot/20__tier2/json_schema/"
     description: "JSON schema validation with retry logic and parse failure rate measurement"

--- a/config/test_suites.yaml
+++ b/config/test_suites.yaml
@@ -268,6 +268,16 @@ test_suites:
     path: "robot/20__tier2/context_window/tests"
     description: "Context window degradation testing — needle-in-haystack retrieval at increasing fill levels and positions"
 
+  canary-logic:
+    label: "Canary Degradation Logic"
+    path: "robot/10__tier1/canary"
+    description: "Deterministic tier:1 (axis:none) logic tests for the canary session-degradation engine (rfc.canary): whole-word token hit detection, first-miss stop, and the full hit/miss curve, driven by scripted responses (no model). Deterministic twin: tests/test_canary.py."
+
+  canary-session:
+    label: "Canary Session Degradation"
+    path: "robot/40__tier4/canary"
+    description: "LIVE tier:4 (axis:model) canary session-degradation measurement: pins a standing 'echo this token every reply' instruction on a real model session, drives many turns, and records turns/tokens/wall-clock to the first dropped token (the degradation point). Opt-in via CANARY_LIVE=1; the model-sweep follow-up fans it across every model. The same responder-agnostic engine backs a future axis:harness leg."
+
   causal-reasoning:
     label: "Causal Reasoning"
     path: "robot/20__tier2/causal_reasoning"
@@ -455,6 +465,11 @@ ci:
       path: "robot/40__tier4/harness_matrix/"
       output_dir: "results/harness_matrix"
       tags: ["agentic", "coding-agent"]
+
+    robot-canary-session-tests:
+      path: "robot/40__tier4/canary/"
+      output_dir: "results/canary"
+      tags: ["ollama"]
 
     robot-causal-reasoning-tests:
       path: "robot/20__tier2/causal_reasoning/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "robotframework-chat"
-version = "1.28.0"
+version = "1.29.0"
 description = "Robot Framework-based test harness for systematically testing LLMs"
 license = "Apache-2.0"
 readme = "readme.md"

--- a/robot/10__tier1/canary/__init__.robot
+++ b/robot/10__tier1/canary/__init__.robot
@@ -1,0 +1,2 @@
+*** Settings ***
+Name              Canary Degradation Logic

--- a/robot/10__tier1/canary/canary.resource
+++ b/robot/10__tier1/canary/canary.resource
@@ -1,0 +1,8 @@
+*** Settings ***
+Documentation     Shared keywords for the deterministic canary-degradation logic
+...               suite. Imports only the pure engine surface
+...               (``rfc.canary.CanaryEngineKeywords``) — no LLM, no harness — so
+...               the suite is honestly ``axis:none`` and always green in CI.
+
+Library           rfc.canary.CanaryEngineKeywords
+Library           Collections

--- a/robot/10__tier1/canary/test_canary_degradation_logic.robot
+++ b/robot/10__tier1/canary/test_canary_degradation_logic.robot
@@ -1,0 +1,86 @@
+*** Settings ***
+Documentation     Canary session-degradation LOGIC tests (deterministic).
+...
+...               The canary idea: pin one standing instruction on a session —
+...               "include the token <name> in every reply" — then drive many
+...               turns and detect the FIRST turn that drops the token. That turn
+...               is the session's degradation point. This suite verifies the
+...               detection contract itself (whole-word hit detection, first-miss
+...               stop, and the full hit/miss curve) with SCRIPTED responses, so
+...               it needs no model and is always green in CI.
+...
+...               The live, model-driven counterpart is the tier:4 suite
+...               ``robot/40__tier4/canary`` (axis:model), which plugs a real LLM
+...               session into the same engine. Deterministic twin in Python:
+...               ``tests/test_canary.py``.
+
+Resource          canary.resource
+
+Test Tags         canary    tier:1    verify:python    axis:none
+
+*** Variables ***
+${TOKEN}          Tyler
+
+*** Test Cases ***
+Session Holds The Canary For Every Turn
+    [Documentation]    Every reply echoes the token, so the session never
+    ...                degrades: degraded is False and there is no degradation
+    ...                turn.
+    ${responses}=    Create List
+    ...    Sure thing, ${TOKEN}!
+    ...    Happy to help, ${TOKEN}.
+    ...    Of course, ${TOKEN} — here you go.
+    ${result}=    Run Scripted Canary Session    ${responses}    ${TOKEN}
+    Session Should Not Degrade    ${result}
+    Should Be Equal As Integers    ${result.total_turns}    3
+    Should Be Equal As Integers    ${result.degradation_turn}    0
+
+Session Degrades At The First Dropped Token
+    [Documentation]    The token holds for two turns, then drops on turn 3.
+    ...                First-miss policy: degradation is declared at turn 3 and
+    ...                the run stops there.
+    ${responses}=    Create List
+    ...    Hi ${TOKEN}
+    ...    Still here, ${TOKEN}
+    ...    I forgot the standing instruction this time.
+    ...    ${TOKEN} again
+    ${result}=    Run Scripted Canary Session    ${responses}    ${TOKEN}
+    Session Should Degrade At Turn    ${result}    3
+    Should Be True    ${result.degraded}
+    Should Be Equal As Integers    ${result.total_turns}    3
+    ...    stop-on-degradation must halt at the first miss, not run to the end
+
+Run To Cap Records The Full Hit-Miss Curve
+    [Documentation]    With stop-on-degradation disabled the whole session runs;
+    ...                the first miss is still the degradation turn, but later
+    ...                recoveries and re-drops are all recorded.
+    ${responses}=    Create List
+    ...    ${TOKEN} one
+    ...    dropped here
+    ...    ${TOKEN} recovered
+    ...    dropped again
+    ${result}=    Run Scripted Canary Session    ${responses}    ${TOKEN}
+    ...    stop_on_degradation=${False}
+    Should Be Equal As Integers    ${result.total_turns}    4
+    Session Should Degrade At Turn    ${result}    2
+    Should Be Equal As Integers    ${result.survived_turns}    1
+
+Canary Hit Detection Is Whole-Word And Case-Insensitive
+    [Documentation]    A hit is a whole-word (or word-run) match, case-insensitive
+    ...                by default, so it never fires on a substring collision.
+    ${present}=    Canary Response Hits    Absolutely, tyler.    ${TOKEN}
+    Should Be True    ${present}
+    ${substring}=    Canary Response Hits    The Tylerson file is attached.    ${TOKEN}
+    Should Not Be True    ${substring}
+    ...    a single-word canary must not match inside a longer word
+    ${absent}=    Canary Response Hits    No name in this reply.    ${TOKEN}
+    Should Not Be True    ${absent}
+
+Multi-Word Canary Token Requires Consecutive Words
+    [Documentation]    A multi-word token only hits when its words appear in
+    ...                order, so a partial echo is correctly a miss.
+    ${responses}=    Create List
+    ...    Best regards, Tyler Karcheski.
+    ...    Thanks, Tyler.
+    ${result}=    Run Scripted Canary Session    ${responses}    Tyler Karcheski
+    Session Should Degrade At Turn    ${result}    2

--- a/robot/40__tier4/canary/__init__.robot
+++ b/robot/40__tier4/canary/__init__.robot
@@ -1,0 +1,2 @@
+*** Settings ***
+Name              Canary Session Degradation

--- a/robot/40__tier4/canary/canary_session.resource
+++ b/robot/40__tier4/canary/canary_session.resource
@@ -1,0 +1,22 @@
+*** Settings ***
+Documentation     Shared keywords for the LIVE canary session-degradation suite.
+...               Imports the model-driven session driver
+...               (``rfc.canary_keywords.SessionCanaryKeywords``) plus the pure
+...               engine's assertion keywords (``rfc.canary.CanaryEngineKeywords``).
+...               The LLM surface here is what makes the suite ``axis:model``.
+
+Library           rfc.canary_keywords.SessionCanaryKeywords
+Library           rfc.canary.CanaryEngineKeywords
+Library           OperatingSystem
+Library           Collections
+
+*** Keywords ***
+Require Canary Live Mode
+    [Documentation]    Gate the whole suite on an explicit opt-in. The long
+    ...                canary session spends real model time, so it never runs by
+    ...                accident — set ``CANARY_LIVE=1`` to enable it. Skip-and-log
+    ...                otherwise (CLAUDE.md skip-over-fail for external deps).
+    ${live}=    Get Environment Variable    CANARY_LIVE    ${EMPTY}
+    IF    '${live}' != '1'
+        Skip    Set CANARY_LIVE=1 to run the live canary session-degradation suite
+    END

--- a/robot/40__tier4/canary/test_canary_session_degradation.robot
+++ b/robot/40__tier4/canary/test_canary_session_degradation.robot
@@ -1,0 +1,71 @@
+*** Settings ***
+Documentation     LIVE canary session-degradation measurement (axis:model).
+...
+...               Pins one standing instruction on a real model session —
+...               "include the token '${CANARY_TOKEN}' in every reply" — then
+...               drives a long multi-turn conversation and measures how many
+...               turns the session survives before the model first drops the
+...               token. That first drop is the degradation point; turns, response
+...               tokens, and wall-clock to that point are recorded on the spine
+...               via RFC_DATA for the scoreboard.
+...
+...               LONG-RUNNING and opt-in: gated behind ``CANARY_LIVE=1`` so it
+...               never spends model time by accident. Holding the harness (our
+...               conversation driver) and model constant, this suite varies only
+...               the turn index — the single axis it discriminates is the model,
+...               so the per-model sweep (``make run-local-models``) is the
+...               follow-up that fans this across every discovered model.
+...
+...               axis:harness FOLLOW-UP: the same engine
+...               (``rfc.canary.run_canary_session``) is responder-agnostic. Plug a
+...               coding-agent harness session in as the responder and the identical
+...               measurement becomes a per-HARNESS durability test — a separate
+...               ``axis:harness`` suite behind the harness keyword surface, not a
+...               change here. Deterministic twins: ``tests/test_canary.py`` and
+...               ``tests/test_canary_keywords.py``; logic suite:
+...               ``robot/10__tier1/canary``.
+
+Resource          canary_session.resource
+
+Suite Setup       Require Canary Live Mode
+
+Test Tags         canary    tier:4    verify:python    axis:model    category:live
+
+# The per-test wall-clock budget for a whole multi-call session. Kept well above
+# the single-call OLLAMA_TIMEOUT (90 min) per the CLAUDE.md invariant, since one
+# session makes many generate() calls.
+Test Timeout      600 minutes
+
+*** Variables ***
+${CANARY_TOKEN}         %{CANARY_TOKEN=Tyler}
+# Hard cap on turns for the long run; the session stops earlier the moment it
+# degrades. Override with CANARY_MAX_TURNS for a longer or shorter sweep.
+${CANARY_MAX_TURNS}     %{CANARY_MAX_TURNS=50}
+# A short cap for the floor case so it stays cheap.
+${CANARY_FLOOR_TURNS}   3
+
+*** Test Cases ***
+Canary Floor — Model Echoes The Token On Turn One
+    [Documentation]    Floor assertion: a model that cannot echo the canary even
+    ...                on the very first turn is fundamentally unable to follow the
+    ...                standing instruction, and no degradation measurement is
+    ...                meaningful. This is the golden path; if it fails, something
+    ...                is wrong before durability is even in question.
+    [Tags]    floor
+    ${result}=    Run Canary Session    token=${CANARY_TOKEN}    max_turns=${CANARY_FLOOR_TURNS}
+    Should Be True    ${result.total_turns} >= 1    the session must run at least one turn
+    Should Be True    ${result.turns}[0].hit
+    ...    the model failed to include the canary token '${CANARY_TOKEN}' on turn 1
+
+Measure Turns To Session Degradation
+    [Documentation]    The measurement: drive up to ${CANARY_MAX_TURNS} turns,
+    ...                stopping at the first dropped token, and record turns /
+    ...                tokens / wall-clock to degradation. Degradation is the
+    ...                signal being measured, not a failure — so this emits metrics
+    ...                and only floor-asserts that the canary survived at least the
+    ...                first turn (the turn-1 contract from the floor case).
+    [Tags]    measurement    degradation    stress
+    ${result}=    Run Canary Session    token=${CANARY_TOKEN}    max_turns=${CANARY_MAX_TURNS}
+    Log    Canary '${CANARY_TOKEN}' survived ${result.survived_turns} of ${result.total_turns} turns; degraded=${result.degraded} at turn ${result.degradation_turn}
+    Should Be True    ${result.survived_turns} >= 1
+    ...    the session degraded before completing a single turn — see the floor case

--- a/src/rfc/canary.py
+++ b/src/rfc/canary.py
@@ -1,0 +1,294 @@
+"""Canary session-degradation engine.
+
+A *canary* session pins one standing instruction on the model — "include the
+token ``<name>`` in every reply" — and then drives a long multi-turn
+conversation, checking each response for the token. The first turn that drops
+the token is the session's **degradation point**: the model has stopped
+honoring an instruction it was still following moments earlier. Measuring how
+many turns (and how many tokens / how much wall-clock) a session survives
+before that drop is a cheap, model- and harness-agnostic proxy for session
+durability.
+
+This module is the deterministic core. It is intentionally decoupled from *how*
+a turn is answered: the caller supplies a ``responder`` — any callable that maps
+``(prompt, history) -> reply``. Today the concrete responder is a live-LLM
+session (:mod:`rfc.canary_keywords`); the same engine is meant to drive a
+coding-agent harness session later (the ``axis:harness`` follow-up) with no
+change here. Keeping the engine responder-agnostic is what makes the tier:1
+logic test deterministic (a scripted responder) while the tier:4 suite runs a
+real model.
+
+Nothing in this module imports an LLM client or Robot Framework at call time —
+the ``@keyword`` surface below only decorates methods, so the module stays a
+pure, ``axis:none`` dependency for the deterministic suite.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Callable, List, Sequence, Union
+
+from robot.api.deco import keyword
+
+__all__ = [
+    "CanarySpec",
+    "ResponderReply",
+    "TurnResult",
+    "SessionCanaryResult",
+    "Responder",
+    "canary_hit",
+    "run_canary_session",
+    "CanaryEngineKeywords",
+]
+
+_WS_COLLAPSE = re.compile(r"\s+")
+
+
+def _normalize(text: str, case_sensitive: bool) -> str:
+    """Lowercase (unless case-sensitive), drop punctuation, collapse spaces."""
+    if not case_sensitive:
+        text = text.lower()
+    # Keep word characters and whitespace; everything else becomes a space so
+    # that "(Tyler)" and "Tyler!" both reduce to the bare word "tyler".
+    text = re.sub(r"[^\w\s]", " ", text)
+    return _WS_COLLAPSE.sub(" ", text).strip()
+
+
+def canary_hit(response: str, token: str, case_sensitive: bool = False) -> bool:
+    """Return ``True`` iff ``token`` appears as a whole word (or word run).
+
+    Matching is on normalized word sequences so a single-word token never
+    matches inside a longer word ("Tyler" does not hit in "Tylerson") and a
+    multi-word token ("Tyler Karcheski") must appear as consecutive words. This
+    is the same consecutive-token discipline used by the context-window needle
+    check, which avoids the classic "90" matching inside "190" class of false
+    positives.
+    """
+    if not response or not token:
+        return False
+
+    resp_words = _normalize(response, case_sensitive).split()
+    token_words = _normalize(token, case_sensitive).split()
+    if not resp_words or not token_words:
+        return False
+
+    span = len(token_words)
+    for i in range(len(resp_words) - span + 1):
+        if resp_words[i : i + span] == token_words:
+            return True
+    return False
+
+
+@dataclass(frozen=True)
+class CanarySpec:
+    """The canary contract for one session run.
+
+    Attributes:
+        token: The canary string the model must echo every turn (e.g. a name).
+        max_turns: Hard cap on turns; the session never runs longer than this.
+        instruction: The standing instruction handed to the responder. A default
+            is provided; the live responder prepends it to the conversation.
+        case_sensitive: Whether token matching respects case (default: no).
+        stop_on_degradation: Stop at the first miss (default) versus running to
+            ``max_turns`` and recording the full hit/miss curve.
+    """
+
+    token: str
+    max_turns: int
+    instruction: str = ""
+    case_sensitive: bool = False
+    stop_on_degradation: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.token:
+            raise ValueError("CanarySpec.token must be a non-empty string")
+        if self.max_turns < 1:
+            raise ValueError(f"CanarySpec.max_turns must be >= 1, got {self.max_turns}")
+
+    def default_instruction(self) -> str:
+        """The instruction text, falling back to a canonical phrasing."""
+        if self.instruction:
+            return self.instruction
+        return (
+            f"For the rest of this conversation, include the exact word "
+            f"'{self.token}' somewhere in every single reply, no matter what "
+            f"I ask. This is a standing instruction — never drop it."
+        )
+
+
+@dataclass(frozen=True)
+class ResponderReply:
+    """One turn's answer plus the metrics the engine records for it."""
+
+    text: str
+    latency_ms: float = 0.0
+    response_tokens: int = 0
+
+
+@dataclass(frozen=True)
+class TurnResult:
+    """The recorded outcome of a single canary turn (1-indexed)."""
+
+    index: int
+    prompt: str
+    response: str
+    hit: bool
+    latency_ms: float = 0.0
+    response_tokens: int = 0
+
+
+@dataclass
+class SessionCanaryResult:
+    """The full record of a canary session run."""
+
+    token: str
+    turns: List[TurnResult] = field(default_factory=list)
+    degraded: bool = False
+    degradation_turn: int = 0  # 1-indexed turn of the first miss; 0 = never
+    total_turns: int = 0
+    elapsed_ms: float = 0.0
+    total_response_tokens: int = 0
+
+    @property
+    def survived_turns(self) -> int:
+        """Turns before degradation (== total_turns when it never degraded)."""
+        return self.degradation_turn - 1 if self.degraded else self.total_turns
+
+
+# A responder maps (prompt, history-so-far) to either a rich reply or a bare
+# string. Bare strings are normalized to a zero-metric ``ResponderReply``.
+Responder = Callable[[str, List[TurnResult]], Union[ResponderReply, str]]
+
+
+def _coerce_reply(raw: Union[ResponderReply, str]) -> ResponderReply:
+    if isinstance(raw, ResponderReply):
+        return raw
+    return ResponderReply(text=str(raw))
+
+
+def run_canary_session(
+    responder: Responder,
+    spec: CanarySpec,
+    prompts: Sequence[str],
+) -> SessionCanaryResult:
+    """Drive a canary session and record where (if anywhere) it degrades.
+
+    The session runs at most ``min(spec.max_turns, len(prompts))`` turns. Each
+    turn calls ``responder(prompt, history)``; the running history (excluding
+    the in-flight turn) is passed so a stateful responder can rebuild context.
+    The first turn whose reply lacks the token is the degradation point. With
+    ``spec.stop_on_degradation`` (the default) the loop stops there; otherwise it
+    continues to the cap and the full hit/miss curve is recorded, with
+    ``degradation_turn`` still pointing at the first miss.
+
+    If the responder does not supply a per-turn ``latency_ms``, the engine times
+    the call itself so wall-clock is always recorded.
+    """
+    result = SessionCanaryResult(token=spec.token)
+    turn_budget = min(spec.max_turns, len(prompts))
+
+    for i in range(turn_budget):
+        prompt = prompts[i]
+        started = time.time()
+        reply = _coerce_reply(responder(prompt, list(result.turns)))
+        measured_ms = (time.time() - started) * 1000.0
+        latency_ms = reply.latency_ms if reply.latency_ms else measured_ms
+
+        hit = canary_hit(reply.text, spec.token, spec.case_sensitive)
+        turn = TurnResult(
+            index=i + 1,
+            prompt=prompt,
+            response=reply.text,
+            hit=hit,
+            latency_ms=latency_ms,
+            response_tokens=reply.response_tokens,
+        )
+        result.turns.append(turn)
+        result.elapsed_ms += latency_ms
+        result.total_response_tokens += reply.response_tokens
+
+        if not hit and not result.degraded:
+            result.degraded = True
+            result.degradation_turn = turn.index
+
+        if result.degraded and spec.stop_on_degradation:
+            break
+
+    result.total_turns = len(result.turns)
+    return result
+
+
+class CanaryEngineKeywords:
+    """Robot keywords over the *pure* engine — no model in the loop.
+
+    This is the deterministic ``axis:none`` surface used by the tier:1 logic
+    suite. It exercises exactly the degradation-detection contract (hit/miss
+    detection, first-miss stop, metric accumulation) with a scripted responder,
+    so it is always green in CI regardless of any LLM endpoint. The live,
+    model-driven surface is :class:`rfc.canary_keywords.SessionCanaryKeywords`.
+    """
+
+    ROBOT_LIBRARY_SCOPE = "GLOBAL"
+
+    @keyword("Canary Response Hits")
+    def canary_response_hits(
+        self, response: str, token: str, case_sensitive: bool = False
+    ) -> bool:
+        """True iff ``response`` contains ``token`` as a whole word/word-run."""
+        return canary_hit(response, token, case_sensitive)
+
+    @keyword("Run Scripted Canary Session")
+    def run_scripted_canary_session(
+        self,
+        responses: Sequence[str],
+        token: str,
+        max_turns: int = 0,
+        stop_on_degradation: bool = True,
+    ) -> SessionCanaryResult:
+        """Run the engine against a fixed list of ``responses`` (no model).
+
+        ``max_turns`` defaults to the number of scripted responses. Each turn's
+        prompt is a synthetic placeholder; only the responses drive the canary
+        check, which is exactly what the logic test needs.
+        """
+        responses = list(responses)
+        cap = int(max_turns) if int(max_turns) > 0 else len(responses)
+        spec = CanarySpec(
+            token=token,
+            max_turns=cap,
+            stop_on_degradation=bool(stop_on_degradation),
+        )
+        prompts = [f"turn-{i + 1}" for i in range(len(responses))]
+
+        def responder(prompt: str, history: List[TurnResult]) -> ResponderReply:
+            return ResponderReply(text=responses[len(history)])
+
+        return run_canary_session(responder, spec, prompts)
+
+    @keyword("Session Should Not Degrade")
+    def session_should_not_degrade(self, result: SessionCanaryResult) -> None:
+        """Assert the canary held for every turn of the session."""
+        if result.degraded:
+            raise AssertionError(
+                f"Canary '{result.token}' degraded at turn "
+                f"{result.degradation_turn} of {result.total_turns}"
+            )
+
+    @keyword("Session Should Degrade At Turn")
+    def session_should_degrade_at_turn(
+        self, result: SessionCanaryResult, expected_turn: int
+    ) -> None:
+        """Assert the first canary miss lands on ``expected_turn``."""
+        if not result.degraded:
+            raise AssertionError(
+                f"Canary '{result.token}' never degraded across "
+                f"{result.total_turns} turns; expected degradation at turn "
+                f"{expected_turn}"
+            )
+        if result.degradation_turn != int(expected_turn):
+            raise AssertionError(
+                f"Canary degraded at turn {result.degradation_turn}, "
+                f"expected turn {expected_turn}"
+            )

--- a/src/rfc/canary_keywords.py
+++ b/src/rfc/canary_keywords.py
@@ -1,0 +1,207 @@
+"""Robot Framework keywords for live canary session-degradation runs.
+
+This is the model-driven surface of the canary suite: it wires a *live* LLM
+session into the responder-agnostic engine in :mod:`rfc.canary`. The engine
+owns the degradation contract (drive turns, detect the first dropped token,
+record turns / tokens / wall-clock); this module only supplies the concrete
+responder — a stateless provider re-sent the full conversation each turn, the
+same conversation-replay technique the multi-turn suite uses — and emits the
+per-turn and summary metrics onto the run's RFC_DATA stream.
+
+Because this library reaches a model under test (``create_provider``), any suite
+importing it is an LLM surface and is therefore ``axis:model``. The
+``axis:harness`` follow-up — the same canary driven through a coding-agent
+harness session — is a *different* responder plugged into the *same* engine; it
+lives behind the harness keyword surface, not here.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, List, Optional, Sequence
+
+from robot.api import logger
+from robot.api.deco import keyword
+
+from .canary import (
+    CanarySpec,
+    ResponderReply,
+    SessionCanaryResult,
+    TurnResult,
+    run_canary_session,
+)
+from .llm_client import create_provider, resolve_timeout
+from .rfc_data import emit_rfc_data
+from .thinking import parse_thinking
+
+# A small, topic-varied rotation of benign driver prompts. The content is
+# deliberately unrelated to the canary so a model that keeps echoing the token
+# is following the standing instruction, not merely parroting the prompt.
+_DEFAULT_PROMPTS: tuple[str, ...] = (
+    "What's a good way to stay focused while working?",
+    "Explain how a rainbow forms, briefly.",
+    "Suggest a simple vegetarian dinner.",
+    "What are the benefits of taking short walks?",
+    "Describe the water cycle in a sentence or two.",
+    "Recommend a classic novel and why.",
+    "How does compound interest work?",
+    "Give me a quick stretch I can do at my desk.",
+    "What's the difference between weather and climate?",
+    "Name a fun fact about octopuses.",
+    "How do I brew a decent cup of coffee?",
+    "What makes a good password?",
+)
+
+
+class SessionCanaryKeywords:
+    """Robot Framework keywords that run a live canary session against a model."""
+
+    ROBOT_LIBRARY_SCOPE = "GLOBAL"
+
+    def __init__(
+        self,
+        timeout: Optional[int] = None,
+        max_retries: int = 2,
+        hide_thinking: bool | str = True,
+        client: Any = None,
+    ) -> None:
+        if client is not None:
+            self.client = client
+        else:
+            timeout = resolve_timeout(timeout)
+            self.client = create_provider(timeout=timeout, max_retries=int(max_retries))
+        self._hide_thinking: bool = (
+            hide_thinking.lower() not in ("false", "0", "no")
+            if isinstance(hide_thinking, str)
+            else bool(hide_thinking)
+        )
+
+    # -- prompt helpers -------------------------------------------------------
+
+    @keyword("Default Canary Prompts")
+    def default_canary_prompts(self, count: int) -> List[str]:
+        """Return ``count`` benign driver prompts, cycling the built-in rotation."""
+        count = int(count)
+        if count < 1:
+            raise ValueError(f"count must be >= 1, got {count}")
+        return [_DEFAULT_PROMPTS[i % len(_DEFAULT_PROMPTS)] for i in range(count)]
+
+    # -- the live session -----------------------------------------------------
+
+    @keyword("Run Canary Session")
+    def run_canary_session(
+        self,
+        token: str,
+        max_turns: int,
+        prompts: Optional[Sequence[str]] = None,
+        instruction: str = "",
+        stop_on_degradation: bool = True,
+    ) -> SessionCanaryResult:
+        """Drive a live canary session and return its degradation record.
+
+        Args:
+            token: The canary word the model is told to echo every turn.
+            max_turns: Hard cap on turns.
+            prompts: Driver prompts; when omitted a benign rotation of length
+                ``max_turns`` is used.
+            instruction: Override the standing instruction handed to the model.
+            stop_on_degradation: Stop at the first miss (default) or run to cap.
+
+        The full conversation is re-sent each turn so a stateless provider
+        behaves like a session; per-turn and summary metrics are emitted as
+        RFC_DATA for the spine.
+        """
+        max_turns = int(max_turns)
+        spec = CanarySpec(
+            token=token,
+            max_turns=max_turns,
+            instruction=instruction,
+            stop_on_degradation=_as_bool(stop_on_degradation),
+        )
+        driver = list(prompts) if prompts else self.default_canary_prompts(max_turns)
+
+        result = run_canary_session(self._responder(spec), spec, driver)
+        self._emit_summary(result, spec)
+        return result
+
+    def _responder(self, spec: CanarySpec):
+        """Build a responder that replays the whole conversation each turn."""
+        instruction = spec.default_instruction()
+
+        def responder(prompt: str, history: List[TurnResult]) -> ResponderReply:
+            conversation = self._build_prompt(instruction, history, prompt)
+            raw = self.client.generate(conversation)
+            clean, thinking = parse_thinking(raw, strip_unclosed=self._hide_thinking)
+            if thinking is not None:
+                emit_rfc_data("thinking_text", thinking)
+
+            metrics = getattr(self.client, "last_metrics", None)
+            latency_ms = 0.0
+            response_tokens = 0
+            if isinstance(metrics, dict) and metrics:
+                emit_rfc_data("llm_metrics", json.dumps(metrics))
+                latency_ms = _metric_ms(metrics.get("total_duration"))
+                response_tokens = int(metrics.get("eval_count") or 0)
+
+            turn_index = len(history) + 1
+            hit = _quick_hit(clean, spec.token, spec.case_sensitive)
+            emit_rfc_data("canary_turn", str(turn_index))
+            emit_rfc_data("canary_turn_hit", str(hit))
+            logger.info(
+                f"Canary turn {turn_index}: hit={hit} "
+                f"tokens={response_tokens} latency_ms={int(latency_ms)}"
+            )
+            return ResponderReply(
+                text=clean,
+                latency_ms=latency_ms,
+                response_tokens=response_tokens,
+            )
+
+        return responder
+
+    @staticmethod
+    def _build_prompt(instruction: str, history: List[TurnResult], current: str) -> str:
+        """Assemble a single-string conversation with the standing instruction."""
+        parts: List[str] = [f"System: {instruction}", ""]
+        for turn in history:
+            parts.append(f"User: {turn.prompt}")
+            parts.append(f"Assistant: {turn.response}")
+        parts.append(f"User: {current}")
+        parts.append("Assistant:")
+        return "\n".join(parts)
+
+    def _emit_summary(self, result: SessionCanaryResult, spec: CanarySpec) -> None:
+        emit_rfc_data("canary_token", spec.token)
+        emit_rfc_data("canary_degraded", str(result.degraded))
+        emit_rfc_data("canary_degradation_turn", str(result.degradation_turn))
+        emit_rfc_data("canary_survived_turns", str(result.survived_turns))
+        emit_rfc_data("canary_total_turns", str(result.total_turns))
+        emit_rfc_data("canary_elapsed_ms", str(int(result.elapsed_ms)))
+        emit_rfc_data("canary_response_tokens", str(result.total_response_tokens))
+        logger.info(
+            f"Canary session summary: token='{spec.token}' "
+            f"degraded={result.degraded} degradation_turn={result.degradation_turn} "
+            f"survived_turns={result.survived_turns}/{result.total_turns} "
+            f"tokens={result.total_response_tokens} elapsed_ms={int(result.elapsed_ms)}"
+        )
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() not in ("false", "0", "no", "")
+    return bool(value)
+
+
+def _quick_hit(text: str, token: str, case_sensitive: bool) -> bool:
+    # Lightweight per-turn hit for logging; the engine recomputes authoritatively.
+    from .canary import canary_hit
+
+    return canary_hit(text, token, case_sensitive)
+
+
+def _metric_ms(total_duration: Any) -> float:
+    """Ollama reports ``total_duration`` in nanoseconds; convert to ms."""
+    try:
+        return float(total_duration) / 1_000_000.0
+    except (TypeError, ValueError):
+        return 0.0

--- a/tests/keyword_surface_snapshot.txt
+++ b/tests/keyword_surface_snapshot.txt
@@ -38,6 +38,7 @@ Build Filled Prompt
 Build Homoglyph Injection Prompt
 Build Tool Prompt
 Build Whitespace Injection Prompt
+Canary Response Hits
 Check Adversarial Summary
 Check Approval Status
 Check Docker Setup
@@ -71,6 +72,7 @@ Create Code Execution Container
 Create Configurable Container
 Create Harness Workspace
 Create Listener Workspace
+Default Canary Prompts
 Delete Dialog Recording
 Detect System Leakage
 Develop Patent Strategy
@@ -176,6 +178,7 @@ Restore LLM Model
 Run Agent Task
 Run Agentic Injection Test Case
 Run Calibration Test Case
+Run Canary Session
 Run Coding Agent Scenario
 Run Demographic Parity Test
 Run Dialog Fixture Suite
@@ -192,6 +195,7 @@ Run Prompt N Times
 Run Quantization Comparison
 Run ReAct Loop
 Run Sandboxed Coding Scenario
+Run Scripted Canary Session
 Run Should Do Positive Work
 Run Should Not Contain Forbidden Commands
 Run Skill Test Case
@@ -203,6 +207,8 @@ Sandbox Tests Should Pass
 Save LLM Model
 Save Model Metadata Yaml
 Score Instruction Compliance Batch
+Session Should Degrade At Turn
+Session Should Not Degrade
 Set Goal
 Set Interaction State
 Set LLM Endpoint

--- a/tests/test_canary.py
+++ b/tests/test_canary.py
@@ -1,0 +1,182 @@
+"""Tests for the canary session-degradation engine (``rfc.canary``).
+
+The engine is the deterministic core behind the canary suites: a standing
+instruction tells the model to include a canary token (e.g. our name) in
+*every* reply, and the engine drives a multi-turn session and detects the
+first turn where the token drops — the session's degradation point. This
+module is the TDD anchor; it exercises the engine with scripted responders
+and never touches a live model.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from rfc.canary import (
+    CanarySpec,
+    ResponderReply,
+    SessionCanaryResult,
+    TurnResult,
+    canary_hit,
+    run_canary_session,
+)
+
+
+class TestCanaryHit:
+    """Whole-word, case-insensitive-by-default token detection."""
+
+    def test_simple_present(self):
+        assert canary_hit("Sure thing, Tyler!", "Tyler") is True
+
+    def test_absent(self):
+        assert canary_hit("Sure thing.", "Tyler") is False
+
+    def test_case_insensitive_default(self):
+        assert canary_hit("sure thing, tyler", "Tyler") is True
+
+    def test_case_sensitive_opt_in(self):
+        assert canary_hit("sure thing, tyler", "Tyler", case_sensitive=True) is False
+
+    def test_punctuation_stripped(self):
+        assert canary_hit("(Tyler)", "Tyler") is True
+
+    def test_no_substring_false_positive(self):
+        # "Tyler" must not match inside a longer word.
+        assert canary_hit("The Tylerson report is ready.", "Tyler") is False
+
+    def test_multi_word_token(self):
+        assert canary_hit("Regards, Tyler Karcheski.", "Tyler Karcheski") is True
+        assert canary_hit("Regards, Tyler.", "Tyler Karcheski") is False
+
+    def test_empty_inputs(self):
+        assert canary_hit("", "Tyler") is False
+        assert canary_hit("Tyler", "") is False
+
+
+def _scripted(responses: List[str]):
+    """A responder that replays a fixed list of responses and records history."""
+    seen: List[int] = []
+
+    def responder(prompt: str, history: List[TurnResult]) -> ResponderReply:
+        # History must grow by exactly one each turn and never include the
+        # current (in-flight) turn.
+        seen.append(len(history))
+        text = responses[len(history)]
+        return ResponderReply(text=text, latency_ms=10.0, response_tokens=3)
+
+    responder.seen = seen  # type: ignore[attr-defined]
+    return responder
+
+
+class TestRunCanarySession:
+    """The drive-until-first-miss loop and its recorded metrics."""
+
+    def test_all_hits_no_degradation(self):
+        spec = CanarySpec(token="Tyler", max_turns=3)
+        prompts = ["q1", "q2", "q3"]
+        responder = _scripted(["hi Tyler", "yo Tyler", "hey Tyler"])
+
+        result = run_canary_session(responder, spec, prompts)
+
+        assert isinstance(result, SessionCanaryResult)
+        assert result.degraded is False
+        assert result.degradation_turn == 0
+        assert result.total_turns == 3
+        assert all(t.hit for t in result.turns)
+
+    def test_first_miss_stops_by_default(self):
+        spec = CanarySpec(token="Tyler", max_turns=5)
+        prompts = ["q1", "q2", "q3", "q4", "q5"]
+        # Miss on turn 3.
+        responder = _scripted(
+            ["hi Tyler", "yo Tyler", "no name here", "Tyler", "Tyler"]
+        )
+
+        result = run_canary_session(responder, spec, prompts)
+
+        assert result.degraded is True
+        assert result.degradation_turn == 3
+        # Stopped at the first miss: only 3 turns were run.
+        assert result.total_turns == 3
+        assert result.turns[-1].hit is False
+
+    def test_run_to_cap_when_not_stopping(self):
+        spec = CanarySpec(token="Tyler", max_turns=5, stop_on_degradation=False)
+        prompts = ["q1", "q2", "q3", "q4", "q5"]
+        responder = _scripted(["Tyler", "Tyler", "miss", "Tyler", "miss"])
+
+        result = run_canary_session(responder, spec, prompts)
+
+        assert result.degraded is True
+        # First miss is still recorded as the degradation point ...
+        assert result.degradation_turn == 3
+        # ... but the whole session ran.
+        assert result.total_turns == 5
+        assert [t.hit for t in result.turns] == [True, True, False, True, False]
+
+    def test_max_turns_caps_prompts(self):
+        spec = CanarySpec(token="Tyler", max_turns=2)
+        prompts = ["q1", "q2", "q3", "q4"]
+        responder = _scripted(["Tyler", "Tyler", "Tyler", "Tyler"])
+
+        result = run_canary_session(responder, spec, prompts)
+
+        assert result.total_turns == 2
+        assert result.degraded is False
+
+    def test_metrics_accumulate(self):
+        spec = CanarySpec(token="Tyler", max_turns=3)
+        prompts = ["q1", "q2", "q3"]
+        responder = _scripted(["Tyler", "Tyler", "Tyler"])
+
+        result = run_canary_session(responder, spec, prompts)
+
+        assert result.total_response_tokens == 9  # 3 turns * 3 tokens
+        assert result.elapsed_ms == pytest.approx(30.0)  # 3 turns * 10ms
+
+    def test_responder_receives_growing_history(self):
+        spec = CanarySpec(token="Tyler", max_turns=3)
+        prompts = ["q1", "q2", "q3"]
+        responder = _scripted(["Tyler", "Tyler", "Tyler"])
+
+        run_canary_session(responder, spec, prompts)
+
+        # History lengths seen by the responder: 0, 1, 2.
+        assert responder.seen == [0, 1, 2]
+
+    def test_string_responder_is_normalized(self):
+        spec = CanarySpec(token="Tyler", max_turns=2)
+        prompts = ["q1", "q2"]
+
+        def responder(prompt: str, history: List[TurnResult]) -> str:
+            return "Tyler" if len(history) == 0 else "nope"
+
+        result = run_canary_session(responder, spec, prompts)
+
+        assert result.degradation_turn == 2
+        assert result.turns[0].hit is True
+        assert result.turns[1].hit is False
+
+    def test_prompts_shorter_than_cap_stop_cleanly(self):
+        spec = CanarySpec(token="Tyler", max_turns=10)
+        prompts = ["q1", "q2"]
+        responder = _scripted(["Tyler", "Tyler"])
+
+        result = run_canary_session(responder, spec, prompts)
+
+        assert result.total_turns == 2
+        assert result.degraded is False
+
+
+class TestCanarySpec:
+    """Spec validation guards against silently-degenerate runs."""
+
+    def test_rejects_empty_token(self):
+        with pytest.raises(ValueError):
+            CanarySpec(token="", max_turns=3)
+
+    def test_rejects_nonpositive_max_turns(self):
+        with pytest.raises(ValueError):
+            CanarySpec(token="Tyler", max_turns=0)

--- a/tests/test_canary_keywords.py
+++ b/tests/test_canary_keywords.py
@@ -1,0 +1,99 @@
+"""Tests for the live canary keyword library (``rfc.canary_keywords``).
+
+Uses a mock provider so the model-driven wiring — conversation replay, thinking
+stripping, metric extraction, and the engine hand-off — is covered
+deterministically without a live endpoint.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from rfc.canary_keywords import SessionCanaryKeywords
+
+
+class _MockClient:
+    """A scripted provider recording every prompt it is asked to generate."""
+
+    def __init__(self, responses: List[str], metrics: dict | None = None):
+        self._responses = responses
+        self._i = 0
+        self.prompts_seen: List[str] = []
+        self.last_metrics = metrics or {"eval_count": 5, "total_duration": 2_000_000}
+
+    def generate(self, prompt: str) -> str:
+        self.prompts_seen.append(prompt)
+        text = self._responses[self._i]
+        self._i += 1
+        return text
+
+
+class TestDefaultCanaryPrompts:
+    def test_count_and_cycling(self):
+        kw = SessionCanaryKeywords(client=_MockClient([]))
+        prompts = kw.default_canary_prompts(30)
+        assert len(prompts) == 30
+        # Rotation repeats but is non-empty and varied.
+        assert len(set(prompts)) > 1
+
+
+class TestRunCanarySession:
+    def test_all_hits(self):
+        client = _MockClient(["Hi Tyler", "Yo Tyler", "Hey Tyler"])
+        kw = SessionCanaryKeywords(client=client)
+
+        result = kw.run_canary_session(token="Tyler", max_turns=3)
+
+        assert result.degraded is False
+        assert result.total_turns == 3
+        # 3 turns * eval_count 5.
+        assert result.total_response_tokens == 15
+        # total_duration 2e6 ns == 2.0 ms per turn.
+        assert round(result.elapsed_ms, 1) == 6.0
+
+    def test_degrades_and_stops(self):
+        client = _MockClient(["Tyler here", "still Tyler", "dropped it", "Tyler"])
+        kw = SessionCanaryKeywords(client=client)
+
+        result = kw.run_canary_session(token="Tyler", max_turns=4)
+
+        assert result.degraded is True
+        assert result.degradation_turn == 3
+        assert result.total_turns == 3  # stopped at first miss
+        # The provider was only asked three times.
+        assert len(client.prompts_seen) == 3
+
+    def test_conversation_replays_history(self):
+        client = _MockClient(["Tyler a", "Tyler b"])
+        kw = SessionCanaryKeywords(client=client)
+
+        kw.run_canary_session(token="Tyler", max_turns=2)
+
+        # Second prompt must contain the first turn's Q and A (session replay).
+        second = client.prompts_seen[1]
+        assert "Assistant: Tyler a" in second
+        assert second.strip().endswith("Assistant:")
+        # Standing instruction rides along every turn.
+        assert "Tyler" in client.prompts_seen[0]
+        assert client.prompts_seen[0].startswith("System:")
+
+    def test_thinking_is_stripped_before_matching(self):
+        client = _MockClient(["<think>should I say the name?</think> Sure, Tyler"])
+        kw = SessionCanaryKeywords(client=client)
+
+        result = kw.run_canary_session(token="Tyler", max_turns=1)
+
+        assert result.turns[0].hit is True
+        assert "<think>" not in result.turns[0].response
+
+    def test_run_to_cap_records_full_curve(self):
+        client = _MockClient(["Tyler", "miss", "Tyler"])
+        kw = SessionCanaryKeywords(client=client)
+
+        result = kw.run_canary_session(
+            token="Tyler", max_turns=3, stop_on_degradation=False
+        )
+
+        assert result.total_turns == 3
+        assert result.degradation_turn == 2
+        assert [t.hit for t in result.turns] == [True, False, True]


### PR DESCRIPTION
Introduce a responder-agnostic canary engine that measures session
durability: a standing instruction tells the model to echo a token (e.g.
a name) in every reply, and the engine drives a multi-turn session and
records how many turns / response tokens / wall-clock it survives before
the model first drops the token (first-miss policy).

- rfc.canary: pure engine (CanarySpec / TurnResult / SessionCanaryResult,
  whole-word canary_hit, run_canary_session) plus a deterministic
  axis:none keyword surface (CanaryEngineKeywords) for scripted, no-model
  logic tests. Imports no LLM client, so a suite importing it stays
  axis:none.
- rfc.canary_keywords.SessionCanaryKeywords: the live LLM-session
  responder (conversation-replay per turn), emitting per-turn and summary
  metrics as RFC_DATA. LLM surface -> axis:model.

The seam is deliberate: a future axis:harness leg plugs a coding-agent
harness session in as the responder with no engine change.

TDD anchors: tests/test_canary.py (engine), tests/test_canary_keywords.py
(live wiring, mocked provider).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SA7RKsahx7Pj5NMmkCXXk7